### PR TITLE
pin to latest commits

### DIFF
--- a/tests/smoke-actions.yaml
+++ b/tests/smoke-actions.yaml
@@ -11,7 +11,7 @@ input:
             provider: github
             repo: dependabot/smoke-tests
             directory: /actions
-            commit: 832e37c1a7a4ef89feb9dc7cfa06f62205191994
+            commit: 8b2c0d821028c531826db20ca22cffdd2cc05abf
 output:
   - type: update_dependency_list
     expect:
@@ -35,7 +35,7 @@ output:
   - type: create_pull_request
     expect:
         data:
-            base-commit-sha: 832e37c1a7a4ef89feb9dc7cfa06f62205191994
+            base-commit-sha: 8b2c0d821028c531826db20ca22cffdd2cc05abf
             dependencies:
               - name: actions/checkout
                 previous-requirements:
@@ -235,4 +235,4 @@ output:
   - type: mark_as_processed
     expect:
         data:
-            base-commit-sha: 832e37c1a7a4ef89feb9dc7cfa06f62205191994
+            base-commit-sha: 8b2c0d821028c531826db20ca22cffdd2cc05abf

--- a/tests/smoke-go.yaml
+++ b/tests/smoke-go.yaml
@@ -14,7 +14,7 @@ input:
             provider: github
             repo: dependabot/smoke-tests
             directory: /go
-            commit: 832e37c1a7a4ef89feb9dc7cfa06f62205191994
+            commit: 8b2c0d821028c531826db20ca22cffdd2cc05abf
 output:
     - type: update_dependency_list
       expect:
@@ -47,7 +47,7 @@ output:
     - type: create_pull_request
       expect:
         data:
-            base-commit-sha: 832e37c1a7a4ef89feb9dc7cfa06f62205191994
+            base-commit-sha: 8b2c0d821028c531826db20ca22cffdd2cc05abf
             dependencies:
                 - name: github.com/fatih/color
                   previous-requirements:
@@ -174,7 +174,7 @@ output:
     - type: create_pull_request
       expect:
         data:
-            base-commit-sha: 832e37c1a7a4ef89feb9dc7cfa06f62205191994
+            base-commit-sha: 8b2c0d821028c531826db20ca22cffdd2cc05abf
             dependencies:
                 - name: rsc.io/quote
                   previous-requirements:
@@ -262,4 +262,4 @@ output:
     - type: mark_as_processed
       expect:
         data:
-            base-commit-sha: 832e37c1a7a4ef89feb9dc7cfa06f62205191994
+            base-commit-sha: 8b2c0d821028c531826db20ca22cffdd2cc05abf

--- a/tests/smoke-pub.yaml
+++ b/tests/smoke-pub.yaml
@@ -23,7 +23,7 @@ input:
             provider: github
             repo: dependabot/smoke-tests
             directory: /pub
-            commit: 832e37c1a7a4ef89feb9dc7cfa06f62205191994
+            commit: 8b2c0d821028c531826db20ca22cffdd2cc05abf
 output:
     - type: update_dependency_list
       expect:
@@ -95,7 +95,7 @@ output:
     - type: create_pull_request
       expect:
         data:
-            base-commit-sha: 832e37c1a7a4ef89feb9dc7cfa06f62205191994
+            base-commit-sha: 8b2c0d821028c531826db20ca22cffdd2cc05abf
             dependencies:
                 - name: collection
                   previous-requirements:
@@ -267,7 +267,7 @@ output:
     - type: create_pull_request
       expect:
         data:
-            base-commit-sha: 832e37c1a7a4ef89feb9dc7cfa06f62205191994
+            base-commit-sha: 8b2c0d821028c531826db20ca22cffdd2cc05abf
             dependencies:
                 - name: fixnum
                   previous-requirements:
@@ -497,7 +497,7 @@ output:
     - type: create_pull_request
       expect:
         data:
-            base-commit-sha: 832e37c1a7a4ef89feb9dc7cfa06f62205191994
+            base-commit-sha: 8b2c0d821028c531826db20ca22cffdd2cc05abf
             dependencies:
                 - name: path
                   previous-requirements:
@@ -606,7 +606,7 @@ output:
     - type: create_pull_request
       expect:
         data:
-            base-commit-sha: 832e37c1a7a4ef89feb9dc7cfa06f62205191994
+            base-commit-sha: 8b2c0d821028c531826db20ca22cffdd2cc05abf
             dependencies:
                 - name: retry
                   previous-requirements:
@@ -713,4 +713,4 @@ output:
     - type: mark_as_processed
       expect:
         data:
-            base-commit-sha: 832e37c1a7a4ef89feb9dc7cfa06f62205191994
+            base-commit-sha: 8b2c0d821028c531826db20ca22cffdd2cc05abf

--- a/tests/smoke-terraform.yaml
+++ b/tests/smoke-terraform.yaml
@@ -20,7 +20,7 @@ input:
             provider: github
             repo: dependabot/smoke-tests
             directory: /terraform
-            commit: 832e37c1a7a4ef89feb9dc7cfa06f62205191994
+            commit: 8b2c0d821028c531826db20ca22cffdd2cc05abf
 output:
     - type: update_dependency_list
       expect:
@@ -97,7 +97,7 @@ output:
     - type: create_pull_request
       expect:
         data:
-            base-commit-sha: 832e37c1a7a4ef89feb9dc7cfa06f62205191994
+            base-commit-sha: 8b2c0d821028c531826db20ca22cffdd2cc05abf
             dependencies:
                 - name: duplicate_label::github::cloudposse/terraform-null-label::tags/0.3.7
                   previous-requirements:
@@ -356,7 +356,7 @@ output:
     - type: create_pull_request
       expect:
         data:
-            base-commit-sha: 832e37c1a7a4ef89feb9dc7cfa06f62205191994
+            base-commit-sha: 8b2c0d821028c531826db20ca22cffdd2cc05abf
             dependencies:
                 - name: github_ssh_without_protocol::github::cloudposse/terraform-aws-jenkins::tags/0.4.0
                   previous-requirements:
@@ -542,7 +542,7 @@ output:
     - type: create_pull_request
       expect:
         data:
-            base-commit-sha: 832e37c1a7a4ef89feb9dc7cfa06f62205191994
+            base-commit-sha: 8b2c0d821028c531826db20ca22cffdd2cc05abf
             dependencies:
                 - name: logs::github::cloudposse/terraform-aws-s3-log-storage::tags/0.2.2
                   previous-requirements:
@@ -728,7 +728,7 @@ output:
     - type: create_pull_request
       expect:
         data:
-            base-commit-sha: 832e37c1a7a4ef89feb9dc7cfa06f62205191994
+            base-commit-sha: 8b2c0d821028c531826db20ca22cffdd2cc05abf
             dependencies:
                 - name: origin_label::github::cloudposse/terraform-null-label::tags/0.3.7
                   previous-requirements:
@@ -987,4 +987,4 @@ output:
     - type: mark_as_processed
       expect:
         data:
-            base-commit-sha: 832e37c1a7a4ef89feb9dc7cfa06f62205191994
+            base-commit-sha: 8b2c0d821028c531826db20ca22cffdd2cc05abf


### PR DESCRIPTION
Bumping due to https://github.com/dependabot/dependabot-core/pull/5843

The commits were in the past before the reorganization so now that they are going to be fixed these matter again!