### PR TITLE
Enable using public go module proxy

### DIFF
--- a/tests/smoke-go.yaml
+++ b/tests/smoke-go.yaml
@@ -11,6 +11,8 @@ input:
             - dependency-name: rsc.io/quote
               source: tests/smoke-go.yaml
               version-requirement: '>1.5.2'
+        experiments:
+            goprivate:
         source:
             provider: github
             repo: dependabot/smoke-tests


### PR DESCRIPTION
We do this by default unless a job is configured to use private dependencies. This should make the test run faster.