### PR TITLE
Add a bundler grouped update smoke test for a job that has dependency-group rules

### DIFF
--- a/tests/smoke-bundler-group-rules.yaml
+++ b/tests/smoke-bundler-group-rules.yaml
@@ -27,8 +27,6 @@ input:
         credentials-metadata:
             - host: github.com
               type: git_source
-            - host: github.com
-              type: git_source
         max-updater-run-time: 2700
     credentials:
         - host: github.com

--- a/tests/smoke-bundler-group-rules.yaml
+++ b/tests/smoke-bundler-group-rules.yaml
@@ -1,0 +1,465 @@
+input:
+    job:
+        package-manager: bundler
+        allowed-updates:
+            - dependency-type: direct
+              update-type: all
+        dependency-groups:
+            - name: ruleset
+              rules:
+                patterns:
+                    - rack
+                    - rubocop
+        experiments:
+            grouped-updates-prototype: true
+        ignore-conditions:
+            - dependency-name: rubocop
+              source: tests/smoke-bundler-grouped.yaml
+              version-requirement: < 1.48.1
+        source:
+            provider: github
+            repo: dependabot/smoke-tests
+            directory: /bundler
+            commit: f558406ea0f067dcb5e223e257dcd91c27ea3a85
+            hostname: github.com
+            api-endpoint: https://api.github.com/
+        commit-message-options: {}
+        credentials-metadata:
+            - host: github.com
+              type: git_source
+            - host: github.com
+              type: git_source
+        max-updater-run-time: 2700
+    credentials:
+        - host: github.com
+          password: $LOCAL_GITHUB_ACCESS_TOKEN
+          type: git_source
+          username: x-access-token
+output:
+    - type: record_package_manager_version
+      expect:
+        data:
+            ecosystem: bundler
+            package-managers:
+                bundler: "2"
+    - type: update_dependency_list
+      expect:
+        data:
+            dependencies:
+                - name: rubocop
+                  requirements:
+                    - file: Gemfile
+                      groups:
+                        - default
+                      requirement: 0.76.0
+                      source: null
+                  version: 0.76.0
+                - name: toml-rb
+                  requirements:
+                    - file: Gemfile
+                      groups:
+                        - default
+                      requirement: 2.2.0
+                      source: null
+                  version: 2.2.0
+                - name: rack
+                  requirements:
+                    - file: Gemfile
+                      groups:
+                        - default
+                      requirement: '>= 0'
+                      source:
+                        branch: null
+                        ref: 2.1.4
+                        type: git
+                        url: git@github.com:rack/rack.git
+                  version: f3cf79d6460dc592767941806d1b2b7008f73e01
+                - name: ast
+                  requirements: []
+                  version: 2.4.2
+                - name: citrus
+                  requirements: []
+                  version: 3.0.2
+                - name: jaro_winkler
+                  requirements: []
+                  version: 1.5.4
+                - name: parallel
+                  requirements: []
+                  version: 1.22.1
+                - name: parser
+                  requirements: []
+                  version: 3.1.2.0
+                - name: rainbow
+                  requirements: []
+                  version: 3.1.1
+                - name: ruby-progressbar
+                  requirements: []
+                  version: 1.11.0
+                - name: unicode-display_width
+                  requirements: []
+                  version: 1.6.1
+            dependency_files:
+                - /bundler/Gemfile
+                - /bundler/Gemfile.lock
+    - type: create_pull_request
+      expect:
+        data:
+            base-commit-sha: f558406ea0f067dcb5e223e257dcd91c27ea3a85
+            dependencies:
+                - name: rubocop
+                  previous-requirements:
+                    - file: Gemfile
+                      groups:
+                        - default
+                      requirement: 0.76.0
+                      source: null
+                  previous-version: 0.76.0
+                  requirements:
+                    - file: Gemfile
+                      groups:
+                        - default
+                      requirement: 1.50.2
+                      source: null
+                  version: 1.50.2
+                - name: rack
+                  previous-requirements:
+                    - file: Gemfile
+                      groups:
+                        - default
+                      requirement: '>= 0'
+                      source:
+                        branch: null
+                        ref: 2.1.4
+                        type: git
+                        url: git@github.com:rack/rack.git
+                  previous-version: f3cf79d6460dc592767941806d1b2b7008f73e01
+                  requirements:
+                    - file: Gemfile
+                      groups:
+                        - default
+                      requirement: '>= 0'
+                      source:
+                        branch: null
+                        ref: v3.0.7
+                        type: git
+                        url: git@github.com:rack/rack.git
+                  version: 36ebd3d0ca0c7348e18dcdc4b5d2530e04238b8a
+            updated-dependency-files:
+                - content: |
+                    # frozen_string_literal: true
+
+                    source "https://rubygems.org"
+
+                    gem "rubocop", "1.50.2"
+                    gem "toml-rb", "2.2.0"
+                    gem 'rack', git: 'git@github.com:rack/rack.git', tag: 'v3.0.7'
+                  content_encoding: utf-8
+                  deleted: false
+                  directory: /bundler
+                  name: Gemfile
+                  operation: update
+                  support_file: false
+                  type: file
+                - content: |
+                    GIT
+                      remote: git@github.com:rack/rack.git
+                      revision: 36ebd3d0ca0c7348e18dcdc4b5d2530e04238b8a
+                      tag: v3.0.7
+                      specs:
+                        rack (3.0.7)
+
+                    GEM
+                      remote: https://rubygems.org/
+                      specs:
+                        ast (2.4.2)
+                        citrus (3.0.2)
+                        json (2.6.3)
+                        parallel (1.23.0)
+                        parser (3.2.2.0)
+                          ast (~> 2.4.1)
+                        rainbow (3.1.1)
+                        regexp_parser (2.8.0)
+                        rexml (3.2.5)
+                        rubocop (1.50.2)
+                          json (~> 2.3)
+                          parallel (~> 1.10)
+                          parser (>= 3.2.0.0)
+                          rainbow (>= 2.2.2, < 4.0)
+                          regexp_parser (>= 1.8, < 3.0)
+                          rexml (>= 3.2.5, < 4.0)
+                          rubocop-ast (>= 1.28.0, < 2.0)
+                          ruby-progressbar (~> 1.7)
+                          unicode-display_width (>= 2.4.0, < 3.0)
+                        rubocop-ast (1.28.0)
+                          parser (>= 3.2.1.0)
+                        ruby-progressbar (1.13.0)
+                        toml-rb (2.2.0)
+                          citrus (~> 3.0, > 3.0)
+                        unicode-display_width (2.4.2)
+
+                    PLATFORMS
+                      ruby
+
+                    DEPENDENCIES
+                      rack!
+                      rubocop (= 1.50.2)
+                      toml-rb (= 2.2.0)
+
+                    BUNDLED WITH
+                       2.1.4
+                  content_encoding: utf-8
+                  deleted: false
+                  directory: /bundler
+                  name: Gemfile.lock
+                  operation: update
+                  support_file: false
+                  type: file
+            pr-title: Bump rubocop and rack in /bundler
+            pr-body: |
+                Bumps [rubocop](https://github.com/rubocop/rubocop) and [rack](https://github.com/rack/rack). These dependencies needed to be updated together.
+                Updates `rubocop` from 0.76.0 to 1.50.2
+                <details>
+                <summary>Release notes</summary>
+                <p><em>Sourced from <a href="https://github.com/rubocop/rubocop/releases">rubocop's releases</a>.</em></p>
+                <blockquote>
+                <h2>RuboCop 1.50.2</h2>
+                <h3>Bug fixes</h3>
+                <ul>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/pull/11799">#11799</a>: Fix a false positive for <code>Style/CollectionCompact</code> when using <code>reject</code> on hash to reject nils in Ruby 2.3 analysis. (<a href="https://github.com/koic"><code>@​koic</code></a>)</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/issues/11792">#11792</a>: Fix an error for <code>Lint/DuplicateMatchPattern</code> when using hash pattern with <code>if</code> guard. (<a href="https://github.com/koic"><code>@​koic</code></a>)</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/issues/11800">#11800</a>: Mark <code>Style/InvertibleUnlessCondition</code> as unsafe. (<a href="https://github.com/koic"><code>@​koic</code></a>)</li>
+                </ul>
+                <h2>RuboCop 1.50.1</h2>
+                <h3>Bug fixes</h3>
+                <ul>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/issues/11787">#11787</a>: Fix a false positive for <code>Lint/DuplicateMatchPattern</code> when repeated <code>in</code> patterns but different <code>if</code> guard is used. (<a href="https://github.com/koic"><code>@​koic</code></a>)</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/pull/11789">#11789</a>: Fix false negatives for <code>Style/ParallelAssignment</code> when Ruby 2.7+. (<a href="https://github.com/koic"><code>@​koic</code></a>)</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/issues/11783">#11783</a>: Fix a false positive for <code>Style/RedundantLineContinuation</code> using line concatenation for assigning a return value and without argument parentheses. (<a href="https://github.com/koic"><code>@​koic</code></a>)</li>
+                </ul>
+                <h2>RuboCop 1.50</h2>
+                <h3>New features</h3>
+                <ul>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/pull/11749">#11749</a>: Add new <code>Lint/DuplicateMatchPattern</code> cop. (<a href="https://github.com/koic"><code>@​koic</code></a>)</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/pull/11773">#11773</a>: Make <code>Layout/ClassStructure</code> aware of singleton class. (<a href="https://github.com/koic"><code>@​koic</code></a>)</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/pull/11779">#11779</a>: Make <code>Lint/RedundantStringCoercion</code> aware of print method arguments. (<a href="https://github.com/koic"><code>@​koic</code></a>)</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/pull/11776">#11776</a>: Make <code>Metrics/ClassLength</code> aware of singleton class. (<a href="https://github.com/koic"><code>@​koic</code></a>)</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/pull/11775">#11775</a>: Make <code>Style/TrailingBodyOnClass</code> aware of singleton class. (<a href="https://github.com/koic"><code>@​koic</code></a>)</li>
+                </ul>
+                <h3>Bug fixes</h3>
+                <ul>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/issues/11758">#11758</a>: Fix a false positive for <code>Style/RedundantLineContinuation</code> when line continuations for string. (<a href="https://github.com/koic"><code>@​koic</code></a>)</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/pull/11754">#11754</a>: Fix a false positive for <code>Style/RedundantLineContinuation</code> when using <code>&amp;&amp;</code> and <code>||</code> with a multiline condition. (<a href="https://github.com/ydah"><code>@​ydah</code></a>)</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/issues/11765">#11765</a>: Fix an error for <code>Style/MultilineMethodSignature</code> when line break after <code>def</code> keyword. (<a href="https://github.com/koic"><code>@​koic</code></a>)</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/issues/11762">#11762</a>: Fix an incorrect autocorrect for <code>Style/ClassEqualityComparison</code>  when comparing a variable or return value for equality. (<a href="https://github.com/koic"><code>@​koic</code></a>)</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/pull/11752">#11752</a>: Fix a false positive for <code>Style/RedundantLineContinuation</code> when using line concatenation and calling a method without parentheses. (<a href="https://github.com/koic"><code>@​koic</code></a>)</li>
+                </ul>
+                <h2>RuboCop 1.49</h2>
+                <h3>New features</h3>
+                <ul>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/issues/11122">#11122</a>: Add new <code>Style/RedundantLineContinuation</code> cop. (<a href="https://github.com/ydah"><code>@​ydah</code></a>)</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/issues/11696">#11696</a>: Add new <code>Style/DataInheritance</code> cop. ([<a href="https://github.com/ktopolski"><code>@​ktopolski</code></a>][])</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/pull/11746">#11746</a>: Make <code>Layout/EndAlignment</code> aware of pattern matching. (<a href="https://github.com/koic"><code>@​koic</code></a>)</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/pull/11750">#11750</a>: Make <code>Metrics/BlockNesting</code> aware of numbered parameter. (<a href="https://github.com/koic"><code>@​koic</code></a>)</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/issues/11699">#11699</a>: Make <code>Style/ClassEqualityComparison</code> aware of <code>Class#to_s</code> and <code>Class#inspect</code> for class equality comparison. (<a href="https://github.com/koic"><code>@​koic</code></a>)</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/pull/11737">#11737</a>: Make <code>Style/MapToHash</code> and <code>Style/MapToSet</code> aware of numbered parameters. (<a href="https://github.com/koic"><code>@​koic</code></a>)</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/issues/11732">#11732</a>: Make <code>Style/MapToHash</code> and <code>Style/MapToSet</code> aware of symbol proc. (<a href="https://github.com/koic"><code>@​koic</code></a>)</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/pull/11703">#11703</a>: Make <code>Naming/InclusiveLanguage</code> support autocorrection when there is only one suggestion. (<a href="https://github.com/koic"><code>@​koic</code></a>)</li>
+                </ul>
+                <!-- raw HTML omitted -->
+                </blockquote>
+                <p>... (truncated)</p>
+                </details>
+                <details>
+                <summary>Changelog</summary>
+                <p><em>Sourced from <a href="https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md">rubocop's changelog</a>.</em></p>
+                <blockquote>
+                <h2>1.50.2 (2023-04-17)</h2>
+                <h3>Bug fixes</h3>
+                <ul>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/pull/11799">#11799</a>: Fix a false positive for <code>Style/CollectionCompact</code> when using <code>reject</code> on hash to reject nils in Ruby 2.3 analysis. ([<a href="https://github.com/koic"><code>@​koic</code></a>][])</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/issues/11792">#11792</a>: Fix an error for <code>Lint/DuplicateMatchPattern</code> when using hash pattern with <code>if</code> guard. ([<a href="https://github.com/koic"><code>@​koic</code></a>][])</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/issues/11800">#11800</a>: Mark <code>Style/InvertibleUnlessCondition</code> as unsafe. ([<a href="https://github.com/koic"><code>@​koic</code></a>][])</li>
+                </ul>
+                <h2>1.50.1 (2023-04-12)</h2>
+                <h3>Bug fixes</h3>
+                <ul>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/issues/11787">#11787</a>: Fix a false positive for <code>Lint/DuplicateMatchPattern</code> when repeated <code>in</code> patterns but different <code>if</code> guard is used. ([<a href="https://github.com/koic"><code>@​koic</code></a>][])</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/pull/11789">#11789</a>: Fix false negatives for <code>Style/ParallelAssignment</code> when Ruby 2.7+. ([<a href="https://github.com/koic"><code>@​koic</code></a>][])</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/issues/11783">#11783</a>: Fix a false positive for <code>Style/RedundantLineContinuation</code> using line concatenation for assigning a return value and without argument parentheses. ([<a href="https://github.com/koic"><code>@​koic</code></a>][])</li>
+                </ul>
+                <h2>1.50.0 (2023-04-11)</h2>
+                <h3>New features</h3>
+                <ul>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/pull/11749">#11749</a>: Add new <code>Lint/DuplicateMatchPattern</code> cop. ([<a href="https://github.com/koic"><code>@​koic</code></a>][])</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/pull/11773">#11773</a>: Make <code>Layout/ClassStructure</code> aware of singleton class. ([<a href="https://github.com/koic"><code>@​koic</code></a>][])</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/pull/11779">#11779</a>: Make <code>Lint/RedundantStringCoercion</code> aware of print method arguments. ([<a href="https://github.com/koic"><code>@​koic</code></a>][])</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/pull/11776">#11776</a>: Make <code>Metrics/ClassLength</code> aware of singleton class. ([<a href="https://github.com/koic"><code>@​koic</code></a>][])</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/pull/11775">#11775</a>: Make <code>Style/TrailingBodyOnClass</code> aware of singleton class. ([<a href="https://github.com/koic"><code>@​koic</code></a>][])</li>
+                </ul>
+                <h3>Bug fixes</h3>
+                <ul>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/issues/11758">#11758</a>: Fix a false positive for <code>Style/RedundantLineContinuation</code> when line continuations for string. ([<a href="https://github.com/koic"><code>@​koic</code></a>][])</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/pull/11754">#11754</a>: Fix a false positive for <code>Style/RedundantLineContinuation</code> when using <code>&amp;&amp;</code> and <code>||</code> with a multiline condition. ([<a href="https://github.com/ydah"><code>@​ydah</code></a>][])</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/issues/11765">#11765</a>: Fix an error for <code>Style/MultilineMethodSignature</code> when line break after <code>def</code> keyword. ([<a href="https://github.com/koic"><code>@​koic</code></a>][])</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/issues/11762">#11762</a>: Fix an incorrect autocorrect for <code>Style/ClassEqualityComparison</code>  when comparing a variable or return value for equality. ([<a href="https://github.com/koic"><code>@​koic</code></a>][])</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/pull/11752">#11752</a>: Fix a false positive for <code>Style/RedundantLineContinuation</code> when using line concatenation and calling a method without parentheses. ([<a href="https://github.com/koic"><code>@​koic</code></a>][])</li>
+                </ul>
+                <h2>1.49.0 (2023-04-03)</h2>
+                <h3>New features</h3>
+                <ul>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/issues/11122">#11122</a>: Add new <code>Style/RedundantLineContinuation</code> cop. ([<a href="https://github.com/ydah"><code>@​ydah</code></a>][])</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/issues/11696">#11696</a>: Add new <code>Style/DataInheritance</code> cop. ([<a href="https://github.com/ktopolski"><code>@​ktopolski</code></a>][])</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/pull/11746">#11746</a>: Make <code>Layout/EndAlignment</code> aware of pattern matching. ([<a href="https://github.com/koic"><code>@​koic</code></a>][])</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/pull/11750">#11750</a>: Make <code>Metrics/BlockNesting</code> aware of numbered parameter. ([<a href="https://github.com/koic"><code>@​koic</code></a>][])</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/issues/11699">#11699</a>: Make <code>Style/ClassEqualityComparison</code> aware of <code>Class#to_s</code> and <code>Class#inspect</code> for class equality comparison. ([<a href="https://github.com/koic"><code>@​koic</code></a>][])</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/pull/11737">#11737</a>: Make <code>Style/MapToHash</code> and <code>Style/MapToSet</code> aware of numbered parameters. ([<a href="https://github.com/koic"><code>@​koic</code></a>][])</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/issues/11732">#11732</a>: Make <code>Style/MapToHash</code> and <code>Style/MapToSet</code> aware of symbol proc. ([<a href="https://github.com/koic"><code>@​koic</code></a>][])</li>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/pull/11703">#11703</a>: Make <code>Naming/InclusiveLanguage</code> support autocorrection when there is only one suggestion. ([<a href="https://github.com/koic"><code>@​koic</code></a>][])</li>
+                </ul>
+                <h3>Bug fixes</h3>
+                <ul>
+                <li><a href="https://redirect.github.com/rubocop/rubocop/issues/11730">#11730</a>: Fix an error for <code>Layout/HashAlignment</code> when using anonymous keyword rest arguments. ([<a href="https://github.com/koic"><code>@​koic</code></a>][])</li>
+                </ul>
+                <!-- raw HTML omitted -->
+                </blockquote>
+                <p>... (truncated)</p>
+                </details>
+                <details>
+                <summary>Commits</summary>
+                <ul>
+                <li><a href="https://github.com/rubocop/rubocop/commit/ca0beb7eff823fab00e6517c6f48ec44b4f123e5"><code>ca0beb7</code></a> Cut 1.50.2</li>
+                <li><a href="https://github.com/rubocop/rubocop/commit/90844aef864cdef9883e71e27f1eb22228fe74a6"><code>90844ae</code></a> Update Changelog</li>
+                <li><a href="https://github.com/rubocop/rubocop/commit/f59711f700263c8fd8ad92af6fdaade4f6b85147"><code>f59711f</code></a> [Fix <a href="https://redirect.github.com/rubocop/rubocop/issues/11803">#11803</a>] Update the doc for <code>Style/RedundantFetchBlock</code></li>
+                <li><a href="https://github.com/rubocop/rubocop/commit/b5c8dda3469c0b5fdb2bcd6f795d33caa20ba61a"><code>b5c8dda</code></a> Merge pull request <a href="https://redirect.github.com/rubocop/rubocop/issues/11799">#11799</a> from koic/fix_a_false_positive_for_style_collection...</li>
+                <li><a href="https://github.com/rubocop/rubocop/commit/eeffa1000b5c0e14de417f2f0ed995ff8e3ff277"><code>eeffa10</code></a> Merge pull request <a href="https://redirect.github.com/rubocop/rubocop/issues/11805">#11805</a> from tagliala/chore/fix-typo-in-deprecated-attribut...</li>
+                <li><a href="https://github.com/rubocop/rubocop/commit/13eef33ef3d52c2c8bf74368a374ae48c817044a"><code>13eef33</code></a> Fix typo in DeprecatedAttributeAssignment cop</li>
+                <li><a href="https://github.com/rubocop/rubocop/commit/edcae93ed7e915807cfed9d1d6d4fa183fe3a24f"><code>edcae93</code></a> [Fix <a href="https://redirect.github.com/rubocop/rubocop/issues/11800">#11800</a>] Mark <code>Style/InvertibleUnlessCondition</code> as unsafe</li>
+                <li><a href="https://github.com/rubocop/rubocop/commit/c62667394667e5aed15a21bddfefce8282bf089e"><code>c626673</code></a> Fix a false positive for <code>Style/CollectionCompact</code></li>
+                <li><a href="https://github.com/rubocop/rubocop/commit/8dfe1b473d8e6083dded2c10cba0da6ab2354e69"><code>8dfe1b4</code></a> [Doc] Tweak examples for <code>AllowMultilineFinalElement</code></li>
+                <li><a href="https://github.com/rubocop/rubocop/commit/c59e349efcdd1ac0ce55e5a932b75d77d50ff659"><code>c59e349</code></a> [Fix <a href="https://redirect.github.com/rubocop/rubocop/issues/11792">#11792</a>] Fix an error for <code>Lint/DuplicateMatchPattern</code></li>
+                <li>Additional commits viewable in <a href="https://github.com/rubocop/rubocop/compare/v0.76.0...v1.50.2">compare view</a></li>
+                </ul>
+                </details>
+                <br />
+
+                Updates `rack` from 2.1.4 to v3.0.7
+                <details>
+                <summary>Release notes</summary>
+                <p><em>Sourced from <a href="https://github.com/rack/rack/releases">rack's releases</a>.</em></p>
+                <blockquote>
+                <h2>v3.0.7</h2>
+                <h2>What's Changed</h2>
+                <ul>
+                <li>Backport &quot;Make query parameters without = have nil values&quot;. by <a href="https://github.com/jeremyevans"><code>@​jeremyevans</code></a> in <a href="https://redirect.github.com/rack/rack/pull/2060">rack/rack#2060</a></li>
+                </ul>
+                <p><strong>Full Changelog</strong>: <a href="https://github.com/rack/rack/compare/v3.0.6.1...v3.0.7">https://github.com/rack/rack/compare/v3.0.6.1...v3.0.7</a></p>
+                <h2>v3.0.6.1</h2>
+                <p>No release notes provided.</p>
+                <h2>v3.0.4.1</h2>
+                <p><strong>Full Changelog</strong>: <a href="https://github.com/rack/rack/compare/v3.0.4...v3.0.4.1">https://github.com/rack/rack/compare/v3.0.4...v3.0.4.1</a></p>
+                <h2>v3.0.4</h2>
+                <p><strong>Full Changelog</strong>: <a href="https://github.com/rack/rack/compare/v3.0.3...v3.0.4">https://github.com/rack/rack/compare/v3.0.3...v3.0.4</a></p>
+                <h2>v3.0.3</h2>
+                <h2>What's Changed</h2>
+                <ul>
+                <li>Release v3.0.3 by <a href="https://github.com/ioquatix"><code>@​ioquatix</code></a> in <a href="https://redirect.github.com/rack/rack/pull/2000">rack/rack#2000</a></li>
+                </ul>
+                <p><strong>Full Changelog</strong>: <a href="https://github.com/rack/rack/compare/v3.0.2...v3.0.3">https://github.com/rack/rack/compare/v3.0.2...v3.0.3</a></p>
+                <h2>v3.0.2</h2>
+                <p><strong>Full Changelog</strong>: <a href="https://github.com/rack/rack/compare/v3.0.1...v3.0.2">https://github.com/rack/rack/compare/v3.0.1...v3.0.2</a></p>
+                <h2>v2.2.6.4</h2>
+                <p>No release notes provided.</p>
+                </blockquote>
+                </details>
+                <details>
+                <summary>Changelog</summary>
+                <p><em>Sourced from <a href="https://github.com/rack/rack/blob/main/CHANGELOG.md">rack's changelog</a>.</em></p>
+                <blockquote>
+                <h2>[3.0.7] - 2023-03-16</h2>
+                <ul>
+                <li>Make query parameters without <code>=</code> have <code>nil</code> values. (<a href="https://redirect.github.com/rack/rack/pull/2059">#2059</a>, [<a href="https://github.com/jeremyevans"><code>@​jeremyevans</code></a>])</li>
+                </ul>
+                <h2>[3.0.6.1] - 2023-03-13</h2>
+                <ul>
+                <li>[CVE-2023-27539] Avoid ReDoS in header parsing</li>
+                </ul>
+                <h2>[3.0.6] - 2023-03-13</h2>
+                <ul>
+                <li>Add <code>QueryParser#missing_value</code> for handling missing values + tests. (<a href="https://redirect.github.com/rack/rack/pull/2052">#2052</a>, [<a href="https://github.com/ioquatix"><code>@​ioquatix</code></a>])</li>
+                </ul>
+                <h2>[3.0.5] - 2023-03-13</h2>
+                <ul>
+                <li>Split form/query parsing into two steps. (<a href="https://redirect.github.com/rack/rack/pull/2038">#2038</a>, <a href="https://github.com/matthewd"><code>@​matthewd</code></a>)</li>
+                </ul>
+                <h2>[3.0.4.2] - 2023-03-02</h2>
+                <ul>
+                <li>[CVE-2023-27530] Introduce multipart_total_part_limit to limit total parts</li>
+                </ul>
+                <h2>[3.0.4.1] - 2023-01-17</h2>
+                <ul>
+                <li>[CVE-2022-44571] Fix ReDoS vulnerability in multipart parser</li>
+                <li>[CVE-2022-44570] Fix ReDoS in Rack::Utils.get_byte_ranges</li>
+                <li>[CVE-2022-44572] Forbid control characters in attributes (also ReDoS)</li>
+                </ul>
+                <h2>[3.0.4] - 2023-01-17</h2>
+                <ul>
+                <li><code>Rack::Request#POST</code> should consistently raise errors. Cache errors that occur when invoking <code>Rack::Request#POST</code> so they can be raised again later. (<a href="https://redirect.github.com/rack/rack/pull/2010">#2010</a>, [<a href="https://github.com/ioquatix"><code>@​ioquatix</code></a>])</li>
+                <li>Fix <code>Rack::Lint</code> error message for <code>HTTP_CONTENT_TYPE</code> and <code>HTTP_CONTENT_LENGTH</code>. (<a href="https://redirect.github.com/rack/rack/pull/2007">#2007</a>, <a href="https://github.com/byroot"><code>@​byroot</code></a>)</li>
+                <li>Extend <code>Rack::MethodOverride</code> to handle <code>QueryParser::ParamsTooDeepError</code> error. (<a href="https://redirect.github.com/rack/rack/pull/2006">#2006</a>, <a href="https://github.com/byroot"><code>@​byroot</code></a>)</li>
+                </ul>
+                <h2>[3.0.3] - 2022-12-27</h2>
+                <h3>Fixed</h3>
+                <ul>
+                <li><code>Rack::URLMap</code> uses non-deprecated form of <code>Regexp.new</code>. (<a href="https://redirect.github.com/rack/rack/pull/1998">#1998</a>, <a href="https://github.com/weizheheng"><code>@​weizheheng</code></a>)</li>
+                </ul>
+                <h2>[3.0.2] -2022-12-05</h2>
+                <h3>Fixed</h3>
+                <ul>
+                <li><code>Utils.build_nested_query</code> URL-encodes nested field names including the square brackets.</li>
+                <li>Allow <code>Rack::Response</code> to pass through streaming bodies. (<a href="https://redirect.github.com/rack/rack/pull/1993">#1993</a>, [<a href="https://github.com/ioquatix"><code>@​ioquatix</code></a>])</li>
+                </ul>
+                <h2>[3.0.1] - 2022-11-18</h2>
+                <h3>Fixed</h3>
+                <ul>
+                <li><code>MethodOverride</code> does not look for an override if a request does not include form/parseable data.</li>
+                </ul>
+                <!-- raw HTML omitted -->
+                </blockquote>
+                <p>... (truncated)</p>
+                </details>
+                <details>
+                <summary>Commits</summary>
+                <ul>
+                <li><a href="https://github.com/rack/rack/commit/2429b7ba38e402fc2e29405cab69395134020aed"><code>2429b7b</code></a> Bump patch version.</li>
+                <li><a href="https://github.com/rack/rack/commit/94dd78b30794d0e2f3855e92afdf98cdb4835f79"><code>94dd78b</code></a> Update changelog.</li>
+                <li><a href="https://github.com/rack/rack/commit/d38b45615d9c71b7a4f692ab5845b8d06a22d774"><code>d38b456</code></a> Make query parameters without = have nil values (<a href="https://redirect.github.com/rack/rack/issues/2059">#2059</a>) (<a href="https://redirect.github.com/rack/rack/issues/2060">#2060</a>)</li>
+                <li><a href="https://github.com/rack/rack/commit/51e7a0f92edcccf91ab3b79d36751866699de76e"><code>51e7a0f</code></a> Merge branch '3-0-sec' into 3-0-stable</li>
+                <li><a href="https://github.com/rack/rack/commit/098d8e12c1553411ee198d7890c1fd9f1e8cf979"><code>098d8e1</code></a> bump version</li>
+                <li><a href="https://github.com/rack/rack/commit/231ef369ad0b542575fb36c74fcfcfabcf6c530c"><code>231ef36</code></a> Avoid ReDoS problem</li>
+                <li><a href="https://github.com/rack/rack/commit/54a9ed22035c6d10bc1bb8f1815f81307fd9d99b"><code>54a9ed2</code></a> Update changelog.</li>
+                <li><a href="https://github.com/rack/rack/commit/e9e9ae663d83f142d7666aee49622287828fa06f"><code>e9e9ae6</code></a> Bump patch version.</li>
+                <li><a href="https://github.com/rack/rack/commit/848c9c00562edbe54e72f83fcf253fcdc9449f74"><code>848c9c0</code></a> Add <code>QueryParser#missing_value</code> for handling missing values + tests. (<a href="https://redirect.github.com/rack/rack/issues/2052">#2052</a>)</li>
+                <li><a href="https://github.com/rack/rack/commit/9f8ba5e1fdf860338af7a65519278b32de00f516"><code>9f8ba5e</code></a> Bump patch version.</li>
+                <li>Additional commits viewable in <a href="https://github.com/rack/rack/compare/f3cf79d6460dc592767941806d1b2b7008f73e01...36ebd3d0ca0c7348e18dcdc4b5d2530e04238b8a">compare view</a></li>
+                </ul>
+                </details>
+                <br />
+            commit-message: |-
+                Bump rubocop and rack in /bundler
+
+                Bumps [rubocop](https://github.com/rubocop/rubocop) and [rack](https://github.com/rack/rack). These dependencies needed to be updated together.
+
+                Updates `rubocop` from 0.76.0 to 1.50.2
+                - [Release notes](https://github.com/rubocop/rubocop/releases)
+                - [Changelog](https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md)
+                - [Commits](https://github.com/rubocop/rubocop/compare/v0.76.0...v1.50.2)
+
+                Updates `rack` from 2.1.4 to v3.0.7
+                - [Release notes](https://github.com/rack/rack/releases)
+                - [Changelog](https://github.com/rack/rack/blob/main/CHANGELOG.md)
+                - [Commits](https://github.com/rack/rack/compare/f3cf79d6460dc592767941806d1b2b7008f73e01...36ebd3d0ca0c7348e18dcdc4b5d2530e04238b8a)
+            grouped-update: true
+    - type: mark_as_processed
+      expect:
+        data:
+            base-commit-sha: f558406ea0f067dcb5e223e257dcd91c27ea3a85


### PR DESCRIPTION
Adds a bundler grouped update smoke test for a job that has dependency-group rules.

This smoke test also includes an ignore config which grouped updates now supports.

This is different from the existing bundler grouped update smoke test because that tests the default `group-all` behavior that appears for jobs _without_ a dependency-group rule.