### PR TITLE
regenerate Cargo smoke test due to Rust/Cargo version bump

### DIFF
--- a/tests/smoke-cargo.yaml
+++ b/tests/smoke-cargo.yaml
@@ -130,9 +130,9 @@ output:
 
                     [[package]]
                     name = "bumpalo"
-                    version = "3.11.1"
+                    version = "3.12.0"
                     source = "registry+https://github.com/rust-lang/crates.io-index"
-                    checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+                    checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
                     [[package]]
                     name = "cfg-if"
@@ -150,18 +150,18 @@ output:
 
                     [[package]]
                     name = "js-sys"
-                    version = "0.3.60"
+                    version = "0.3.61"
                     source = "registry+https://github.com/rust-lang/crates.io-index"
-                    checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+                    checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
                     dependencies = [
                      "wasm-bindgen",
                     ]
 
                     [[package]]
                     name = "libc"
-                    version = "0.2.139"
+                    version = "0.2.140"
                     source = "registry+https://github.com/rust-lang/crates.io-index"
-                    checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+                    checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
                     [[package]]
                     name = "log"
@@ -192,24 +192,24 @@ output:
 
                     [[package]]
                     name = "once_cell"
-                    version = "1.17.0"
+                    version = "1.17.1"
                     source = "registry+https://github.com/rust-lang/crates.io-index"
-                    checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+                    checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
                     [[package]]
                     name = "proc-macro2"
-                    version = "1.0.49"
+                    version = "1.0.56"
                     source = "registry+https://github.com/rust-lang/crates.io-index"
-                    checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+                    checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
                     dependencies = [
                      "unicode-ident",
                     ]
 
                     [[package]]
                     name = "quote"
-                    version = "1.0.23"
+                    version = "1.0.26"
                     source = "registry+https://github.com/rust-lang/crates.io-index"
-                    checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+                    checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
                     dependencies = [
                      "proc-macro2",
                     ]
@@ -233,9 +233,9 @@ output:
 
                     [[package]]
                     name = "syn"
-                    version = "1.0.107"
+                    version = "1.0.109"
                     source = "registry+https://github.com/rust-lang/crates.io-index"
