### PR TITLE
Remove dependency-groups from go and cargo tests, remove grouped-update flag

### DIFF
--- a/tests/smoke-cargo.yaml
+++ b/tests/smoke-cargo.yaml
@@ -441,7 +441,6 @@ output:
                 - [Release notes](https://github.com/time-rs/time/releases)
                 - [Changelog](https://github.com/time-rs/time/blob/main/CHANGELOG.md)
                 - [Commits](https://github.com/time-rs/time/compare/v0.3.0-alpha-2...v0.3.20)
-            dependency-group: {}
     - type: create_pull_request
       expect:
         data:
@@ -717,7 +716,6 @@ output:
                 - [Release notes](https://github.com/rust-lang/regex/releases)
                 - [Changelog](https://github.com/rust-lang/regex/blob/master/CHANGELOG.md)
                 - [Commits](https://github.com/rust-lang/regex/compare/1.6.0...1.7.3)
-            dependency-group: {}
     - type: create_pull_request
       expect:
         data:
@@ -977,7 +975,6 @@ output:
                 - [Release notes](https://github.com/rust-random/rand/releases)
                 - [Changelog](https://github.com/rust-random/rand/blob/master/CHANGELOG.md)
                 - [Commits](https://github.com/rust-random/rand/compare/8792268dfe57e49bb4518190bf4fe66176759a44...937320cbfeebd4352a23086d9c6e68f067f74644)
-            dependency-group: {}
     - type: create_pull_request
       expect:
         data:
@@ -1216,7 +1213,6 @@ output:
                 Bumps [itoa](https://github.com/dtolnay/itoa) from 1.0.5 to 1.0.6.
                 - [Release notes](https://github.com/dtolnay/itoa/releases)
                 - [Commits](https://github.com/dtolnay/itoa/compare/ef4faeda61024dfb38b3897e46aeda8140828dc6...3cab737d59c60014655268a79930861db300023d)
-            dependency-group: {}
     - type: create_pull_request
       expect:
         data:
@@ -1454,7 +1450,6 @@ output:
                 Bumps [libc](https://github.com/rust-lang/libc) from 0.2.141 to 0.2.142.
                 - [Release notes](https://github.com/rust-lang/libc/releases)
                 - [Commits](https://github.com/rust-lang/libc/compare/0.2.141...0.2.142)
-            dependency-group: {}
     - type: mark_as_processed
       expect:
         data:

--- a/tests/smoke-go-security.yaml
+++ b/tests/smoke-go-security.yaml
@@ -187,7 +187,6 @@ output:
                 Bumps [github.com/fatih/color](https://github.com/fatih/color) from 1.7.0 to 1.10.0.
                 - [Release notes](https://github.com/fatih/color/releases)
                 - [Commits](https://github.com/fatih/color/compare/v1.7.0...v1.10.0)
-            dependency-group: {}
     - type: mark_as_processed
       expect:
         data:

--- a/tests/smoke-go.yaml
+++ b/tests/smoke-go.yaml
@@ -224,7 +224,6 @@ output:
                 Bumps [github.com/fatih/color](https://github.com/fatih/color) from 1.7.0 to 1.13.0.
                 - [Release notes](https://github.com/fatih/color/releases)
                 - [Commits](https://github.com/fatih/color/compare/v1.7.0...v1.13.0)
-            dependency-group: {}
     - type: create_pull_request
       expect:
         data:
@@ -314,7 +313,6 @@ output:
                 Bumps [github.com/inconshreveable/mousetrap](https://github.com/inconshreveable/mousetrap) from 0.0.0-20141017200713-76626ae9c91c to 1.1.0.
                 - [Release notes](https://github.com/inconshreveable/mousetrap/releases)
                 - [Commits](https://github.com/inconshreveable/mousetrap/commits/v1.1)
-            dependency-group: {}
     - type: create_pull_request
       expect:
         data:
@@ -429,7 +427,6 @@ output:
                 Bumps [golang.org/x/crypto](https://github.com/golang/crypto) from 0.0.0-20180617042118-027cca12c2d6 to 0.6.0.
                 - [Release notes](https://github.com/golang/crypto/releases)
                 - [Commits](https://github.com/golang/crypto/commits/v0.6.0)
-            dependency-group: {}
     - type: create_pull_request
       expect:
         data:
@@ -524,7 +521,6 @@ output:
                 Bumps [rsc.io/quote](https://github.com/rsc/quote) from 1.4.0 to 1.5.2.
                 - [Release notes](https://github.com/rsc/quote/releases)
                 - [Commits](https://github.com/rsc/quote/compare/v1.4.0...v1.5.2)
-            dependency-group: {}
     - type: mark_as_processed
       expect:
         data:

--- a/tests/smoke-gradle-version-catalog.yaml
+++ b/tests/smoke-gradle-version-catalog.yaml
@@ -256,7 +256,6 @@ output:
                 Bump com.android.application in /gradle-version-catalog
 
                 Bumps com.android.application from 7.3.1 to 7.4.2.
-            grouped-update: false
     - type: create_pull_request
       expect:
         data:
@@ -311,7 +310,6 @@ output:
                 Bump com.android.library from 7.3.1 to 7.4.2 in /gradle-version-catalog
 
                 Bumps com.android.library from 7.3.1 to 7.4.2.
-            grouped-update: false
     - type: create_pull_request
       expect:
         data:
@@ -511,7 +509,6 @@ output:
                 - [Release notes](https://github.com/JetBrains/kotlin/releases)
                 - [Changelog](https://github.com/JetBrains/kotlin/blob/master/ChangeLog.md)
                 - [Commits](https://github.com/JetBrains/kotlin/compare/v1.7.0...v1.8.10)
-            grouped-update: false
     - type: create_pull_request
       expect:
         data:
@@ -664,7 +661,6 @@ output:
                 Bump androidx.core:core-ktx in /gradle-version-catalog
 
                 Bumps androidx.core:core-ktx from 1.7.0 to 1.9.0.
-            grouped-update: false
     - type: create_pull_request
       expect:
         data:
@@ -734,7 +730,6 @@ output:
                 Bump androidx.lifecycle:lifecycle-runtime-ktx in /gradle-version-catalog
 
                 Bumps androidx.lifecycle:lifecycle-runtime-ktx from 2.3.1 to 2.6.0.
-            grouped-update: false
     - type: create_pull_request
       expect:
         data:
@@ -800,7 +795,6 @@ output:
                 Bump androidx.activity:activity-compose in /gradle-version-catalog
 
                 Bumps androidx.activity:activity-compose from 1.3.1 to 1.6.1.
-            grouped-update: false
     - type: create_pull_request
       expect:
         data:
@@ -965,7 +959,6 @@ output:
                 Updates `androidx.compose.ui:ui-tooling` from 1.2.0 to 1.3.3
 
                 Updates `androidx.compose.ui:ui-test-manifest` from 1.2.0 to 1.3.3
-            grouped-update: false
     - type: create_pull_request
       expect:
         data:
@@ -1035,7 +1028,6 @@ output:
                 Bump androidx.test.ext:junit in /gradle-version-catalog
 
                 Bumps androidx.test.ext:junit from 1.1.3 to 1.1.5.
-            grouped-update: false
     - type: create_pull_request
       expect:
         data:
@@ -1105,7 +1097,6 @@ output:
                 Bump androidx.test.espresso:espresso-core in /gradle-version-catalog
 
                 Bumps androidx.test.espresso:espresso-core from 3.5.0 to 3.5.1.
-            grouped-update: false
     - type: create_pull_request
       expect:
         data:
@@ -1173,7 +1164,6 @@ output:
                 Bump org.jmailen.kotlinter in /gradle-version-catalog
 
                 Bumps org.jmailen.kotlinter from 3.11.0 to 3.13.0.
-            grouped-update: false
     - type: mark_as_processed
       expect:
         data:

--- a/tests/smoke-yarn.yaml
+++ b/tests/smoke-yarn.yaml
@@ -441,7 +441,6 @@ output:
                 Bump fetch-factory from 0.0.1 to 0.2.1 in /yarn/subdir
 
                 Bumps fetch-factory from 0.0.1 to 0.2.1.
-            grouped-update: false
     - type: create_pull_request
       expect:
         data:
@@ -741,7 +740,6 @@ output:
                 - [Release notes](https://github.com/jshttp/etag/releases)
                 - [Changelog](https://github.com/jshttp/etag/blob/master/HISTORY.md)
                 - [Commits](https://github.com/jshttp/etag/compare/v1.0.0...v1.8.1)
-            grouped-update: false
     - type: mark_as_processed
       expect:
         data:


### PR DESCRIPTION
This realigns these smoke tests with https://github.com/dependabot/cli/pull/103 released in cli version v1.20.1, which changed `dependency-group` to be omitted if empty to align with the API's expectations.

This just walks back some changes made to smoke tests that needed to be refreshed when v1.20.0 was forcing this key to be put in output files.