### PR TITLE
Ensure sane starting point for yarn berry test

### DIFF
--- a/yarn-berry/yarn.lock
+++ b/yarn-berry/yarn.lock
@@ -2376,7 +2376,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jquery@npm:3.5.0":
+"jquery@npm:^3.5.0":
   version: 3.5.0
   resolution: "jquery@npm:3.5.0"
   checksum: 5085f2f2e26fe5cbab10b3d05aef1dd9980c6f01aa07bbb238fc7778695b21fa5c182e5dd9ea6e7852349edae3a203b96849fd86862c81fc1c49d5fd1281f886
@@ -3538,7 +3538,7 @@ __metadata:
   resolution: "yarn@workspace:."
   dependencies:
     jest: 28.1.3
-    jquery: 3.5.0
+    jquery: ^3.5.0
     ts-jest: 28.0.8
     typescript: ^4.9.3
   languageName: unknown


### PR DESCRIPTION
Run `yarn install --mode=update-lockfile` on the yarn berry setup creates some source control changes, because the requirement in the package.json file is out of the with locked requirements.

We should make sure to start off with a clean slate and this is what this PR does.