### PR TITLE
Update test to conform to `poetry` `1.2.1`

### DIFF
--- a/tests/smoke-poetry.yaml
+++ b/tests/smoke-poetry.yaml
@@ -363,7 +363,6 @@ output:
                         {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
                     ]
                     toml = [
-                        {file = "toml-0.10.0-py2.7.egg", hash = "sha256:f1db651f9657708513243e61e6cc67d101a39bad662eaa9b5546f789338e07a3"},
                         {file = "toml-0.10.0-py2.py3-none-any.whl", hash = "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"},
                         {file = "toml-0.10.0.tar.gz", hash = "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c"},
                     ]


### PR DESCRIPTION
`poetry` `1.2.1` no longer generates this line that was present in `1.2.0`.

I'm not 100% positive, but I _think_ that might be the result of https://github.com/python-poetry/poetry/pull/6389.

Details here: https://github.com/dependabot/dependabot-core/pull/5746#issuecomment-1253773172