### PR TITLE
Update bundler smoke test for updated grouped PR intros

### DIFF
--- a/tests/smoke-bundler-group-rules.yaml
+++ b/tests/smoke-bundler-group-rules.yaml
@@ -188,7 +188,7 @@ output:
                           rubocop-ast (>= 1.28.0, < 2.0)
                           ruby-progressbar (~> 1.7)
                           unicode-display_width (>= 2.4.0, < 3.0)
-                        rubocop-ast (1.28.0)
+                        rubocop-ast (1.28.1)
                           parser (>= 3.2.1.0)
                         ruby-progressbar (1.13.0)
                         toml-rb (2.2.0)
@@ -214,7 +214,7 @@ output:
                   type: file
             pr-title: Bump the ruleset group in /bundler with 2 updates
             pr-body: |
-                Bumps [rubocop](https://github.com/rubocop/rubocop) and [rack](https://github.com/rack/rack). These dependencies needed to be updated together.
+                Bumps the ruleset group in /bundler with 2 updates: [rubocop](https://github.com/rubocop/rubocop) and [rack](https://github.com/rack/rack).
                 Updates `rubocop` from 0.76.0 to 1.50.2
                 <details>
                 <summary>Release notes</summary>
@@ -456,7 +456,7 @@ output:
             commit-message: |-
                 Bump the ruleset group in /bundler with 2 updates
 
-                Bumps [rubocop](https://github.com/rubocop/rubocop) and [rack](https://github.com/rack/rack). These dependencies needed to be updated together.
+                Bumps the ruleset group in /bundler with 2 updates: [rubocop](https://github.com/rubocop/rubocop) and [rack](https://github.com/rack/rack).
 
                 Updates `rubocop` from 0.76.0 to 1.50.2
                 - [Release notes](https://github.com/rubocop/rubocop/releases)


### PR DESCRIPTION
dependabot/dependabot-core#7247 added handling for grouped PR intros, which caused the bundler-group-rules e2e test to start failing in core. This PR regenerates the smoke test expectations for the new copy. Once this is merged we can re-enable the failing e2e in core.