### PR TITLE
Security updates must specify the dependency to be updated

### DIFF
--- a/tests/smoke-go-security.yaml
+++ b/tests/smoke-go-security.yaml
@@ -3,6 +3,8 @@ input:
         package-manager: go_modules
         allowed-updates:
             - update-type: all
+        dependencies:
+            - github.com/fatih/color
         ignore-conditions:
             - dependency-name: github.com/fatih/color
               source: tests/smoke-go-security.yaml


### PR DESCRIPTION
This smoke test was failing for the new, isolated security update operation class in https://github.com/dependabot/dependabot-core/pull/6961

It was odd as local testing with the CLI was showing the right outcome, but I realised that one consequence of this isolated updater is that it enforced the de-facto contract that a security update job _must_ specify the `dependencies` it is attempting to update.

Currently, if we do not set the dependencies we effectively perform an "All Versions Update" by suppress any updates we could make other than those we have advisory data for.

This 'working by accident' state is something the isolated Operations are trying to remediate, so let's update the test to use the real-world job definition.

### Notes

In the future, if we wanted to have some kind of 'All Security Updates possible' workflow, this is something we should treat as a new Operation class to be clear about the input payloads, etc, so we head into the right code line. There's still more work to be done in the Updater in order to make it more flexible/fully featured but for now I think closing the door on these accidental outcomes is in the spirit of the refactor.