### PR TITLE
Update Gradle smoke test to include full name

### DIFF
--- a/tests/smoke-gradle.yaml
+++ b/tests/smoke-gradle.yaml
@@ -193,12 +193,12 @@ output:
                   operation: update
                   support_file: false
                   type: file
-            pr-title: Bump guice from 4.2.0 to 5.1.0 in /gradle
+            pr-title: Bump com.google.inject:guice from 4.2.0 to 5.1.0 in /gradle
             pr-body: |
-                Bumps [guice](https://github.com/google/guice) from 4.2.0 to 5.1.0.
+                Bumps [com.google.inject:guice](https://github.com/google/guice) from 4.2.0 to 5.1.0.
                 <details>
                 <summary>Release notes</summary>
-                <p><em>Sourced from <a href="https://github.com/google/guice/releases">guice's releases</a>.</em></p>
+                <p><em>Sourced from <a href="https://github.com/google/guice/releases">com.google.inject:guice's releases</a>.</em></p>
                 <blockquote>
                 <h2>Guice 5.1.0</h2>
                 <p>See <a href="https://github.com/google/guice/wiki/Guice510">https://github.com/google/guice/wiki/Guice510</a> for release notes.</p>
@@ -232,9 +232,9 @@ output:
                 </details>
                 <br />
             commit-message: |-
-                Bump guice from 4.2.0 to 5.1.0 in /gradle
+                Bump com.google.inject:guice from 4.2.0 to 5.1.0 in /gradle
 
-                Bumps [guice](https://github.com/google/guice) from 4.2.0 to 5.1.0.
+                Bumps [com.google.inject:guice](https://github.com/google/guice) from 4.2.0 to 5.1.0.
                 - [Release notes](https://github.com/google/guice/releases)
                 - [Commits](https://github.com/google/guice/compare/4.2...5.1.0)
     - type: create_pull_request
@@ -331,9 +331,9 @@ output:
                   operation: update
                   support_file: false
                   type: file
-            pr-title: Bump text from 1.12-1.4.0 to 1.12-1.6.5 in /gradle
+            pr-title: Bump net.kyori:text from 1.12-1.4.0 to 1.12-1.6.5 in /gradle
             pr-body: |
-                Bumps [text](https://github.com/KyoriPowered/text) from 1.12-1.4.0 to 1.12-1.6.5.
+                Bumps [net.kyori:text](https://github.com/KyoriPowered/text) from 1.12-1.4.0 to 1.12-1.6.5.
                 <details>
                 <summary>Commits</summary>
                 <ul>
@@ -342,9 +342,9 @@ output:
                 </details>
                 <br />
             commit-message: |-
-                Bump text from 1.12-1.4.0 to 1.12-1.6.5 in /gradle
+                Bump net.kyori:text from 1.12-1.4.0 to 1.12-1.6.5 in /gradle
 
-                Bumps [text](https://github.com/KyoriPowered/text) from 1.12-1.4.0 to 1.12-1.6.5.
+                Bumps [net.kyori:text](https://github.com/KyoriPowered/text) from 1.12-1.4.0 to 1.12-1.6.5.
                 - [Release notes](https://github.com/KyoriPowered/text/releases)
                 - [Commits](https://github.com/KyoriPowered/text/commits)
     - type: create_pull_request
@@ -441,13 +441,13 @@ output:
                   operation: update
                   support_file: false
                   type: file
-            pr-title: Bump org.eclipse.jgit from 4.11.0.201803080745-r to 6.3.0.202209071007-r in /gradle
+            pr-title: Bump org.eclipse.jgit:org.eclipse.jgit from 4.11.0.201803080745-r to 6.3.0.202209071007-r in /gradle
             pr-body: |
-                Bumps org.eclipse.jgit from 4.11.0.201803080745-r to 6.3.0.202209071007-r.
+                Bumps org.eclipse.jgit:org.eclipse.jgit from 4.11.0.201803080745-r to 6.3.0.202209071007-r.
             commit-message: |-
-                Bump org.eclipse.jgit in /gradle
+                Bump org.eclipse.jgit:org.eclipse.jgit in /gradle
 
-                Bumps org.eclipse.jgit from 4.11.0.201803080745-r to 6.3.0.202209071007-r.
+                Bumps org.eclipse.jgit:org.eclipse.jgit from 4.11.0.201803080745-r to 6.3.0.202209071007-r.
     - type: create_pull_request
       expect:
         data:
@@ -542,12 +542,12 @@ output:
                   operation: update
                   support_file: false
                   type: file
-            pr-title: Bump hibernate-core from 5.3.0.CR1 to 6.1.3.Final in /gradle
+            pr-title: Bump org.hibernate:hibernate-core from 5.3.0.CR1 to 6.1.3.Final in /gradle
             pr-body: |
-                Bumps [hibernate-core](https://github.com/hibernate/hibernate-orm) from 5.3.0.CR1 to 6.1.3.Final.
+                Bumps [org.hibernate:hibernate-core](https://github.com/hibernate/hibernate-orm) from 5.3.0.CR1 to 6.1.3.Final.
                 <details>
                 <summary>Changelog</summary>
-                <p><em>Sourced from <a href="https://github.com/hibernate/hibernate-orm/blob/6.1.3/changelog.txt">hibernate-core's changelog</a>.</em></p>
+                <p><em>Sourced from <a href="https://github.com/hibernate/hibernate-orm/blob/6.1.3/changelog.txt">org.hibernate:hibernate-core's changelog</a>.</em></p>
                 <blockquote>
                 <h2>Changes in 6.1.3.Final (September 08, 2022)</h2>
                 <p><a href="https://hibernate.atlassian.net/projects/HHH/versions/32093">https://hibernate.atlassian.net/projects/HHH/versions/32093</a></p>
@@ -601,9 +601,9 @@ output:
                 </details>
                 <br />
             commit-message: |-
-                Bump hibernate-core from 5.3.0.CR1 to 6.1.3.Final in /gradle
+                Bump org.hibernate:hibernate-core in /gradle
 
-                Bumps [hibernate-core](https://github.com/hibernate/hibernate-orm) from 5.3.0.CR1 to 6.1.3.Final.
+                Bumps [org.hibernate:hibernate-core](https://github.com/hibernate/hibernate-orm) from 5.3.0.CR1 to 6.1.3.Final.
                 - [Release notes](https://github.com/hibernate/hibernate-orm/releases)
                 - [Changelog](https://github.com/hibernate/hibernate-orm/blob/6.1.3/changelog.txt)
                 - [Commits](https://github.com/hibernate/hibernate-orm/commits/6.1.3)


### PR DESCRIPTION
In https://github.com/dependabot/dependabot-core/pull/6526, the display name for Gradle was updated to include the full name. See that PR for rationale.

Updated the smoke test by finding the image name from: https://github.com/dependabot/dependabot-core/actions/runs/4034930902/attempts/1#summary-10953476551

And then running:
```shell
dependabot --updater-image ghcr.io/dependabot/dependabot-updater-gradle:5eff30823a1eb0aba02f2267d14427a8bb547414 test -f tests/smoke-gradle.yaml -o tests/smoke-gradle.yaml
```

And committing the diff.