-                    checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+                    checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
                     dependencies = [
                      "proc-macro2",
                      "quote",
@@ -255,15 +255,15 @@ output:
 
                     [[package]]
                     name = "unicode-ident"
-                    version = "1.0.6"
+                    version = "1.0.8"
                     source = "registry+https://github.com/rust-lang/crates.io-index"
-                    checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+                    checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
                     [[package]]
                     name = "wasm-bindgen"
-                    version = "0.2.83"
+                    version = "0.2.84"
                     source = "registry+https://github.com/rust-lang/crates.io-index"
-                    checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+                    checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
                     dependencies = [
                      "cfg-if",
                      "wasm-bindgen-macro",
@@ -271,9 +271,9 @@ output:
 
                     [[package]]
                     name = "wasm-bindgen-backend"
-                    version = "0.2.83"
+                    version = "0.2.84"
                     source = "registry+https://github.com/rust-lang/crates.io-index"
-                    checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+                    checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
                     dependencies = [
                      "bumpalo",
                      "log",
@@ -286,9 +286,9 @@ output:
 
                     [[package]]
                     name = "wasm-bindgen-macro"
-                    version = "0.2.83"
+                    version = "0.2.84"
                     source = "registry+https://github.com/rust-lang/crates.io-index"
-                    checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+                    checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
                     dependencies = [
                      "quote",
                      "wasm-bindgen-macro-support",
@@ -296,9 +296,9 @@ output:
 
                     [[package]]
                     name = "wasm-bindgen-macro-support"
-                    version = "0.2.83"
+                    version = "0.2.84"
                     source = "registry+https://github.com/rust-lang/crates.io-index"
-                    checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+                    checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
                     dependencies = [
                      "proc-macro2",
                      "quote",
@@ -309,9 +309,9 @@ output:
 
                     [[package]]
                     name = "wasm-bindgen-shared"
-                    version = "0.2.83"
+                    version = "0.2.84"
                     source = "registry+https://github.com/rust-lang/crates.io-index"
-                    checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+                    checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
                   content_encoding: utf-8
                   deleted: false
                   directory: /
@@ -442,6 +442,7 @@ output:
                 - [Release notes](https://github.com/time-rs/time/releases)
                 - [Changelog](https://github.com/time-rs/time/blob/main/CHANGELOG.md)
                 - [Commits](https://github.com/time-rs/time/compare/0.1.38...v0.3.12)
+            grouped-update: false
     - type: create_pull_request
       expect:
         data:
@@ -542,9 +543,9 @@ output:
 
                     [[package]]
                     name = "regex-syntax"
-                    version = "0.6.28"
+                    version = "0.6.29"
                     source = "registry+https://github.com/rust-lang/crates.io-index"
-                    checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+                    checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
                     [[package]]
                     name = "time"
@@ -699,6 +700,7 @@ output:
                 - [Release notes](https://github.com/rust-lang/regex/releases)
                 - [Changelog](https://github.com/rust-lang/regex/blob/master/CHANGELOG.md)
                 - [Commits](https://github.com/rust-lang/regex/commits/1.6.0)
+            grouped-update: false
     - type: create_pull_request
       expect:
         data:
@@ -708,7 +710,7 @@ output:
                   previous-requirements: []
                   previous-version: 0.2.40
                   requirements: []
-                  version: 0.2.139
+                  version: 0.2.140
             updated-dependency-files:
                 - content: |
                     # This file is automatically @generated by Cargo.
@@ -744,9 +746,9 @@ output:
 
                     [[package]]
                     name = "libc"
-                    version = "0.2.139"
+                    version = "0.2.140"
                     source = "registry+https://github.com/rust-lang/crates.io-index"
-                    checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+                    checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
                     [[package]]
                     name = "memchr"
@@ -810,65 +812,64 @@ output:
                   operation: update
                   support_file: false
                   type: file
-            pr-title: Bump libc from 0.2.40 to 0.2.139
+            pr-title: Bump libc from 0.2.40 to 0.2.140
             pr-body: |
-                Bumps [libc](https://github.com/rust-lang/libc) from 0.2.40 to 0.2.139.
+                Bumps [libc](https://github.com/rust-lang/libc) from 0.2.40 to 0.2.140.
                 <details>
                 <summary>Release notes</summary>
                 <p><em>Sourced from <a href="https://github.com/rust-lang/libc/releases">libc's releases</a>.</em></p>
                 <blockquote>
-                <h2>0.2.139</h2>
+                <h2>0.2.140</h2>
                 <h2>What's Changed</h2>
                 <ul>
-                <li>Update FreeBSD 12 CI environment to 12.4 by <a href="https://github.com/asomers"><code>@​asomers</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3028">rust-lang/libc#3028</a></li>
-                <li>Try readding all inotify flags by <a href="https://github.com/carbotaniuman"><code>@​carbotaniuman</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3030">rust-lang/libc#3030</a></li>
-                <li>linux: Add AT_SYSINFO_EHDR constant by <a href="https://github.com/Phantomical"><code>@​Phantomical</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3027">rust-lang/libc#3027</a></li>
-                <li>Add missing string-to-number functions from ISO C by <a href="https://github.com/LegionMammal978"><code>@​LegionMammal978</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3036">rust-lang/libc#3036</a></li>
-                <li>Add support for QNX/Neutrino 7.1 by <a href="https://github.com/gh-tr"><code>@​gh-tr</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3038">rust-lang/libc#3038</a></li>
-                <li>Add misc constants and functions for android by <a href="https://github.com/fkm3"><code>@​fkm3</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/2758">rust-lang/libc#2758</a></li>
-                <li>adding KERNEL_VERSION macro for linux. by <a href="https://github.com/devnexen"><code>@​devnexen</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3041">rust-lang/libc#3041</a></li>
-                <li>Prepare 0.2.139 release by <a href="https://github.com/flba-eb"><code>@​flba-eb</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3042">rust-lang/libc#3042</a></li>
-                </ul>
-                <h2>New Contributors</h2>
-                <ul>
-                <li><a href="https://github.com/Phantomical"><code>@​Phantomical</code></a> made their first contribution in <a href="https://redirect.github.com/rust-lang/libc/pull/3027">rust-lang/libc#3027</a></li>
-                <li><a href="https://github.com/LegionMammal978"><code>@​LegionMammal978</code></a> made their first contribution in <a href="https://redirect.github.com/rust-lang/libc/pull/3036">rust-lang/libc#3036</a></li>
-                <li><a href="https://github.com/gh-tr"><code>@​gh-tr</code></a> made their first contribution in <a href="https://redirect.github.com/rust-lang/libc/pull/3038">rust-lang/libc#3038</a></li>
-                <li><a href="https://github.com/fkm3"><code>@​fkm3</code></a> made their first contribution in <a href="https://redirect.github.com/rust-lang/libc/pull/2758">rust-lang/libc#2758</a></li>
-                </ul>
-                <p><strong>Full Changelog</strong>: <a href="https://github.com/rust-lang/libc/compare/0.2.138...0.2.139">https://github.com/rust-lang/libc/compare/0.2.138...0.2.139</a></p>
-                <h2>0.2.138</h2>
-                <h2>What's Changed</h2>
-                <ul>
-                <li>Fix typo: <code>readfs</code> -&gt; <code>readfds</code> by <a href="https://github.com/giraffate"><code>@​giraffate</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/2981">rust-lang/libc#2981</a></li>
-                <li>linux: Add POSIX_SPAWN_SETSID flag by <a href="https://github.com/HarveyHunt"><code>@​HarveyHunt</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/2983">rust-lang/libc#2983</a></li>
-                <li>Enforce order of any <code>s_*!</code> macro calls by <a href="https://github.com/flba-eb"><code>@​flba-eb</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/2985">rust-lang/libc#2985</a></li>
-                <li>Add FICLONE ioctl for linux aarch64 by <a href="https://github.com/dtolnay"><code>@​dtolnay</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/2986">rust-lang/libc#2986</a></li>
-                <li>Revive <code>x86_64-linux-android</code> CI with an old nightly by <a href="https://github.com/JohnTitor"><code>@​JohnTitor</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/2990">rust-lang/libc#2990</a></li>
-                <li>fix wrong definitions of getpwent_r and getgrent_r on solarish os by <a href="https://github.com/SteveLauC"><code>@​SteveLauC</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/2914">rust-lang/libc#2914</a></li>
-                <li>add extended attributes constants on NetBSD by <a href="https://github.com/SteveLauC"><code>@​SteveLauC</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/2988">rust-lang/libc#2988</a></li>
-                <li>Use an old emulator to fix Android CI by <a href="https://github.com/JohnTitor"><code>@​JohnTitor</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/2989">rust-lang/libc#2989</a></li>
-                <li>Add ucontext and clone_args for loongarch64 by <a href="https://github.com/zhaixiaojuan"><code>@​zhaixiaojuan</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/2993">rust-lang/libc#2993</a></li>
-                <li>Add Android uinput bindings by <a href="https://github.com/spencercw"><code>@​spencercw</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/2984">rust-lang/libc#2984</a></li>
-                <li>add extattr_list_xxx() on NetBSD by <a href="https://github.com/SteveLauC"><code>@​SteveLauC</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/2991">rust-lang/libc#2991</a></li>
-                <li>freebsd procctl flags update by <a href="https://github.com/devnexen"><code>@​devnexen</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/2992">rust-lang/libc#2992</a></li>
-                <li>Report the actual error when failing to get the rustc version by <a href="https://github.com/bjorn3"><code>@​bjorn3</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3000">rust-lang/libc#3000</a></li>
-                <li>ci: Read test output from stderr by <a href="https://github.com/JohnTitor"><code>@​JohnTitor</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3005">rust-lang/libc#3005</a></li>
-                <li>freebsd subset of memstat api addition by <a href="https://github.com/devnexen"><code>@​devnexen</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/2998">rust-lang/libc#2998</a></li>
-                <li>Add rand48 functions by <a href="https://github.com/carbotaniuman"><code>@​carbotaniuman</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/2995">rust-lang/libc#2995</a></li>
-                <li>Add sys/ucontext.h signatures for linux aarch64 glibc by <a href="https://github.com/dtolnay"><code>@​dtolnay</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3001">rust-lang/libc#3001</a></li>
-                <li>Add pull request template by <a href="https://github.com/JohnTitor"><code>@​JohnTitor</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3006">rust-lang/libc#3006</a></li>
-                <li>Add kexec_file_load system call for arm64 linux by <a href="https://github.com/dtolnay"><code>@​dtolnay</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3009">rust-lang/libc#3009</a></li>
-                <li>Migrate from highfive to triagebot by <a href="https://github.com/ehuss"><code>@​ehuss</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3018">rust-lang/libc#3018</a></li>
-                <li>mips32: fix missing __s64 type definition by <a href="https://github.com/cppcoffee"><code>@​cppcoffee</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3016">rust-lang/libc#3016</a></li>
-                <li>Revert &quot;Auto merge of <a href="https://redirect.github.com/rust-lang/libc/issues/3018">#3018</a> - ehuss:highfive-triagebot, r=JohnTitor&quot; by <a href="https://github.com/JohnTitor"><code>@​JohnTitor</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3019">rust-lang/libc#3019</a></li>
-                <li>Fix the loongarch64 kernel ABI by <a href="https://github.com/xen0n"><code>@​xen0n</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3007">rust-lang/libc#3007</a></li>
-                <li>adding SYS_pidfd_send_signal/SYS_pidfd_getfd constants to linux uclib… by <a href="https://github.com/devnexen"><code>@​devnexen</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3012">rust-lang/libc#3012</a></li>
-                <li>handle c circular dependence (linux gnu) by <a href="https://github.com/BelovDV"><code>@​BelovDV</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3013">rust-lang/libc#3013</a></li>
-                <li>Migrate from highfive to triagebot by <a href="https://github.com/ehuss"><code>@​ehuss</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3020">rust-lang/libc#3020</a></li>
-                <li>Rearrange <code>sockaddr_storage</code> padding/alignment fields on Linux and Fuchsia by <a href="https://github.com/stevenengler"><code>@​stevenengler</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3010">rust-lang/libc#3010</a></li>
-                <li>linux musl adding <code>PIDFD_NONBLOCK</code> constant. by <a href="https://github.com/devnexen"><code>@​devnexen</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3003">rust-lang/libc#3003</a></li>
-                <li>Add more capsicum functions for FreeBSD by <a href="https://github.com/asomers"><code>@​asomers</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3022">rust-lang/libc#3022</a></li>
+                <li>linux-like: add AT_RECURSIVE constant by <a href="https://github.com/lucab"><code>@​lucab</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3043">rust-lang/libc#3043</a></li>
+                <li>Set correct <code>FD_SETSIZE</code> for <code>espidf</code> by <a href="https://github.com/zRedShift"><code>@​zRedShift</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3054">rust-lang/libc#3054</a></li>
+                <li>Fix Fuchsia target names by <a href="https://github.com/JohnTitor"><code>@​JohnTitor</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3059">rust-lang/libc#3059</a></li>
+                <li>PIDFD_NONBLOCK addition into uclibc. by <a href="https://github.com/devnexen"><code>@​devnexen</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3029">rust-lang/libc#3029</a></li>
+                <li>linux add scheduler core for prctl constants by <a href="https://github.com/devnexen"><code>@​devnexen</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3055">rust-lang/libc#3055</a></li>
+                <li>linux-like: add OPEN_TREE_CLONE and OPEN_TREE_CLOEXEC by <a href="https://github.com/lucab"><code>@​lucab</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3048">rust-lang/libc#3048</a></li>
+                <li>adding mimmutable from openbsd (7.3) by <a href="https://github.com/devnexen"><code>@​devnexen</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3063">rust-lang/libc#3063</a></li>
+                <li>Fix compile error for riscv64-linux-android by <a href="https://github.com/colincross"><code>@​colincross</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3064">rust-lang/libc#3064</a></li>
+                <li>android: add missing syscall constants by <a href="https://github.com/lucab"><code>@​lucab</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3062">rust-lang/libc#3062</a></li>
+                <li>haiku posix layer adding locale flavor of strcasecmp api by <a href="https://github.com/devnexen"><code>@​devnexen</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3069">rust-lang/libc#3069</a></li>
+                <li>linux: add pthread barriers by <a href="https://github.com/Forestryks"><code>@​Forestryks</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3065">rust-lang/libc#3065</a></li>
+                <li>netbsd 10 adding getentropy/getrandom. by <a href="https://github.com/devnexen"><code>@​devnexen</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3071">rust-lang/libc#3071</a></li>
+                <li>Ignore some ABI changed fns on macOS by <a href="https://github.com/JohnTitor"><code>@​JohnTitor</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3077">rust-lang/libc#3077</a></li>
+                <li>Add struct ctl_info by <a href="https://github.com/siegfried"><code>@​siegfried</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3046">rust-lang/libc#3046</a></li>
+                <li>linux: add additional netlink interface attribute tags by <a href="https://github.com/tones111"><code>@​tones111</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3053">rust-lang/libc#3053</a></li>
+                <li>Add <code>pthread_main_np</code> on Apple targets by <a href="https://github.com/madsmtm"><code>@​madsmtm</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3079">rust-lang/libc#3079</a></li>
+                <li>uclibc/mips: add O_NOATIME &amp; O_PATH constant by <a href="https://github.com/cppcoffee"><code>@​cppcoffee</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3058">rust-lang/libc#3058</a></li>
+                <li>linux/uclibc: resync syscall tables by <a href="https://github.com/lucab"><code>@​lucab</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3061">rust-lang/libc#3061</a></li>
+                <li>freebsd 14 add ptrace_sc_remote. by <a href="https://github.com/devnexen"><code>@​devnexen</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3073">rust-lang/libc#3073</a></li>
+                <li>netbsd 10 event api update. by <a href="https://github.com/devnexen"><code>@​devnexen</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3080">rust-lang/libc#3080</a></li>
+                <li>linux glibc update arm64 HWCAP2 list including the last 6.1 kernel en… by <a href="https://github.com/devnexen"><code>@​devnexen</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3081">rust-lang/libc#3081</a></li>
+                <li>adding specific freebsd signal constants by <a href="https://github.com/devnexen"><code>@​devnexen</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3082">rust-lang/libc#3082</a></li>
+                <li>Add getentropy for Emscripten by <a href="https://github.com/kleisauke"><code>@​kleisauke</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3087">rust-lang/libc#3087</a></li>
+                <li>netbsd 10 add ppoll api support by <a href="https://github.com/devnexen"><code>@​devnexen</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3083">rust-lang/libc#3083</a></li>
+                <li>uclibc/mips: add missing O_LARGEFILE constant by <a href="https://github.com/cppcoffee"><code>@​cppcoffee</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3088">rust-lang/libc#3088</a></li>
+                <li>add <code>user_regs</code> for linux on arm by <a href="https://github.com/Freax13"><code>@​Freax13</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3072">rust-lang/libc#3072</a></li>
+                <li>linux: add PTRACE_SYSCALL_INFO_* by <a href="https://github.com/mbyzhang"><code>@​mbyzhang</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3074">rust-lang/libc#3074</a></li>
+                <li>linux: add PR_SET_PTRACER_ANY by <a href="https://github.com/howjmay"><code>@​howjmay</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3086">rust-lang/libc#3086</a></li>
+                <li>uclibc/mips: add missing constant by <a href="https://github.com/cppcoffee"><code>@​cppcoffee</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3092">rust-lang/libc#3092</a></li>
+                <li>m68k: Fix incorrect type for sigaction::sa_flags by <a href="https://github.com/glaubitz"><code>@​glaubitz</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3078">rust-lang/libc#3078</a></li>
+                <li>Solaris/Illumos: use correct types for getrandom(2) flags by <a href="https://github.com/josephlr"><code>@​josephlr</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3090">rust-lang/libc#3090</a></li>
+                <li>Upgrade FreeBSD 14 image by <a href="https://github.com/JohnTitor"><code>@​JohnTitor</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3096">rust-lang/libc#3096</a></li>
+                <li>ANDROID: Add syncfs API in liblibc by <a href="https://github.com/shikhapanwar"><code>@​shikhapanwar</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3060">rust-lang/libc#3060</a></li>
+                <li>add SO_TS_* constants for FreeBSD by <a href="https://github.com/folkertdev"><code>@​folkertdev</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3098">rust-lang/libc#3098</a></li>
+                <li>uclibc/mips: add more missing constant by <a href="https://github.com/cppcoffee"><code>@​cppcoffee</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3094">rust-lang/libc#3094</a></li>
+                <li>pidfile util api for freebsd addition. by <a href="https://github.com/devnexen"><code>@​devnexen</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3099">rust-lang/libc#3099</a></li>
+                <li>freebsd add initial sctp support by <a href="https://github.com/devnexen"><code>@​devnexen</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3101">rust-lang/libc#3101</a></li>
+                <li>uclibc/mips: add missing MAP_HUGETLB constant by <a href="https://github.com/cppcoffee"><code>@​cppcoffee</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3100">rust-lang/libc#3100</a></li>
+                <li>xous: add initial C definitions by <a href="https://github.com/xobs"><code>@​xobs</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3084">rust-lang/libc#3084</a></li>
+                <li>freebsd further sctp support. by <a href="https://github.com/devnexen"><code>@​devnexen</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3102">rust-lang/libc#3102</a></li>
+                <li>apple add pthread_stack_frame_decode_np by <a href="https://github.com/devnexen"><code>@​devnexen</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3105">rust-lang/libc#3105</a></li>
+                <li>linux tcp adding TCP_MD5SIG_MAXKEYLEN const. by <a href="https://github.com/devnexen"><code>@​devnexen</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3107">rust-lang/libc#3107</a></li>
+                <li>linux: add more constants and FUTEX_OP for futex by <a href="https://github.com/voskh0d"><code>@​voskh0d</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3109">rust-lang/libc#3109</a></li>
+                <li>linux starting adding sctp support by <a href="https://github.com/devnexen"><code>@​devnexen</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3095">rust-lang/libc#3095</a></li>
+                <li>freebsd tcp_info data addition. by <a href="https://github.com/devnexen"><code>@​devnexen</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3112">rust-lang/libc#3112</a></li>
+                <li>netbsd tcp_info data addition. by <a href="https://github.com/devnexen"><code>@​devnexen</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3113">rust-lang/libc#3113</a></li>
+                <li>FreeBSD: move all new ABI to base module, add more O_ flags by <a href="https://github.com/valpackett"><code>@​valpackett</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3114">rust-lang/libc#3114</a></li>
+                <li>freebsd sctp support part 3 by <a href="https://github.com/devnexen"><code>@​devnexen</code></a> in <a href="https://redirect.github.com/rust-lang/libc/pull/3118">rust-lang/libc#3118</a></li>
                 </ul>
                 <!-- raw HTML omitted -->
                 </blockquote>
@@ -877,26 +878,27 @@ output:
                 <details>
                 <summary>Commits</summary>
                 <ul>
-                <li><a href="https://github.com/rust-lang/libc/commit/f4bc85111b2403a9c9cb49890305cb6b32c5af41"><code>f4bc851</code></a> Auto merge of <a href="https://redirect.github.com/rust-lang/libc/issues/3042">#3042</a> - flba-eb:release_0.2.139, r=JohnTitor</li>
-                <li><a href="https://github.com/rust-lang/libc/commit/dc3d43cae02e591c22e618af4eb98c68064e1a3a"><code>dc3d43c</code></a> Prepare 0.2.139 release</li>
-                <li><a href="https://github.com/rust-lang/libc/commit/c59ca735304319dd4face349f49fb77f2164b544"><code>c59ca73</code></a> Auto merge of <a href="https://redirect.github.com/rust-lang/libc/issues/3041">#3041</a> - devnexen:linux_kernel_version, r=JohnTitor</li>
-                <li><a href="https://github.com/rust-lang/libc/commit/88d6a1fd9b4b62729bd55a76e727f5f1d0aeef20"><code>88d6a1f</code></a> adding KERNEL_VERSION macro for linux.</li>
-                <li><a href="https://github.com/rust-lang/libc/commit/45b431a79ec7f72c245fb0631f2d05a9f16ca5a8"><code>45b431a</code></a> Auto merge of <a href="https://redirect.github.com/rust-lang/libc/issues/2758">#2758</a> - fkm3:master, r=JohnTitor</li>
-                <li><a href="https://github.com/rust-lang/libc/commit/572e11b963e85b7a5bcd94bc5f98d980baa21c92"><code>572e11b</code></a> Add misc constants and functions for android</li>
-                <li><a href="https://github.com/rust-lang/libc/commit/318dccc93a46344afabff64001d929fc37432f41"><code>318dccc</code></a> Auto merge of <a href="https://redirect.github.com/rust-lang/libc/issues/3038">#3038</a> - gh-tr:rebased/20221216, r=JohnTitor</li>
-                <li><a href="https://github.com/rust-lang/libc/commit/07636f636d6c0aeb65dfd1c4b0565c1cb4bad6e5"><code>07636f6</code></a> Auto merge of <a href="https://redirect.github.com/rust-lang/libc/issues/3036">#3036</a> - LegionMammal978:iso-c-funcs, r=JohnTitor</li>
-                <li><a href="https://github.com/rust-lang/libc/commit/720151f84493d3a4ca7081ee7b85f3c115a33860"><code>720151f</code></a> Add support for QNX/Neutrino 7.1</li>
-                <li><a href="https://github.com/rust-lang/libc/commit/6a58758d5f4198305191747c5c8b6af3c5057898"><code>6a58758</code></a> Add ISO C functions atof, atol, atoll, strtoll, strtoull</li>
-                <li>Additional commits viewable in <a href="https://github.com/rust-lang/libc/compare/0.2.40...0.2.139">compare view</a></li>
+                <li><a href="https://github.com/rust-lang/libc/commit/ad7bbf4b5d4f61d2b05b6dad1bd5880e40fc22f7"><code>ad7bbf4</code></a> Auto merge of <a href="https://redirect.github.com/rust-lang/libc/issues/3141">#3141</a> - Amanieu:v0.2.140, r=JohnTitor</li>
+                <li><a href="https://github.com/rust-lang/libc/commit/34e9a5e37856ba122791ce6d5f04cec9c7c24f2b"><code>34e9a5e</code></a> Auto merge of <a href="https://redirect.github.com/rust-lang/libc/issues/3143">#3143</a> - connor4312:add-errno, r=JohnTitor</li>
+                <li><a href="https://github.com/rust-lang/libc/commit/89ec88197af91a1a59d0666e474edaed3a6b4aca"><code>89ec881</code></a> Auto merge of <a href="https://redirect.github.com/rust-lang/libc/issues/3037">#3037</a> - ferrocene:pa-check-cfg, r=JohnTitor</li>
+                <li><a href="https://github.com/rust-lang/libc/commit/d63eedc3a3fe078e0aa32ba5a329f10d2e63c18d"><code>d63eedc</code></a> compatibility with rust 1.13.0</li>
+                <li><a href="https://github.com/rust-lang/libc/commit/9d3281baacde77e010ed6b90f8837fbec3acc9d3"><code>9d3281b</code></a> wasi: add __errno_location</li>
+                <li><a href="https://github.com/rust-lang/libc/commit/3363d43574db04c805388566fc1456f9e02ad01d"><code>3363d43</code></a> Auto merge of <a href="https://redirect.github.com/rust-lang/libc/issues/3142">#3142</a> - connor4312:wasi-irwx, r=JohnTitor</li>
+                <li><a href="https://github.com/rust-lang/libc/commit/4b4cd15cef75872808008a15ecb316f6e8a7d061"><code>4b4cd15</code></a> add S_IRWX* constants to wasi</li>
+                <li><a href="https://github.com/rust-lang/libc/commit/b9a49d442bdeeac8cac3bb097f5e224e7623e037"><code>b9a49d4</code></a> add ci job to test check-cfg</li>
+                <li><a href="https://github.com/rust-lang/libc/commit/e74f73544f29fe3559081250b9a657a36bc860eb"><code>e74f735</code></a> support extra check-cfg</li>
+                <li><a href="https://github.com/rust-lang/libc/commit/b636da0a67185598bbe739ed2c20910e51514e4d"><code>b636da0</code></a> emit rustc-check-cfg in the build script when LIBC_CHECK_CFG=1</li>
+                <li>Additional commits viewable in <a href="https://github.com/rust-lang/libc/compare/0.2.40...0.2.140">compare view</a></li>
                 </ul>
                 </details>
                 <br />
             commit-message: |-
-                Bump libc from 0.2.40 to 0.2.139
+                Bump libc from 0.2.40 to 0.2.140
 
-                Bumps [libc](https://github.com/rust-lang/libc) from 0.2.40 to 0.2.139.
+                Bumps [libc](https://github.com/rust-lang/libc) from 0.2.40 to 0.2.140.
                 - [Release notes](https://github.com/rust-lang/libc/releases)
-                - [Commits](https://github.com/rust-lang/libc/compare/0.2.40...0.2.139)
+                - [Commits](https://github.com/rust-lang/libc/compare/0.2.40...0.2.140)
+            grouped-update: false
     - type: create_pull_request
       expect:
         data:
@@ -1015,6 +1017,7 @@ output:
                 Bump redox_syscall from 0.1.37 to 0.1.57
 
                 Bumps redox_syscall from 0.1.37 to 0.1.57.
+            grouped-update: false
     - type: mark_as_processed
       expect:
         data:


### PR DESCRIPTION
https://github.com/dependabot/dependabot-core/pull/6995

The new version got around the cache.