### PR TITLE
catch regressions sooner

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: ["main"]
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "0 * * * *"
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The scheduled smoke run is good at finding regressions in uncached or uncachable ecosystems. Running it more often means we see the problem sooner. 