### PR TITLE
Remove gemspec reference and rebundle

### DIFF
--- a/bundler/Gemfile
+++ b/bundler/Gemfile
@@ -2,8 +2,6 @@
 
 source "https://rubygems.org"
 
-gemspec
-
 gem "rubocop", "0.76.0"
 gem "toml-rb", "2.2.0"
 gem 'rack', git: 'git@github.com:rack/rack.git', tag: '2.1.4'

--- a/bundler/Gemfile.lock
+++ b/bundler/Gemfile.lock
@@ -5,19 +5,12 @@ GIT
   specs:
     rack (2.1.4)
 
-PATH
-  remote: .
-  specs:
-    dependabot-all-updates-test-staging (0.0.0)
-      netaddr (= 2.0.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
     citrus (3.0.2)
     jaro_winkler (1.5.4)
-    netaddr (2.0.1)
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
@@ -38,7 +31,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  dependabot-all-updates-test-staging!
   rack!
   rubocop (= 0.76.0)
   toml-rb (= 2.2.0)


### PR DESCRIPTION
When we re-arranged the project into subfolders, we removed some references to a `gemspec` and I think some submodules, so this PR just cleans up the Gemfile/Gemfile.lock so they are usable for new tests.

I haven't modified the existing tests as they are essentially shrink-wrapped from this change.