### PR TITLE
Improve "Cache one" workflow

### DIFF
--- a/.github/workflows/cache-one.yml
+++ b/.github/workflows/cache-one.yml
@@ -39,7 +39,7 @@ env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  e2e:
+  cache_one:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cache-one.yml
+++ b/.github/workflows/cache-one.yml
@@ -41,6 +41,7 @@ env:
 jobs:
   cache_one:
     runs-on: ubuntu-latest
+    name: Cache ${{ github.event.inputs.package_manager }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Main change is to update the workflow to allow updating the cache even if tests fail.

Motivation is to get out of (I think) a chicken-and-egg issue while trying to get #28 green because tests there will fail because cache is out of date, and cache cannot be updated because tests fail.

Unrelated to this, I wonder if we could manage the cache within the main workflow itself.