### PR TITLE
Don't hardcode master branch in dependencies

### DIFF
--- a/tests/smoke-bundler.yaml
+++ b/tests/smoke-bundler.yaml
@@ -50,7 +50,7 @@ output:
                         - default
                       requirement: '>= 0'
                       source:
-                        branch: master
+                        branch: null
                         ref: 2.1.4
                         type: git
                         url: git@github.com:rack/rack.git


### PR DESCRIPTION
The branch will be left blank if not explicit in the Gemfile.

Needed to get https://github.com/dependabot/dependabot-core/pull/6149 green.