### PR TITLE
Fix npm requirement source

### DIFF
--- a/tests/smoke-npm-remove-transitive.yaml
+++ b/tests/smoke-npm-remove-transitive.yaml
@@ -76,7 +76,9 @@ output:
                       groups:
                         - dependencies
                       requirement: 10.0.1
-                      source: null
+                      source: 
+                        type: registry
+                        url: https://registry.npmjs.org
                   version: 10.0.1
             updated-dependency-files:
                 - content: |


### PR DESCRIPTION
The changes in https://github.com/dependabot/dependabot-core/pull/5816 mean that we expect the source to be populated now. Adjust this test expectation to match.