### PR TITLE
Update maven tests to use groupId and artifactId for the dependency name 

### DIFF
--- a/tests/smoke-maven.yaml
+++ b/tests/smoke-maven.yaml
@@ -200,7 +200,7 @@ output:
                   type: file
             pr-title: Bump org.springframework.boot:spring-boot-starter-parent from 1.5.9.RELEASE to 2.7.2
             pr-body: |
-                Bumps [spring-boot-starter-parent](https://github.com/spring-projects/spring-boot) from 1.5.9.RELEASE to 2.7.2.
+                Bumps [org.springframework.boot:spring-boot-starter-parent](https://github.com/spring-projects/spring-boot) from 1.5.9.RELEASE to 2.7.2.
                 <details>
                 <summary>Release notes</summary>
                 <p><em>Sourced from <a href="https://github.com/spring-projects/spring-boot/releases">spring-boot-starter-parent's releases</a>.</em></p>

--- a/tests/smoke-maven.yaml
+++ b/tests/smoke-maven.yaml
@@ -198,7 +198,7 @@ output:
                   operation: update
                   support_file: false
                   type: file
-            pr-title: Bump spring-boot-starter-parent from 1.5.9.RELEASE to 2.7.2
+            pr-title: Bump org.springframework.boot:spring-boot-starter-parent from 1.5.9.RELEASE to 2.7.2
             pr-body: |
                 Bumps [spring-boot-starter-parent](https://github.com/spring-projects/spring-boot) from 1.5.9.RELEASE to 2.7.2.
                 <details>
@@ -277,9 +277,9 @@ output:
                 </details>
                 <br />
             commit-message: |-
-                Bump spring-boot-starter-parent from 1.5.9.RELEASE to 2.7.2
+                Bump org.springframework.boot:spring-boot-starter-parent
 
-                Bumps [spring-boot-starter-parent](https://github.com/spring-projects/spring-boot) from 1.5.9.RELEASE to 2.7.2.
+                Bumps [org.springframework.boot:spring-boot-starter-parent](https://github.com/spring-projects/spring-boot) from 1.5.9.RELEASE to 2.7.2.
                 - [Release notes](https://github.com/spring-projects/spring-boot/releases)
                 - [Commits](https://github.com/spring-projects/spring-boot/compare/v1.5.9.RELEASE...v2.7.2)
     - type: mark_as_processed


### PR DESCRIPTION
See https://github.com/dependabot/dependabot-core/pull/7146