### PR TITLE
prevent Artifacts from expiring after 90 days

### DIFF
--- a/.github/workflows/refresh-artifacts.yml
+++ b/.github/workflows/refresh-artifacts.yml
@@ -1,0 +1,50 @@
+# Downloads and then uploads the artifacts to keep them from expiring.
+name: Refresh artifacts
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - ".github/workflows/refresh-artifacts.yml"
+  schedule:
+    - cron: "0 12 * * 1" # Every Monday at 12:00 UTC
+
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - actions
+          - bundler
+          - cargo
+          - composer
+          - docker
+          - elm
+          - go
+          - gradle
+          - hex
+          - maven
+          - npm
+          - npm-remove-transitive
+          - nuget
+          - pip
+          - pip-compile
+          - pipenv
+          - poetry
+          - pub
+          - submodules
+          - terraform
+          - yarn-berry
+          - yarn-berry-workspaces
+    steps:
+      - name: Download artifacts
+        run: script/download-cache.sh ${{ matrix.suite }}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: cache-${{ matrix.suite }}
+          path: cache/

--- a/.github/workflows/refresh-artifacts.yml
+++ b/.github/workflows/refresh-artifacts.yml
@@ -42,6 +42,7 @@ jobs:
           - yarn-berry
           - yarn-berry-workspaces
     steps:
+      - uses: actions/checkout@v3
       - name: Download artifacts
         run: script/download-cache.sh ${{ matrix.suite }}
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
We use the Actions Artifacts to store the cache of the tests, but that expires after 90 days. This has already happened once where suddenly many of the caches were gone and we had to regenerate all the tests and caches again. This isn't a huge deal, but we don't need surprises. 

My cheeky solution is to run this job weekly where it downloads and then uploads the cache, keeping it from expiring. 

I set it to weekly in hopes that if it breaks we have more of a chance of catching it before the 90 days are up. 