### PR TITLE
update pub test with latest PR

### DIFF
--- a/tests/smoke-pub.yaml
+++ b/tests/smoke-pub.yaml
@@ -5,25 +5,31 @@ input:
             - update-type: all
         ignore-conditions:
             - dependency-name: collection
-              source: tests/smoke-pub.yaml
-              version-requirement: '>1.16.0'
+              source: smoke-tests/tests/smoke-pub.yaml
+              version-requirement: '>1.17.1'
             - dependency-name: fixnum
-              source: tests/smoke-pub.yaml
-              version-requirement: '>1.0.1'
+              source: smoke-tests/tests/smoke-pub.yaml
+              version-requirement: '>1.1.0'
             - dependency-name: protobuf
-              source: tests/smoke-pub.yaml
-              version-requirement: '>2.0.0'
+              source: smoke-tests/tests/smoke-pub.yaml
+              version-requirement: '>2.1.0'
+            - dependency-name: http
+              source: smoke-tests/tests/smoke-pub.yaml
+              version-requirement: '>0.13.6'
             - dependency-name: path
-              source: tests/smoke-pub.yaml
-              version-requirement: '>1.8.2'
+              source: smoke-tests/tests/smoke-pub.yaml
+              version-requirement: '>1.8.3'
             - dependency-name: retry
-              source: tests/smoke-pub.yaml
-              version-requirement: '>3.1.0'
+              source: smoke-tests/tests/smoke-pub.yaml
+              version-requirement: '>3.1.1'
+            - dependency-name: test
+              source: smoke-tests/tests/smoke-pub.yaml
+              version-requirement: '>1.24.2'
         source:
             provider: github
             repo: dependabot/smoke-tests
             directory: /pub
-            commit: 8b2c0d821028c531826db20ca22cffdd2cc05abf
+            commit: 48e9be2bc45b1336ef6088260fbe56a162c5678e
         credentials-metadata:
             - host: github.com
               type: git_source
@@ -37,6 +43,21 @@ output:
       expect:
         data:
             dependencies:
+                - name: _fe_analyzer_shared
+                  requirements: []
+                  version: 50.0.0
+                - name: analyzer
+                  requirements: []
+                  version: 5.2.0
+                - name: args
+                  requirements: []
+                  version: 2.3.1
+                - name: async
+                  requirements: []
+                  version: 2.10.0
+                - name: boolean_selector
+                  requirements: []
+                  version: 2.1.1
                 - name: collection
                   requirements:
                     - file: pubspec.yaml
@@ -46,9 +67,21 @@ output:
                       source:
                         description:
                             name: collection
-                            url: https://pub.dartlang.org
+                            url: https://pub.dev
                         type: hosted
-                  version: 1.14.13
+                  version: 1.17.0
+                - name: convert
+                  requirements: []
+                  version: 3.1.1
+                - name: coverage
+                  requirements: []
+                  version: 1.6.1
+                - name: crypto
+                  requirements: []
+                  version: 3.0.2
+                - name: file
+                  requirements: []
+                  version: 6.1.4
                 - name: fixnum
                   requirements:
                     - file: pubspec.yaml
@@ -58,9 +91,57 @@ output:
                       source:
                         description:
                             name: fixnum
-                            url: https://pub.dartlang.org
+                            url: https://pub.dev
                         type: hosted
                   version: 0.10.11
+                - name: frontend_server_client
+                  requirements: []
+                  version: 3.2.0
+                - name: glob
+                  requirements: []
+                  version: 2.1.1
+                - name: http
+                  requirements:
+                    - file: pubspec.yaml
+                      groups:
+                        - direct
+                      requirement: 0.13.2
+                      source:
+                        description:
+                            name: http
+                            url: https://pub.dev
+                        type: hosted
+                  version: 0.13.2
+                - name: http_multi_server
+                  requirements: []
+                  version: 3.2.1
+                - name: http_parser
+                  requirements: []
+                  version: 4.0.2
+                - name: io
+                  requirements: []
+                  version: 1.0.3
+                - name: js
+                  requirements: []
+                  version: 0.6.5
+                - name: logging
+                  requirements: []
+                  version: 1.1.0
+                - name: matcher
+                  requirements: []
+                  version: 0.12.13
+                - name: meta
+                  requirements: []
+                  version: 1.8.0
+                - name: mime
+                  requirements: []
+                  version: 1.0.2
+                - name: node_preamble
+                  requirements: []
+                  version: 2.0.1
+                - name: package_config
+                  requirements: []
+                  version: 2.1.0
                 - name: path
                   requirements:
                     - file: pubspec.yaml
@@ -70,9 +151,15 @@ output:
                       source:
                         description:
                             name: path
-                            url: https://pub.dartlang.org
+                            url: https://pub.dev
                         type: hosted
                   version: 1.8.1
+                - name: pedantic
+                  requirements: []
+                  version: 1.11.1
+                - name: pool
+                  requirements: []
+                  version: 1.5.1
                 - name: protobuf
                   requirements:
                     - file: pubspec.yaml
@@ -82,9 +169,12 @@ output:
                       source:
                         description:
                             name: protobuf
-                            url: https://pub.dartlang.org
+                            url: https://pub.dev
                         type: hosted
                   version: 1.1.4
+                - name: pub_semver
+                  requirements: []
+                  version: 2.1.3
                 - name: retry
                   requirements:
                     - file: pubspec.yaml
@@ -94,16 +184,538 @@ output:
                       source:
                         description:
                             name: retry
-                            url: https://pub.dartlang.org
+                            url: https://pub.dev
                         type: hosted
                   version: 2.0.0
+                - name: shelf
+                  requirements: []
+                  version: 1.4.0
+                - name: shelf_packages_handler
+                  requirements: []
+                  version: 3.0.1
+                - name: shelf_static
+                  requirements: []
+                  version: 1.1.1
+                - name: shelf_web_socket
+                  requirements: []
+                  version: 1.0.3
+                - name: source_map_stack_trace
+                  requirements: []
+                  version: 2.1.1
+                - name: source_maps
+                  requirements: []
+                  version: 0.10.11
+                - name: source_span
+                  requirements: []
+                  version: 1.9.1
+                - name: stack_trace
+                  requirements: []
+                  version: 1.11.0
+                - name: stream_channel
+                  requirements: []
+                  version: 2.1.1
+                - name: string_scanner
+                  requirements: []
+                  version: 1.2.0
+                - name: term_glyph
+                  requirements: []
+                  version: 1.2.1
+                - name: test
+                  requirements:
+                    - file: pubspec.yaml
+                      groups:
+                        - dev
+                      requirement: ^1.16.5
+                      source:
+                        description:
+                            name: test
+                            url: https://pub.dev
+                        type: hosted
+                  version: 1.22.0
+                - name: test_api
+                  requirements: []
+                  version: 0.4.16
+                - name: test_core
+                  requirements: []
+                  version: 0.4.20
+                - name: typed_data
+                  requirements: []
+                  version: 1.3.1
+                - name: vm_service
+                  requirements: []
+                  version: 9.4.0
+                - name: watcher
+                  requirements: []
+                  version: 1.0.2
+                - name: web_socket_channel
+                  requirements: []
+                  version: 2.2.0
+                - name: webkit_inspection_protocol
+                  requirements: []
+                  version: 1.2.0
+                - name: yaml
+                  requirements: []
+                  version: 3.1.1
             dependency_files:
                 - /pub/pubspec.yaml
                 - /pub/pubspec.lock
     - type: create_pull_request
       expect:
         data:
-            base-commit-sha: 8b2c0d821028c531826db20ca22cffdd2cc05abf
+            base-commit-sha: 48e9be2bc45b1336ef6088260fbe56a162c5678e
+            dependencies:
+                - name: collection
+                  previous-requirements:
+                    - file: pubspec.yaml
+                      groups:
+                        - direct
+                      requirement: ^1.14.13
+                      source:
+                        description:
+                            name: collection
+                            url: https://pub.dev
+                        type: hosted
+                  previous-version: 1.17.0
+                  requirements:
+                    - file: pubspec.yaml
+                      groups:
+                        - direct
+                      requirement: ^1.17.1
+                      source: null
+                  version: 1.17.1
+            updated-dependency-files:
+                - content: |
+                    name: dependabot_testcase
+                    environment:
+                      sdk: '>=2.12.0 <3.0.0'
+                    dependencies:
+                      collection: ^1.17.1 # Locked to 1.14.13, can update with no unlock.
+                      retry: ^2.0.0 # Can update with updated constraint, no further constraints.
+                      protobuf: 1.1.4 # Can update with updated constraint, only together with fixnum.
+                      fixnum: 0.10.11
+                      path: 1.8.1 # Already at latest
+                      http: "0.13.2" # < 0.13.3 has a security vulnerability: https://github.com/advisories/GHSA-4rgh-jx4f-qfcq
+
+                    dev_dependencies:
+                      test: ^1.16.5
+                  content_encoding: utf-8
+                  deleted: false
+                  directory: /pub
+                  name: pubspec.yaml
+                  operation: update
+                  support_file: false
+                  type: file
+                - content: |
+                    # Generated by pub
+                    # See https://dart.dev/tools/pub/glossary#lockfile
+                    packages:
+                      _fe_analyzer_shared:
+                        dependency: transitive
+                        description:
+                          name: _fe_analyzer_shared
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "50.0.0"
+                      analyzer:
+                        dependency: transitive
+                        description:
+                          name: analyzer
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "5.2.0"
+                      args:
+                        dependency: transitive
+                        description:
+                          name: args
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.3.1"
+                      async:
+                        dependency: transitive
+                        description:
+                          name: async
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.10.0"
+                      boolean_selector:
+                        dependency: transitive
+                        description:
+                          name: boolean_selector
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.1"
+                      collection:
+                        dependency: "direct main"
+                        description:
+                          name: collection
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.17.1"
+                      convert:
+                        dependency: transitive
+                        description:
+                          name: convert
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.1.1"
+                      coverage:
+                        dependency: transitive
+                        description:
+                          name: coverage
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.6.1"
+                      crypto:
+                        dependency: transitive
+                        description:
+                          name: crypto
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.0.2"
+                      file:
+                        dependency: transitive
+                        description:
+                          name: file
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "6.1.4"
+                      fixnum:
+                        dependency: "direct main"
+                        description:
+                          name: fixnum
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.10.11"
+                      frontend_server_client:
+                        dependency: transitive
+                        description:
+                          name: frontend_server_client
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.2.0"
+                      glob:
+                        dependency: transitive
+                        description:
+                          name: glob
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.1"
+                      http:
+                        dependency: "direct main"
+                        description:
+                          name: http
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.13.2"
+                      http_multi_server:
+                        dependency: transitive
+                        description:
+                          name: http_multi_server
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.2.1"
+                      http_parser:
+                        dependency: transitive
+                        description:
+                          name: http_parser
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "4.0.2"
+                      io:
+                        dependency: transitive
+                        description:
+                          name: io
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.0.3"
+                      js:
+                        dependency: transitive
+                        description:
+                          name: js
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.6.5"
+                      logging:
+                        dependency: transitive
+                        description:
+                          name: logging
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.1.0"
+                      matcher:
+                        dependency: transitive
+                        description:
+                          name: matcher
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.12.13"
+                      meta:
+                        dependency: transitive
+                        description:
+                          name: meta
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.8.0"
+                      mime:
+                        dependency: transitive
+                        description:
+                          name: mime
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.0.2"
+                      node_preamble:
+                        dependency: transitive
+                        description:
+                          name: node_preamble
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.0.1"
+                      package_config:
+                        dependency: transitive
+                        description:
+                          name: package_config
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.0"
+                      path:
+                        dependency: "direct main"
+                        description:
+                          name: path
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.8.1"
+                      pedantic:
+                        dependency: transitive
+                        description:
+                          name: pedantic
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.11.1"
+                      pool:
+                        dependency: transitive
+                        description:
+                          name: pool
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.5.1"
+                      protobuf:
+                        dependency: "direct main"
+                        description:
+                          name: protobuf
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.1.4"
+                      pub_semver:
+                        dependency: transitive
+                        description:
+                          name: pub_semver
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.3"
+                      retry:
+                        dependency: "direct main"
+                        description:
+                          name: retry
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.0.0"
+                      shelf:
+                        dependency: transitive
+                        description:
+                          name: shelf
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.4.0"
+                      shelf_packages_handler:
+                        dependency: transitive
+                        description:
+                          name: shelf_packages_handler
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.0.1"
+                      shelf_static:
+                        dependency: transitive
+                        description:
+                          name: shelf_static
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.1.1"
+                      shelf_web_socket:
+                        dependency: transitive
+                        description:
+                          name: shelf_web_socket
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.0.3"
+                      source_map_stack_trace:
+                        dependency: transitive
+                        description:
+                          name: source_map_stack_trace
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.1"
+                      source_maps:
+                        dependency: transitive
+                        description:
+                          name: source_maps
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.10.11"
+                      source_span:
+                        dependency: transitive
+                        description:
+                          name: source_span
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.9.1"
+                      stack_trace:
+                        dependency: transitive
+                        description:
+                          name: stack_trace
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.11.0"
+                      stream_channel:
+                        dependency: transitive
+                        description:
+                          name: stream_channel
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.1"
+                      string_scanner:
+                        dependency: transitive
+                        description:
+                          name: string_scanner
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.2.0"
+                      term_glyph:
+                        dependency: transitive
+                        description:
+                          name: term_glyph
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.2.1"
+                      test:
+                        dependency: "direct dev"
+                        description:
+                          name: test
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.22.0"
+                      test_api:
+                        dependency: transitive
+                        description:
+                          name: test_api
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.4.16"
+                      test_core:
+                        dependency: transitive
+                        description:
+                          name: test_core
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.4.20"
+                      typed_data:
+                        dependency: transitive
+                        description:
+                          name: typed_data
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.3.1"
+                      vm_service:
+                        dependency: transitive
+                        description:
+                          name: vm_service
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "9.4.0"
+                      watcher:
+                        dependency: transitive
+                        description:
+                          name: watcher
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.0.2"
+                      web_socket_channel:
+                        dependency: transitive
+                        description:
+                          name: web_socket_channel
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.2.0"
+                      webkit_inspection_protocol:
+                        dependency: transitive
+                        description:
+                          name: webkit_inspection_protocol
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.2.0"
+                      yaml:
+                        dependency: transitive
+                        description:
+                          name: yaml
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.1.1"
+                    sdks:
+                      dart: ">=2.18.0 <3.0.0"
+                  content_encoding: utf-8
+                  deleted: false
+                  directory: /pub
+                  name: pubspec.lock
+                  operation: update
+                  support_file: false
+                  type: file
+            pr-title: Bump collection from 1.17.0 to 1.17.1 in /pub
+            pr-body: |
+                Bumps [collection](https://github.com/dart-lang/collection) from 1.17.0 to 1.17.1.
+                <details>
+                <summary>Release notes</summary>
+                <p><em>Sourced from <a href="https://github.com/dart-lang/collection/releases">collection's releases</a>.</em></p>
+                <blockquote>
+                <h2>v1.17.1</h2>
+                <ul>
+                <li>Require Dart 2.18</li>
+                <li>Improve docs for <code>splitAfter</code> and <code>splitBefore</code>.</li>
+                </ul>
+                </blockquote>
+                </details>
+                <details>
+                <summary>Changelog</summary>
+                <p><em>Sourced from <a href="https://github.com/dart-lang/collection/blob/master/CHANGELOG.md">collection's changelog</a>.</em></p>
+                <blockquote>
+                <h2>1.17.1</h2>
+                <ul>
+                <li>Require Dart 2.18.</li>
+                <li>Improve docs for <code>splitAfter</code> and <code>splitBefore</code>.</li>
+                </ul>
+                </blockquote>
+                </details>
+                <details>
+                <summary>Commits</summary>
+                <ul>
+                <li><a href="https://github.com/dart-lang/collection/commit/a566328f793cd26c52f3fa4010fe331bb8700383"><code>a566328</code></a> add a publish script; prep to publish (<a href="https://redirect.github.com/dart-lang/collection/issues/267">#267</a>)</li>
+                <li><a href="https://github.com/dart-lang/collection/commit/85e987cf1b8aaba60bdc8b16dd1ee6233436549f"><code>85e987c</code></a> Bump actions/checkout from 3.1.0 to 3.2.0 (<a href="https://redirect.github.com/dart-lang/collection/issues/262">#262</a>)</li>
+                <li><a href="https://github.com/dart-lang/collection/commit/cdb11d410b67279d81673def5a8a78dfc0dec2eb"><code>cdb11d4</code></a> Change <code>CastError</code> to <code>TypeError</code>, since the former is deprecated. (<a href="https://redirect.github.com/dart-lang/collection/issues/258">#258</a>)</li>
+                <li><a href="https://github.com/dart-lang/collection/commit/caf6802bbea65a1a2f9c455add31449dc15b92ba"><code>caf6802</code></a> Tweak docs for split extensions (<a href="https://redirect.github.com/dart-lang/collection/issues/256">#256</a>)</li>
+                <li><a href="https://github.com/dart-lang/collection/commit/efd709fc1760a595f8575f4137a1847de1b49d76"><code>efd709f</code></a> Fix doc comment references among other new lints (<a href="https://redirect.github.com/dart-lang/collection/issues/253">#253</a>)</li>
+                <li>See full diff in <a href="https://github.com/dart-lang/collection/compare/1.17.0...v1.17.1">compare view</a></li>
+                </ul>
+                </details>
+                <br />
+            commit-message: |-
+                Bump collection from 1.17.0 to 1.17.1 in /pub
+
+                Bumps [collection](https://github.com/dart-lang/collection) from 1.17.0 to 1.17.1.
+                - [Release notes](https://github.com/dart-lang/collection/releases)
+                - [Changelog](https://github.com/dart-lang/collection/blob/master/CHANGELOG.md)
+                - [Commits](https://github.com/dart-lang/collection/compare/1.17.0...v1.17.1)
+    - type: create_pull_request
+      expect:
+        data:
+            base-commit-sha: 48e9be2bc45b1336ef6088260fbe56a162c5678e
             dependencies:
                 - name: fixnum
                   previous-requirements:
@@ -117,9 +729,9 @@ output:
                     - file: pubspec.yaml
                       groups:
                         - direct
-                      requirement: ^1.0.1
+                      requirement: ^1.1.0
                       source: null
-                  version: 1.0.1
+                  version: 1.1.0
                 - name: protobuf
                   previous-requirements:
                     - file: pubspec.yaml
@@ -132,11 +744,24 @@ output:
                     - file: pubspec.yaml
                       groups:
                         - direct
-                      requirement: ^2.0.0
+                      requirement: ^2.1.0
                       source: null
-                  version: 2.0.0
+                  version: 2.1.0
             updated-dependency-files:
-                - content: "name: dependabot_testcase\nenvironment:\n  sdk: '>=2.12.0 <3.0.0'\ndependencies:\n  collection: ^1.14.13 # Locked to 1.14.13, can update with no unlock.\n  retry: ^2.0.0 # Can update with updated constraint, no further constraints.\n  protobuf: ^2.0.0 # Can update with updated constraint, only together with fixnum.\n  fixnum: ^1.0.1\n  path: 1.8.1 # Already at latest\n  \n"
+                - content: |
+                    name: dependabot_testcase
+                    environment:
+                      sdk: '>=2.12.0 <3.0.0'
+                    dependencies:
+                      collection: ^1.14.13 # Locked to 1.14.13, can update with no unlock.
+                      retry: ^2.0.0 # Can update with updated constraint, no further constraints.
+                      protobuf: ^2.1.0 # Can update with updated constraint, only together with fixnum.
+                      fixnum: ^1.1.0
+                      path: 1.8.1 # Already at latest
+                      http: "0.13.2" # < 0.13.3 has a security vulnerability: https://github.com/advisories/GHSA-4rgh-jx4f-qfcq
+
+                    dev_dependencies:
+                      test: ^1.16.5
                   content_encoding: utf-8
                   deleted: false
                   directory: /pub
@@ -148,43 +773,358 @@ output:
                     # Generated by pub
                     # See https://dart.dev/tools/pub/glossary#lockfile
                     packages:
+                      _fe_analyzer_shared:
+                        dependency: transitive
+                        description:
+                          name: _fe_analyzer_shared
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "50.0.0"
+                      analyzer:
+                        dependency: transitive
+                        description:
+                          name: analyzer
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "5.2.0"
+                      args:
+                        dependency: transitive
+                        description:
+                          name: args
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.3.1"
+                      async:
+                        dependency: transitive
+                        description:
+                          name: async
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.10.0"
+                      boolean_selector:
+                        dependency: transitive
+                        description:
+                          name: boolean_selector
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.1"
                       collection:
                         dependency: "direct main"
                         description:
                           name: collection
-                          url: "https://pub.dartlang.org"
+                          url: "https://pub.dev"
                         source: hosted
-                        version: "1.14.13"
+                        version: "1.17.0"
+                      convert:
+                        dependency: transitive
+                        description:
+                          name: convert
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.1.1"
+                      coverage:
+                        dependency: transitive
+                        description:
+                          name: coverage
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.6.1"
+                      crypto:
+                        dependency: transitive
+                        description:
+                          name: crypto
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.0.2"
+                      file:
+                        dependency: transitive
+                        description:
+                          name: file
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "6.1.4"
                       fixnum:
                         dependency: "direct main"
                         description:
                           name: fixnum
-                          url: "https://pub.dartlang.org"
+                          url: "https://pub.dev"
                         source: hosted
-                        version: "1.0.1"
+                        version: "1.1.0"
+                      frontend_server_client:
+                        dependency: transitive
+                        description:
+                          name: frontend_server_client
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.2.0"
+                      glob:
+                        dependency: transitive
+                        description:
+                          name: glob
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.1"
+                      http:
+                        dependency: "direct main"
+                        description:
+                          name: http
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.13.2"
+                      http_multi_server:
+                        dependency: transitive
+                        description:
+                          name: http_multi_server
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.2.1"
+                      http_parser:
+                        dependency: transitive
+                        description:
+                          name: http_parser
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "4.0.2"
+                      io:
+                        dependency: transitive
+                        description:
+                          name: io
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.0.3"
+                      js:
+                        dependency: transitive
+                        description:
+                          name: js
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.6.5"
+                      logging:
+                        dependency: transitive
+                        description:
+                          name: logging
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.1.0"
+                      matcher:
+                        dependency: transitive
+                        description:
+                          name: matcher
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.12.13"
+                      meta:
+                        dependency: transitive
+                        description:
+                          name: meta
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.8.0"
+                      mime:
+                        dependency: transitive
+                        description:
+                          name: mime
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.0.2"
+                      node_preamble:
+                        dependency: transitive
+                        description:
+                          name: node_preamble
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.0.1"
+                      package_config:
+                        dependency: transitive
+                        description:
+                          name: package_config
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.0"
                       path:
                         dependency: "direct main"
                         description:
                           name: path
-                          url: "https://pub.dartlang.org"
+                          url: "https://pub.dev"
                         source: hosted
                         version: "1.8.1"
+                      pedantic:
+                        dependency: transitive
+                        description:
+                          name: pedantic
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.11.1"
+                      pool:
+                        dependency: transitive
+                        description:
+                          name: pool
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.5.1"
                       protobuf:
                         dependency: "direct main"
                         description:
                           name: protobuf
-                          url: "https://pub.dartlang.org"
+                          url: "https://pub.dev"
                         source: hosted
-                        version: "2.0.0"
+                        version: "2.1.0"
+                      pub_semver:
+                        dependency: transitive
+                        description:
+                          name: pub_semver
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.3"
                       retry:
                         dependency: "direct main"
                         description:
                           name: retry
-                          url: "https://pub.dartlang.org"
+                          url: "https://pub.dev"
                         source: hosted
                         version: "2.0.0"
+                      shelf:
+                        dependency: transitive
+                        description:
+                          name: shelf
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.4.0"
+                      shelf_packages_handler:
+                        dependency: transitive
+                        description:
+                          name: shelf_packages_handler
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.0.1"
+                      shelf_static:
+                        dependency: transitive
+                        description:
+                          name: shelf_static
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.1.1"
+                      shelf_web_socket:
+                        dependency: transitive
+                        description:
+                          name: shelf_web_socket
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.0.3"
+                      source_map_stack_trace:
+                        dependency: transitive
+                        description:
+                          name: source_map_stack_trace
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.1"
+                      source_maps:
+                        dependency: transitive
+                        description:
+                          name: source_maps
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.10.11"
+                      source_span:
+                        dependency: transitive
+                        description:
+                          name: source_span
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.9.1"
+                      stack_trace:
+                        dependency: transitive
+                        description:
+                          name: stack_trace
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.11.0"
+                      stream_channel:
+                        dependency: transitive
+                        description:
+                          name: stream_channel
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.1"
+                      string_scanner:
+                        dependency: transitive
+                        description:
+                          name: string_scanner
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.2.0"
+                      term_glyph:
+                        dependency: transitive
+                        description:
+                          name: term_glyph
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.2.1"
+                      test:
+                        dependency: "direct dev"
+                        description:
+                          name: test
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.22.0"
+                      test_api:
+                        dependency: transitive
+                        description:
+                          name: test_api
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.4.16"
+                      test_core:
+                        dependency: transitive
+                        description:
+                          name: test_core
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.4.20"
+                      typed_data:
+                        dependency: transitive
+                        description:
+                          name: typed_data
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.3.1"
+                      vm_service:
+                        dependency: transitive
+                        description:
+                          name: vm_service
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "9.4.0"
+                      watcher:
+                        dependency: transitive
+                        description:
+                          name: watcher
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.0.2"
+                      web_socket_channel:
+                        dependency: transitive
+                        description:
+                          name: web_socket_channel
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.2.0"
+                      webkit_inspection_protocol:
+                        dependency: transitive
+                        description:
+                          name: webkit_inspection_protocol
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.2.0"
+                      yaml:
+                        dependency: transitive
+                        description:
+                          name: yaml
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.1.1"
                     sdks:
-                      dart: ">=2.12.0 <3.0.0"
+                      dart: ">=2.18.0 <3.0.0"
                   content_encoding: utf-8
                   deleted: false
                   directory: /pub
@@ -195,11 +1135,39 @@ output:
             pr-title: Bump fixnum and protobuf in /pub
             pr-body: |
                 Bumps [fixnum](https://github.com/dart-lang/fixnum) and [protobuf](https://github.com/google/protobuf.dart). These dependencies needed to be updated together.
-                Updates `fixnum` from 0.10.11 to 1.0.1
+                Updates `fixnum` from 0.10.11 to 1.1.0
+                <details>
+                <summary>Release notes</summary>
+                <p><em>Sourced from <a href="https://github.com/dart-lang/fixnum/releases">fixnum's releases</a>.</em></p>
+                <blockquote>
+                <h2>v1.1.0</h2>
+                <ul>
+                <li>Add <code>tryParseRadix</code>, <code>tryParseInt</code> and <code>tryParseHex</code> static methods
+                to both <code>Int32</code> and <code>Int64</code>.</li>
+                <li>Document exception and overflow behavior of parse functions,
+                and of <code>toHexString</code>.</li>
+                <li>Make <code>Int32</code> parse functions consistent with documentation (accept
+                leading minus sign, do not accept empty inputs).</li>
+                <li>Update the minimum SDK constraint to 2.19.</li>
+                <li>Update to package:lints 2.0.0.</li>
+                </ul>
+                </blockquote>
+                </details>
                 <details>
                 <summary>Changelog</summary>
                 <p><em>Sourced from <a href="https://github.com/dart-lang/fixnum/blob/master/CHANGELOG.md">fixnum's changelog</a>.</em></p>
                 <blockquote>
+                <h2>1.1.0</h2>
+                <ul>
+                <li>Add <code>tryParseRadix</code>, <code>tryParseInt</code> and <code>tryParseHex</code> static methods
+                to both <code>Int32</code> and <code>Int64</code>.</li>
+                <li>Document exception and overflow behavior of parse functions,
+                and of <code>toHexString</code>.</li>
+                <li>Make <code>Int32</code> parse functions consistent with documentation (accept
+                leading minus sign, do not accept empty inputs).</li>
+                <li>Update the minimum SDK constraint to 2.19.</li>
+                <li>Update to package:lints 2.0.0.</li>
+                </ul>
                 <h2>1.0.1</h2>
                 <ul>
                 <li>Switch to using <code>package:lints</code>.</li>
@@ -224,78 +1192,77 @@ output:
                 <details>
                 <summary>Commits</summary>
                 <ul>
-                <li><a href="https://github.com/dart-lang/fixnum/commit/bd68553ca8deac47cd1fcefb9413609e93401115"><code>bd68553</code></a> prep for publishing 1.0.1 (<a href="https://redirect.github.com/dart-lang/fixnum/issues/89">#89</a>)</li>
-                <li><a href="https://github.com/dart-lang/fixnum/commit/3bfc2ed1eea7e7acb79ad4f17392f92c816fc5ce"><code>3bfc2ed</code></a> Switch from homepage to repository in pubspec  (<a href="https://redirect.github.com/dart-lang/fixnum/issues/86">#86</a>)</li>
-                <li><a href="https://github.com/dart-lang/fixnum/commit/848341f061359ef7ddc0cad472c2ecbb036b28ac"><code>848341f</code></a> Enable and fix some lints</li>
-                <li><a href="https://github.com/dart-lang/fixnum/commit/02ef22f7422df5e65cc44b8baffdd768f7d0fd94"><code>02ef22f</code></a> Ignore deprecations for IntegerDivisionByZeroException</li>
-                <li><a href="https://github.com/dart-lang/fixnum/commit/9d90a12c0554554c9f3438d610014c713f8be0d0"><code>9d90a12</code></a> Move from pedantic to lints package (<a href="https://redirect.github.com/dart-lang/fixnum/issues/82">#82</a>)</li>
-                <li><a href="https://github.com/dart-lang/fixnum/commit/e381b306f5842dd97d0732cba92671f786083bef"><code>e381b30</code></a> Update test-package.yml (<a href="https://redirect.github.com/dart-lang/fixnum/issues/77">#77</a>)</li>
-                <li><a href="https://github.com/dart-lang/fixnum/commit/44508def2f9797e642e5f368cbabb622da68c856"><code>44508de</code></a> Update LICENSE (<a href="https://redirect.github.com/dart-lang/fixnum/issues/76">#76</a>)</li>
-                <li><a href="https://github.com/dart-lang/fixnum/commit/762b74f61696d414d0090c5dfc430572f5b4be0f"><code>762b74f</code></a> stable null safety release (<a href="https://redirect.github.com/dart-lang/fixnum/issues/73">#73</a>)</li>
-                <li><a href="https://github.com/dart-lang/fixnum/commit/9dfcbba1a0ccd7166872d26da4fed0d40c746acd"><code>9dfcbba</code></a> Migrate to GitHub Actions (<a href="https://redirect.github.com/dart-lang/fixnum/issues/72">#72</a>)</li>
-                <li><a href="https://github.com/dart-lang/fixnum/commit/44e467e40e9430adffd8ec8c74027e9464ff2105"><code>44e467e</code></a> remove redundant experiment (<a href="https://redirect.github.com/dart-lang/fixnum/issues/71">#71</a>)</li>
-                <li>Additional commits viewable in <a href="https://github.com/dart-lang/fixnum/compare/0.10.11...1.0.1">compare view</a></li>
+                <li><a href="https://github.com/dart-lang/fixnum/commit/96ca1fe71914bc804e1f879f2988ce7b534cd912"><code>96ca1fe</code></a> add a publish script; prep to publish 1.1.0 (<a href="https://redirect.github.com/dart-lang/fixnum/issues/104">#104</a>)</li>
+                <li><a href="https://github.com/dart-lang/fixnum/commit/71f0d4d16054e6be7d8e22bdb3b082b9f82061be"><code>71f0d4d</code></a> Migrate from no-implicit-casts to strict-casts (<a href="https://redirect.github.com/dart-lang/fixnum/issues/103">#103</a>)</li>
+                <li><a href="https://github.com/dart-lang/fixnum/commit/714381c6b1d1fe57e87824e3f13a9c752eee48ea"><code>714381c</code></a> Bump actions/checkout from 3.1.0 to 3.2.0 (<a href="https://redirect.github.com/dart-lang/fixnum/issues/102">#102</a>)</li>
+                <li><a href="https://github.com/dart-lang/fixnum/commit/e4f5e9773de053adcb03bff9f02fa6f9c596fe4c"><code>e4f5e97</code></a> Change IntegerDivisionByZeroException to UnsupportedError (<a href="https://redirect.github.com/dart-lang/fixnum/issues/100">#100</a>)</li>
+                <li><a href="https://github.com/dart-lang/fixnum/commit/3bd726fc843d6f627c114fc5a4f7d9f99034d8c4"><code>3bd726f</code></a> rev the sdk min to 2.19.0-0 (<a href="https://redirect.github.com/dart-lang/fixnum/issues/99">#99</a>)</li>
+                <li><a href="https://github.com/dart-lang/fixnum/commit/62916f2de9074a2832de6211df8d72c912902e97"><code>62916f2</code></a> Split into separate libraries instead of using parts. (<a href="https://redirect.github.com/dart-lang/fixnum/issues/97">#97</a>)</li>
+                <li><a href="https://github.com/dart-lang/fixnum/commit/14d4827a5c047a2564b52729afb6dc2c47fd9a33"><code>14d4827</code></a> Add <code>tryParse</code> methods. (<a href="https://redirect.github.com/dart-lang/fixnum/issues/96">#96</a>)</li>
+                <li><a href="https://github.com/dart-lang/fixnum/commit/bca3816daf641397f7b5ab9cf865a6d10d30c625"><code>bca3816</code></a> blast_repo fixes (<a href="https://redirect.github.com/dart-lang/fixnum/issues/94">#94</a>)</li>
+                <li><a href="https://github.com/dart-lang/fixnum/commit/e0b17cc1f639c55a9c24947392c64b5a68992535"><code>e0b17cc</code></a> Remove deprecated experimental invariant_booleans lint rule (<a href="https://redirect.github.com/dart-lang/fixnum/issues/91">#91</a>)</li>
+                <li><a href="https://github.com/dart-lang/fixnum/commit/164712f6547cdfb2709b752188186baf31fd1730"><code>164712f</code></a> Remove old language version markers (<a href="https://redirect.github.com/dart-lang/fixnum/issues/90">#90</a>)</li>
+                <li>Additional commits viewable in <a href="https://github.com/dart-lang/fixnum/compare/0.10.11...v1.1.0">compare view</a></li>
                 </ul>
                 </details>
                 <br />
 
-                Updates `protobuf` from 1.1.4 to 2.0.0
+                Updates `protobuf` from 1.1.4 to 2.1.0
                 <details>
                 <summary>Release notes</summary>
                 <p><em>Sourced from <a href="https://github.com/google/protobuf.dart/releases">protobuf's releases</a>.</em></p>
                 <blockquote>
-                <h2>protobuf-2.0.1, protoc_plugin-20.0.1</h2>
                 <h2>protobuf-2.0.1</h2>
+                <h2>2.0.1</h2>
                 <ul>
-                <li>Update READMEs of <code>protobuf</code> and <code>protoc_plugin</code>:
+                <li>Fix bug of parsing map-values with default values.</li>
+                <li>Merge fixes from version <code>1.1.2</code> - <code>1.1.4</code> into v2.</li>
+                </ul>
+                <h2>2.0.0</h2>
                 <ul>
-                <li>Use <code>dart pub</code> instead of <code>pub</code> in command examples (<a href="https://github.com/google/protobuf.dart/commit/a7e75cb">a7e75cb</a>)</li>
-                <li>Fix typos, clarify installation instructions, mention native compilation, fix proto syntax for <code>protoc_plugin</code> (<a href="https://redirect.github.com/google/protobuf.dart/issues/610">#610</a>, <a href="https://redirect.github.com/google/protobuf.dart/issues/617">#617</a>, <a href="https://redirect.github.com/google/protobuf.dart/issues/641">#641</a>)</li>
+                <li>Stable null safety release.</li>
                 </ul>
-                </li>
-                <li>Update some of the documentation according to Effective Dart documentation guide (<a href="https://redirect.github.com/google/protobuf.dart/issues/664">#664</a>, <a href="https://redirect.github.com/google/protobuf.dart/issues/674">#674</a>)</li>
-                <li>Improve runtime perf by removing some of the runtime type checks (<a href="https://redirect.github.com/google/protobuf.dart/issues/574">#574</a>, <a href="https://redirect.github.com/google/protobuf.dart/issues/573">#573</a>)</li>
-                <li>Fix a bug when converting negative <code>Timestamp</code> to Dart <code>DateTime</code> (<a href="https://redirect.github.com/google/protobuf.dart/issues/580">#580</a>, <a href="https://redirect.github.com/google/protobuf.dart/issues/577">#577</a>)</li>
-                <li>Document <code>BuilderInfo</code> and <code>FieldInfo</code> properties (<a href="https://redirect.github.com/google/protobuf.dart/issues/597">#597</a>)</li>
-                <li>Improve <code>BuilderInfo</code> initialization by doing some of the work lazily (<a href="https://redirect.github.com/google/protobuf.dart/issues/606">#606</a>)</li>
-                <li>Improve enum hash code generation (<a href="https://redirect.github.com/google/protobuf.dart/issues/556">#556</a>)</li>
-                <li>Fix parsing nested <code>Any</code> messages from JSON (<a href="https://redirect.github.com/google/protobuf.dart/issues/568">#568</a>)</li>
-                <li>Improve message hash code generation performance (<a href="https://redirect.github.com/google/protobuf.dart/issues/554">#554</a>, <a href="https://redirect.github.com/google/protobuf.dart/issues/633">#633</a>)</li>
-                <li>Fix reading uninitialized map fields changing equality and hash code of messages. (<a href="https://redirect.github.com/google/protobuf.dart/issues/638">#638</a>)</li>
-                <li>Fix setting an extension field when there's an unknown field with the same tag. (<a href="https://redirect.github.com/google/protobuf.dart/issues/639">#639</a>)</li>
-                <li>Fix sharing backing memory for <code>repeated bytes</code> and <code>optional bytes</code> fields. (<a href="https://redirect.github.com/google/protobuf.dart/issues/640">#640</a>)</li>
-                <li><code>GeneratedMessage.rebuild</code> now generates a warning when the return value is not used. (<a href="https://redirect.github.com/google/protobuf.dart/issues/631">#631</a>)</li>
-                <li>Fix hash code of messages with empty unknown field set (<a href="https://redirect.github.com/google/protobuf.dart/issues/648">#648</a>)</li>
-                <li>Show field tags with <code>protobuf.omit_field_names</code>, enum value tags with <code>protobuf.omit_enum_names</code> in debug strings (<code>toString</code> methods) (<a href="https://redirect.github.com/google/protobuf.dart/issues/649">#649</a>)</li>
-                <li><code>TimestampMixin.toDateTime</code> now takes an optional named <code>bool</code> argument <code>toLocal</code> (defaults to <code>false</code>) for generating a <code>DateTime</code> in the local time zone (instead of UTC). (<a href="https://redirect.github.com/google/protobuf.dart/issues/653">#653</a>)</li>
-                <li>Fix serialization of <code>infinity</code> and <code>nan</code> doubles in JSON serializers (<a href="https://redirect.github.com/google/protobuf.dart/issues/652">#652</a>)</li>
-                <li>Fix Dart generation for fields starting with underscore (<a href="https://redirect.github.com/google/protobuf.dart/issues/651">#651</a>)</li>
-                <li>Fix proto3 JSON deserialization of fixed32 fields (<a href="https://redirect.github.com/google/protobuf.dart/issues/655">#655</a>)</li>
-                <li>Fix uninitialized repeated field values runtime types for frozen messages (<a href="https://redirect.github.com/google/protobuf.dart/issues/654">#654</a>)</li>
+                <h2>1.1.4</h2>
+                <ul>
+                <li>Fix comparison of empty lists from frozen messages.</li>
+                <li>Switch repo internals to use <code>dart format</code> instead of <code>dartfmt</code>.</li>
                 </ul>
-                <p><a href="https://redirect.github.com/google/protobuf.dart/issues/610">#610</a>: <a href="https://redirect.github.com/google/protobuf.dart/pull/610">google/protobuf.dart#610</a>
-                <a href="https://redirect.github.com/google/protobuf.dart/issues/617">#617</a>: <a href="https://redirect.github.com/google/protobuf.dart/pull/617">google/protobuf.dart#617</a>
-                <a href="https://redirect.github.com/google/protobuf.dart/issues/574">#574</a>: <a href="https://redirect.github.com/google/protobuf.dart/pull/574">google/protobuf.dart#574</a>
-                <a href="https://redirect.github.com/google/protobuf.dart/issues/573">#573</a>: <a href="https://redirect.github.com/google/protobuf.dart/issues/573">google/protobuf.dart#573</a>
-                <a href="https://redirect.github.com/google/protobuf.dart/issues/580">#580</a>: <a href="https://redirect.github.com/google/protobuf.dart/pull/580">google/protobuf.dart#580</a>
-                <a href="https://redirect.github.com/google/protobuf.dart/issues/577">#577</a>: <a href="https://redirect.github.com/google/protobuf.dart/issues/577">google/protobuf.dart#577</a>
-                <a href="https://redirect.github.com/google/protobuf.dart/issues/597">#597</a>: <a href="https://redirect.github.com/google/protobuf.dart/pull/597">google/protobuf.dart#597</a>
-                <a href="https://redirect.github.com/google/protobuf.dart/issues/606">#606</a>: <a href="https://redirect.github.com/google/protobuf.dart/pull/606">google/protobuf.dart#606</a>
-                <a href="https://redirect.github.com/google/protobuf.dart/issues/556">#556</a>: <a href="https://redirect.github.com/google/protobuf.dart/pull/556">google/protobuf.dart#556</a>
-                <a href="https://redirect.github.com/google/protobuf.dart/issues/568">#568</a>: <a href="https://redirect.github.com/google/protobuf.dart/pull/568">google/protobuf.dart#568</a>
-                <a href="https://redirect.github.com/google/protobuf.dart/issues/554">#554</a>: <a href="https://redirect.github.com/google/protobuf.dart/pull/554">google/protobuf.dart#554</a>
-                <a href="https://redirect.github.com/google/protobuf.dart/issues/633">#633</a>: <a href="https://redirect.github.com/google/protobuf.dart/pull/633">google/protobuf.dart#633</a>
-                <a href="https://redirect.github.com/google/protobuf.dart/issues/638">#638</a>: <a href="https://redirect.github.com/google/protobuf.dart/pull/638">google/protobuf.dart#638</a>
-                <a href="https://redirect.github.com/google/protobuf.dart/issues/639">#639</a>: <a href="https://redirect.github.com/google/protobuf.dart/pull/639">google/protobuf.dart#639</a>
-                <a href="https://redirect.github.com/google/protobuf.dart/issues/640">#640</a>: <a href="https://redirect.github.com/google/protobuf.dart/pull/640">google/protobuf.dart#640</a>
-                <a href="https://redirect.github.com/google/protobuf.dart/issues/641">#641</a>: <a href="https://redirect.github.com/google/protobuf.dart/pull/641">google/protobuf.dart#641</a>
-                <a href="https://redirect.github.com/google/protobuf.dart/issues/631">#631</a>: <a href="https://redirect.github.com/google/protobuf.dart/pull/631">google/protobuf.dart#631</a>
-                <a href="https://redirect.github.com/google/protobuf.dart/issues/648">#648</a>: <a href="https://redirect.github.com/google/protobuf.dart/pull/648">google/protobuf.dart#648</a>
-                <a href="https://redirect.github.com/google/protobuf.dart/issues/649">#649</a>: <a href="https://redirect.github.com/google/protobuf.dart/pull/649">google/protobuf.dart#649</a>
-                <a href="https://redirect.github.com/google/protobuf.dart/issues/653">#653</a>: <a href="https://redirect.github.com/google/protobuf.dart/pull/653">google/protobuf.dart#653</a>
-                <a href="https://redirect.github.com/google/protobuf.dart/issues/652">#652</a>: <a href="https://redirect.github.com/google/protobuf.dart/pull/652">google/protobuf.dart#652</a>
-                <a href="https://redirect.github.com/google/protobuf.dart/issues/651">#651</a>: <a href="https://redirect.github.com/google/protobuf.dart/pull/651">google/protobuf.dart#651</a>
-                <a href="https://redirect.github.com/google/protobuf.dart/issues/655">#655</a>: <a href="https://redirect.github.com/google/protobuf.dart/pull/655">google/protobuf.dart#655</a></p>
+                <h2>1.1.3</h2>
+                <ul>
+                <li>Fix that fixed32 int could be negative.</li>
+                </ul>
+                <h2>1.1.2</h2>
+                <ul>
+                <li>Fix proto deserialization issue for repeated and map enum value fields where
+                the enum value is unknown.</li>
+                </ul>
+                <h2>1.1.1</h2>
+                <ul>
+                <li>Fix decoding of <code>oneof</code> fields from proto3 json. The 'whichFoo' state would
+                not be set.</li>
+                <li>Fix the return type of <code>copyWith</code>.</li>
+                </ul>
+                <h2>1.1.0</h2>
+                <ul>
+                <li>Require at least Dart SDK 2.7.0 to enable usage of extension methods.</li>
+                <li>Introduce extension methods <code>GeneratedMessage.rebuild</code> and <code>GeneratedMessage.deepCopy</code> replacing <code>copyWith</code> and <code>clone</code>. Using these  alternatives can result in smaller binaries, because it is defined once instead of once per class. Use <code>protoc_plugin</code> from 19.1.0 to generate deprecation warnings for <code>copyWith</code> and <code>clone</code> methods.</li>
+                <li><code>GeneratedMessage.getExtension</code> throws when reading trying to read an extension that is present in the unknown fields. We consider this change a bug-fix because depending on the old behavior is indicative of a bug in your program.</li>
+                </ul>
+                <h2>1.0.4</h2>
+                <ul>
+                <li>Requires sdk 2.3.0</li>
+                <li>Update pedantic to 1.9.2</li>
+                </ul>
+                <h2>1.0.3</h2>
+                <ul>
+                <li>Enable hashCode memoization for frozen protos.</li>
+                <li>Add <code>timeout</code> to <code>ClientContext</code></li>
+                </ul>
+                <h2>1.0.2</h2>
+                <ul>
+                <li>Fix hashcode of bytes fields.</li>
+                <li>Fix issue with the <code>permissiveEnums</code> option to <code>mergeFromProto3Json</code>. The comparison did not work properly.</li>
+                </ul>
                 <!-- raw HTML omitted -->
                 </blockquote>
                 <p>... (truncated)</p>
@@ -303,17 +1270,17 @@ output:
                 <details>
                 <summary>Commits</summary>
                 <ul>
-                <li><a href="https://github.com/google/protobuf.dart/commit/94f52666aab95fdf557be46f79b436758c372853"><code>94f5266</code></a> Stable null safety release of protobuf (<a href="https://redirect.github.com/google/protobuf.dart/issues/473">#473</a>)</li>
-                <li><a href="https://github.com/google/protobuf.dart/commit/d2620dd915323555bea587b8bf24ca6bd4e05f8a"><code>d2620dd</code></a> Generate null-safe .pbgrpc files (<a href="https://redirect.github.com/google/protobuf.dart/issues/466">#466</a>)</li>
-                <li><a href="https://github.com/google/protobuf.dart/commit/1144e403fc41699c2e074b5fb518d55314ee7a6d"><code>1144e40</code></a> Use null-safe bootstrap protos (<a href="https://redirect.github.com/google/protobuf.dart/issues/464">#464</a>)</li>
-                <li><a href="https://github.com/google/protobuf.dart/commit/fe93fb8d19bf695ff58bc680a9b8c8d5c8865bca"><code>fe93fb8</code></a> Merge master into null safety (<a href="https://redirect.github.com/google/protobuf.dart/issues/463">#463</a>)</li>
-                <li><a href="https://github.com/google/protobuf.dart/commit/9f1969572694d7ace381119e94fcda70ace5b0b3"><code>9f19695</code></a> named optional arguments in constructors for messages (<a href="https://redirect.github.com/google/protobuf.dart/issues/441">#441</a>)</li>
-                <li><a href="https://github.com/google/protobuf.dart/commit/ead5550860320d8dce8c3c81f6fd5b3a17db12f7"><code>ead5550</code></a> Let protoc_plugin depend on protobuf from null-safety and fix changelog. (<a href="https://redirect.github.com/google/protobuf.dart/issues/456">#456</a>)</li>
-                <li><a href="https://github.com/google/protobuf.dart/commit/f611f237e3699caf7c2adab60560bb6f51b969e7"><code>f611f23</code></a> Prepare query_benchmark/ for NNBD (<a href="https://redirect.github.com/google/protobuf.dart/issues/451">#451</a>)</li>
-                <li><a href="https://github.com/google/protobuf.dart/commit/d30a4c8b4f4ead77653e1523b44aa1325dc8d0d0"><code>d30a4c8</code></a> Restore possibility to use reflective API to create default field values usin...</li>
-                <li><a href="https://github.com/google/protobuf.dart/commit/75389dd16f46ca2a4694f4d015240514c7e34077"><code>75389dd</code></a> Allow dart protos to be sent through sendports (and therefore to other isolat...</li>
-                <li><a href="https://github.com/google/protobuf.dart/commit/0d03fd588df69e9863e2a2efc0059dee8f18d5b2"><code>0d03fd5</code></a> Regenerate bootstrap protos with previous version of protoc_plugin (<a href="https://redirect.github.com/google/protobuf.dart/issues/440">#440</a>)</li>
-                <li>Additional commits viewable in <a href="https://github.com/google/protobuf.dart/compare/protobuf-v1.1.4...protobuf-v2.0.0">compare view</a></li>
+                <li><a href="https://github.com/google/protobuf.dart/commit/53f756a0eebe5377e76ac5b483e2007e22467f8d"><code>53f756a</code></a> Release protobuf-2.1.0, protoc_plugin-20.0.1 (<a href="https://redirect.github.com/google/protobuf.dart/issues/677">#677</a>)</li>
+                <li><a href="https://github.com/google/protobuf.dart/commit/c85b4147a61ed058420324583bb654c44c93462c"><code>c85b414</code></a> Specify <code>GeneratedMessage operator==</code> argument type (<a href="https://redirect.github.com/google/protobuf.dart/issues/675">#675</a>)</li>
+                <li><a href="https://github.com/google/protobuf.dart/commit/417d41477f62f3928eb7ced658bb323de127d8a1"><code>417d414</code></a> Add changes since the last protobuf release to CHANGELOG (<a href="https://redirect.github.com/google/protobuf.dart/issues/619">#619</a>)</li>
+                <li><a href="https://github.com/google/protobuf.dart/commit/39cd6672627cb1fef588e3ac2bc0635bf92869d4"><code>39cd667</code></a> Tweak consts.dart docs (<a href="https://redirect.github.com/google/protobuf.dart/issues/674">#674</a>)</li>
+                <li><a href="https://github.com/google/protobuf.dart/commit/408f69b98b2d2de947c4922506416e2ca4905ad5"><code>408f69b</code></a> Update documentation according to Effective Dart documentation guide (<a href="https://redirect.github.com/google/protobuf.dart/issues/664">#664</a>)</li>
+                <li><a href="https://github.com/google/protobuf.dart/commit/af2207af8599e426fff8443a07bff178fc5f527a"><code>af2207a</code></a> Move closures in proto3 deserializer to top-level (<a href="https://redirect.github.com/google/protobuf.dart/issues/668">#668</a>)</li>
+                <li><a href="https://github.com/google/protobuf.dart/commit/e697b1943c9d452ef06ef8a32c0873f58534d7e7"><code>e697b19</code></a> Refactor protobuf bench runners, update README: (<a href="https://redirect.github.com/google/protobuf.dart/issues/665">#665</a>)</li>
+                <li><a href="https://github.com/google/protobuf.dart/commit/f1cc78e3eb24cfff3169087c3341839ed6586dcd"><code>f1cc78e</code></a> Benchmarks: add proto3 ser/deser benchs, move common code to common.dart (<a href="https://redirect.github.com/google/protobuf.dart/issues/667">#667</a>)</li>
+                <li><a href="https://github.com/google/protobuf.dart/commit/5cd7b2dc3b90108521abdd47d5c38a8ab08abe22"><code>5cd7b2d</code></a> Remove makeLongInt helper (<a href="https://redirect.github.com/google/protobuf.dart/issues/666">#666</a>)</li>
+                <li><a href="https://github.com/google/protobuf.dart/commit/eeacbb768c0e18f7ebe85194d9ce0e1db82c9c10"><code>eeacbb7</code></a> Use <code>-O4</code> when compiling benchmarks. (<a href="https://redirect.github.com/google/protobuf.dart/issues/552">#552</a>)</li>
+                <li>Additional commits viewable in <a href="https://github.com/google/protobuf.dart/compare/protobuf-v1.1.4...protobuf-v2.1.0">compare view</a></li>
                 </ul>
                 </details>
                 <br />
@@ -322,39 +1289,53 @@ output:
 
                 Bumps [fixnum](https://github.com/dart-lang/fixnum) and [protobuf](https://github.com/google/protobuf.dart). These dependencies needed to be updated together.
 
-                Updates `fixnum` from 0.10.11 to 1.0.1
+                Updates `fixnum` from 0.10.11 to 1.1.0
+                - [Release notes](https://github.com/dart-lang/fixnum/releases)
                 - [Changelog](https://github.com/dart-lang/fixnum/blob/master/CHANGELOG.md)
-                - [Commits](https://github.com/dart-lang/fixnum/compare/0.10.11...1.0.1)
+                - [Commits](https://github.com/dart-lang/fixnum/compare/0.10.11...v1.1.0)
 
-                Updates `protobuf` from 1.1.4 to 2.0.0
+                Updates `protobuf` from 1.1.4 to 2.1.0
                 - [Release notes](https://github.com/google/protobuf.dart/releases)
-                - [Commits](https://github.com/google/protobuf.dart/compare/protobuf-v1.1.4...protobuf-v2.0.0)
+                - [Commits](https://github.com/google/protobuf.dart/compare/protobuf-v1.1.4...protobuf-v2.1.0)
     - type: create_pull_request
       expect:
         data:
-            base-commit-sha: 8b2c0d821028c531826db20ca22cffdd2cc05abf
+            base-commit-sha: 48e9be2bc45b1336ef6088260fbe56a162c5678e
             dependencies:
-                - name: retry
+                - name: http
                   previous-requirements:
                     - file: pubspec.yaml
                       groups:
                         - direct
-                      requirement: ^2.0.0
+                      requirement: 0.13.2
                       source:
                         description:
-                            name: retry
-                            url: https://pub.dartlang.org
+                            name: http
+                            url: https://pub.dev
                         type: hosted
-                  previous-version: 2.0.0
+                  previous-version: 0.13.2
                   requirements:
                     - file: pubspec.yaml
                       groups:
                         - direct
-                      requirement: ^3.1.0
+                      requirement: ^0.13.6
                       source: null
-                  version: 3.1.0
+                  version: 0.13.6
             updated-dependency-files:
-                - content: "name: dependabot_testcase\nenvironment:\n  sdk: '>=2.12.0 <3.0.0'\ndependencies:\n  collection: ^1.14.13 # Locked to 1.14.13, can update with no unlock.\n  retry: ^3.1.0 # Can update with updated constraint, no further constraints.\n  protobuf: 1.1.4 # Can update with updated constraint, only together with fixnum.\n  fixnum: 0.10.11\n  path: 1.8.1 # Already at latest\n  \n"
+                - content: |
+                    name: dependabot_testcase
+                    environment:
+                      sdk: '>=2.12.0 <3.0.0'
+                    dependencies:
+                      collection: ^1.14.13 # Locked to 1.14.13, can update with no unlock.
+                      retry: ^2.0.0 # Can update with updated constraint, no further constraints.
+                      protobuf: 1.1.4 # Can update with updated constraint, only together with fixnum.
+                      fixnum: 0.10.11
+                      path: 1.8.1 # Already at latest
+                      http: ^0.13.6 # < 0.13.3 has a security vulnerability: https://github.com/advisories/GHSA-4rgh-jx4f-qfcq
+
+                    dev_dependencies:
+                      test: ^1.16.5
                   content_encoding: utf-8
                   deleted: false
                   directory: /pub
@@ -366,43 +1347,351 @@ output:
                     # Generated by pub
                     # See https://dart.dev/tools/pub/glossary#lockfile
                     packages:
+                      _fe_analyzer_shared:
+                        dependency: transitive
+                        description:
+                          name: _fe_analyzer_shared
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "50.0.0"
+                      analyzer:
+                        dependency: transitive
+                        description:
+                          name: analyzer
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "5.2.0"
+                      args:
+                        dependency: transitive
+                        description:
+                          name: args
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.3.1"
+                      async:
+                        dependency: transitive
+                        description:
+                          name: async
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.10.0"
+                      boolean_selector:
+                        dependency: transitive
+                        description:
+                          name: boolean_selector
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.1"
                       collection:
                         dependency: "direct main"
                         description:
                           name: collection
-                          url: "https://pub.dartlang.org"
+                          url: "https://pub.dev"
                         source: hosted
-                        version: "1.14.13"
+                        version: "1.17.0"
+                      convert:
+                        dependency: transitive
+                        description:
+                          name: convert
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.1.1"
+                      coverage:
+                        dependency: transitive
+                        description:
+                          name: coverage
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.6.1"
+                      crypto:
+                        dependency: transitive
+                        description:
+                          name: crypto
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.0.2"
+                      file:
+                        dependency: transitive
+                        description:
+                          name: file
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "6.1.4"
                       fixnum:
                         dependency: "direct main"
                         description:
                           name: fixnum
-                          url: "https://pub.dartlang.org"
+                          url: "https://pub.dev"
                         source: hosted
                         version: "0.10.11"
+                      frontend_server_client:
+                        dependency: transitive
+                        description:
+                          name: frontend_server_client
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.2.0"
+                      glob:
+                        dependency: transitive
+                        description:
+                          name: glob
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.1"
+                      http:
+                        dependency: "direct main"
+                        description:
+                          name: http
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.13.6"
+                      http_multi_server:
+                        dependency: transitive
+                        description:
+                          name: http_multi_server
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.2.1"
+                      http_parser:
+                        dependency: transitive
+                        description:
+                          name: http_parser
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "4.0.2"
+                      io:
+                        dependency: transitive
+                        description:
+                          name: io
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.0.3"
+                      js:
+                        dependency: transitive
+                        description:
+                          name: js
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.6.5"
+                      logging:
+                        dependency: transitive
+                        description:
+                          name: logging
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.1.0"
+                      matcher:
+                        dependency: transitive
+                        description:
+                          name: matcher
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.12.13"
+                      meta:
+                        dependency: transitive
+                        description:
+                          name: meta
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.8.0"
+                      mime:
+                        dependency: transitive
+                        description:
+                          name: mime
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.0.2"
+                      node_preamble:
+                        dependency: transitive
+                        description:
+                          name: node_preamble
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.0.1"
+                      package_config:
+                        dependency: transitive
+                        description:
+                          name: package_config
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.0"
                       path:
                         dependency: "direct main"
                         description:
                           name: path
-                          url: "https://pub.dartlang.org"
+                          url: "https://pub.dev"
                         source: hosted
                         version: "1.8.1"
+                      pool:
+                        dependency: transitive
+                        description:
+                          name: pool
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.5.1"
                       protobuf:
                         dependency: "direct main"
                         description:
                           name: protobuf
-                          url: "https://pub.dartlang.org"
+                          url: "https://pub.dev"
                         source: hosted
                         version: "1.1.4"
+                      pub_semver:
+                        dependency: transitive
+                        description:
+                          name: pub_semver
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.3"
                       retry:
                         dependency: "direct main"
                         description:
                           name: retry
-                          url: "https://pub.dartlang.org"
+                          url: "https://pub.dev"
                         source: hosted
-                        version: "3.1.0"
+                        version: "2.0.0"
+                      shelf:
+                        dependency: transitive
+                        description:
+                          name: shelf
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.4.0"
+                      shelf_packages_handler:
+                        dependency: transitive
+                        description:
+                          name: shelf_packages_handler
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.0.1"
+                      shelf_static:
+                        dependency: transitive
+                        description:
+                          name: shelf_static
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.1.1"
+                      shelf_web_socket:
+                        dependency: transitive
+                        description:
+                          name: shelf_web_socket
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.0.3"
+                      source_map_stack_trace:
+                        dependency: transitive
+                        description:
+                          name: source_map_stack_trace
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.1"
+                      source_maps:
+                        dependency: transitive
+                        description:
+                          name: source_maps
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.10.11"
+                      source_span:
+                        dependency: transitive
+                        description:
+                          name: source_span
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.9.1"
+                      stack_trace:
+                        dependency: transitive
+                        description:
+                          name: stack_trace
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.11.0"
+                      stream_channel:
+                        dependency: transitive
+                        description:
+                          name: stream_channel
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.1"
+                      string_scanner:
+                        dependency: transitive
+                        description:
+                          name: string_scanner
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.2.0"
+                      term_glyph:
+                        dependency: transitive
+                        description:
+                          name: term_glyph
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.2.1"
+                      test:
+                        dependency: "direct dev"
+                        description:
+                          name: test
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.22.0"
+                      test_api:
+                        dependency: transitive
+                        description:
+                          name: test_api
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.4.16"
+                      test_core:
+                        dependency: transitive
+                        description:
+                          name: test_core
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.4.20"
+                      typed_data:
+                        dependency: transitive
+                        description:
+                          name: typed_data
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.3.1"
+                      vm_service:
+                        dependency: transitive
+                        description:
+                          name: vm_service
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "9.4.0"
+                      watcher:
+                        dependency: transitive
+                        description:
+                          name: watcher
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.0.2"
+                      web_socket_channel:
+                        dependency: transitive
+                        description:
+                          name: web_socket_channel
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.2.0"
+                      webkit_inspection_protocol:
+                        dependency: transitive
+                        description:
+                          name: webkit_inspection_protocol
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.2.0"
+                      yaml:
+                        dependency: transitive
+                        description:
+                          name: yaml
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.1.1"
                     sdks:
-                      dart: ">=2.12.0 <3.0.0"
+                      dart: ">=2.18.0 <3.0.0"
                   content_encoding: utf-8
                   deleted: false
                   directory: /pub
@@ -410,32 +1699,1342 @@ output:
                   operation: update
                   support_file: false
                   type: file
-            pr-title: Bump retry from 2.0.0 to 3.1.0 in /pub
+            pr-title: Bump http from 0.13.2 to 0.13.6 in /pub
             pr-body: |
-                Bumps [retry](https://github.com/google/dart-neats) from 2.0.0 to 3.1.0.
+                Bumps [http](https://github.com/dart-lang/http/tree/master/pkgs) from 0.13.2 to 0.13.6.
                 <details>
                 <summary>Commits</summary>
                 <ul>
-                <li><a href="https://github.com/google/dart-neats/commit/a159c67b195255607bcd77366f77f9fc4b692667"><code>a159c67</code></a> Prepare stable release of retry 3.1.0</li>
-                <li><a href="https://github.com/google/dart-neats/commit/a74a84aef9c15335c059d7727bf53b5102427f74"><code>a74a84a</code></a> Publishing chunked_stream 1.4.0</li>
-                <li><a href="https://github.com/google/dart-neats/commit/69d28af7ee4684172d28173ac1d4a413e079bf89"><code>69d28af</code></a> Prepare stable chunked_stream release (<a href="https://redirect.github.com/google/dart-neats/issues/100">#100</a>)</li>
-                <li><a href="https://github.com/google/dart-neats/commit/dddf730e4d354946039ed0e25b32ac362f089123"><code>dddf730</code></a> Added readByteStream and prepare 1.4.0-null-safe.0 release (<a href="https://redirect.github.com/google/dart-neats/issues/96">#96</a>)</li>
-                <li><a href="https://github.com/google/dart-neats/commit/911db008ebbc86279d748b7b84d5cb9e2d911cd5"><code>911db00</code></a> Merge pull request <a href="https://redirect.github.com/google/dart-neats/issues/89">#89</a> from isoos/upgrade-analyzer</li>
-                <li><a href="https://github.com/google/dart-neats/commit/5486fbce71fb0ce1f47882f3e32c2663d21fe1e6"><code>5486fbc</code></a> Migrated slugid to null-safety (<a href="https://redirect.github.com/google/dart-neats/issues/87">#87</a>)</li>
-                <li><a href="https://github.com/google/dart-neats/commit/1731539606d55e581d7c4e902ade515d01963652"><code>1731539</code></a> Update github actions</li>
-                <li><a href="https://github.com/google/dart-neats/commit/be036352a786c8bbf9027b6739b286b63d5707b9"><code>be03635</code></a> Typo</li>
-                <li><a href="https://github.com/google/dart-neats/commit/0a511432180b773464d837b18c6e5aab1fbd851f"><code>0a51143</code></a> Migrate chunked_stream to null safety</li>
-                <li><a href="https://github.com/google/dart-neats/commit/89ac2cbd773e327cfa3e1d561a52f6db85eb192b"><code>89ac2cb</code></a> Updated config (<a href="https://redirect.github.com/google/dart-neats/issues/94">#94</a>)</li>
-                <li>Additional commits viewable in <a href="https://github.com/google/dart-neats/compare/retry-v2.0.0...retry-v3.1.0">compare view</a></li>
+                <li><a href="https://github.com/dart-lang/http/commit/f581ff79c3ce68429ad791470201c66167e7655b"><code>f581ff7</code></a> Prepare to publish (<a href="https://github.com/dart-lang/http/tree/master/pkgs/issues/914">#914</a>)</li>
+                <li><a href="https://github.com/dart-lang/http/commit/fa5365181564715e0d54cf8c70d0d7956025fad4"><code>fa53651</code></a> Document that RetryClient may consume a lot of memory (<a href="https://github.com/dart-lang/http/tree/master/pkgs/issues/915">#915</a>)</li>
+                <li><a href="https://github.com/dart-lang/http/commit/ffb44388762716f8d93aaa8541f8c5f2de159b71"><code>ffb4438</code></a> Fix maxRedirects documentation to mention ClientException rather than Redirec...</li>
+                <li><a href="https://github.com/dart-lang/http/commit/ad0e1cf2165c594692f663bc21ec66ac5cdcf8d6"><code>ad0e1cf</code></a> Fix some spelling (<a href="https://github.com/dart-lang/http/tree/master/pkgs/issues/885">#885</a>)</li>
+                <li><a href="https://github.com/dart-lang/http/commit/74f9d3df83545f83338794d1decc28d10a94d290"><code>74f9d3d</code></a> Add conformances test that verify that the Client works in Isolates (<a href="https://github.com/dart-lang/http/tree/master/pkgs/issues/889">#889</a>)</li>
+                <li><a href="https://github.com/dart-lang/http/commit/ee036044377b193128d74d385b0175faaa875282"><code>ee03604</code></a> Add a flag to allow the default Client to be tree shaken away. (<a href="https://github.com/dart-lang/http/tree/master/pkgs/issues/868">#868</a>)</li>
+                <li><a href="https://github.com/dart-lang/http/commit/2039fb32d1cb152a9913aba434a6341b72a29c98"><code>2039fb3</code></a> Fix a reference count race with forwarded delegates. (<a href="https://github.com/dart-lang/http/tree/master/pkgs/issues/888">#888</a>)</li>
+                <li><a href="https://github.com/dart-lang/http/commit/805a14742e293fb51c0b89004b51add50d825792"><code>805a147</code></a> Fix some spelling (<a href="https://github.com/dart-lang/http/tree/master/pkgs/issues/884">#884</a>)</li>
+                <li><a href="https://github.com/dart-lang/http/commit/5a2f03601b0ca22bc67a528783cc657e908fa3d8"><code>5a2f036</code></a> Move to pkg:dart_flutter_team_lints, require Dart 2.19 (<a href="https://github.com/dart-lang/http/tree/master/pkgs/issues/883">#883</a>)</li>
+                <li><a href="https://github.com/dart-lang/http/commit/35b2cef9d99b904dad68f90f1cea38624d473012"><code>35b2cef</code></a> Corrected the spelling of &quot;Implements&quot; in &quot;/http/lib/src/io_client.dart&quot; (<a href="https://github.com/dart-lang/http/tree/master/pkgs/issues/871">#871</a>)</li>
+                <li>Additional commits viewable in <a href="https://github.com/dart-lang/http/commits/http-v0.13.6/pkgs">compare view</a></li>
                 </ul>
                 </details>
                 <br />
             commit-message: |-
-                Bump retry from 2.0.0 to 3.1.0 in /pub
+                Bump http from 0.13.2 to 0.13.6 in /pub
 
-                Bumps [retry](https://github.com/google/dart-neats) from 2.0.0 to 3.1.0.
-                - [Commits](https://github.com/google/dart-neats/compare/retry-v2.0.0...retry-v3.1.0)
+                Bumps [http](https://github.com/dart-lang/http/tree/master/pkgs) from 0.13.2 to 0.13.6.
+                - [Release notes](https://github.com/dart-lang/http/releases)
+                - [Commits](https://github.com/dart-lang/http/commits/http-v0.13.6/pkgs)
+    - type: create_pull_request
+      expect:
+        data:
+            base-commit-sha: 48e9be2bc45b1336ef6088260fbe56a162c5678e
+            dependencies:
+                - name: path
+                  previous-requirements:
+                    - file: pubspec.yaml
+                      groups:
+                        - direct
+                      requirement: 1.8.1
+                      source:
+                        description:
+                            name: path
+                            url: https://pub.dev
+                        type: hosted
+                  previous-version: 1.8.1
+                  requirements:
+                    - file: pubspec.yaml
+                      groups:
+                        - direct
+                      requirement: ^1.8.3
+                      source: null
+                  version: 1.8.3
+            updated-dependency-files:
+                - content: |
+                    name: dependabot_testcase
+                    environment:
+                      sdk: '>=2.12.0 <3.0.0'
+                    dependencies:
+                      collection: ^1.14.13 # Locked to 1.14.13, can update with no unlock.
+                      retry: ^2.0.0 # Can update with updated constraint, no further constraints.
+                      protobuf: 1.1.4 # Can update with updated constraint, only together with fixnum.
+                      fixnum: 0.10.11
+                      path: ^1.8.3 # Already at latest
+                      http: "0.13.2" # < 0.13.3 has a security vulnerability: https://github.com/advisories/GHSA-4rgh-jx4f-qfcq
+
+                    dev_dependencies:
+                      test: ^1.16.5
+                  content_encoding: utf-8
+                  deleted: false
+                  directory: /pub
+                  name: pubspec.yaml
+                  operation: update
+                  support_file: false
+                  type: file
+                - content: |
+                    # Generated by pub
+                    # See https://dart.dev/tools/pub/glossary#lockfile
+                    packages:
+                      _fe_analyzer_shared:
+                        dependency: transitive
+                        description:
+                          name: _fe_analyzer_shared
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "50.0.0"
+                      analyzer:
+                        dependency: transitive
+                        description:
+                          name: analyzer
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "5.2.0"
+                      args:
+                        dependency: transitive
+                        description:
+                          name: args
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.3.1"
+                      async:
+                        dependency: transitive
+                        description:
+                          name: async
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.10.0"
+                      boolean_selector:
+                        dependency: transitive
+                        description:
+                          name: boolean_selector
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.1"
+                      collection:
+                        dependency: "direct main"
+                        description:
+                          name: collection
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.17.0"
+                      convert:
+                        dependency: transitive
+                        description:
+                          name: convert
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.1.1"
+                      coverage:
+                        dependency: transitive
+                        description:
+                          name: coverage
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.6.1"
+                      crypto:
+                        dependency: transitive
+                        description:
+                          name: crypto
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.0.2"
+                      file:
+                        dependency: transitive
+                        description:
+                          name: file
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "6.1.4"
+                      fixnum:
+                        dependency: "direct main"
+                        description:
+                          name: fixnum
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.10.11"
+                      frontend_server_client:
+                        dependency: transitive
+                        description:
+                          name: frontend_server_client
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.2.0"
+                      glob:
+                        dependency: transitive
+                        description:
+                          name: glob
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.1"
+                      http:
+                        dependency: "direct main"
+                        description:
+                          name: http
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.13.2"
+                      http_multi_server:
+                        dependency: transitive
+                        description:
+                          name: http_multi_server
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.2.1"
+                      http_parser:
+                        dependency: transitive
+                        description:
+                          name: http_parser
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "4.0.2"
+                      io:
+                        dependency: transitive
+                        description:
+                          name: io
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.0.3"
+                      js:
+                        dependency: transitive
+                        description:
+                          name: js
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.6.5"
+                      logging:
+                        dependency: transitive
+                        description:
+                          name: logging
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.1.0"
+                      matcher:
+                        dependency: transitive
+                        description:
+                          name: matcher
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.12.13"
+                      meta:
+                        dependency: transitive
+                        description:
+                          name: meta
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.8.0"
+                      mime:
+                        dependency: transitive
+                        description:
+                          name: mime
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.0.2"
+                      node_preamble:
+                        dependency: transitive
+                        description:
+                          name: node_preamble
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.0.1"
+                      package_config:
+                        dependency: transitive
+                        description:
+                          name: package_config
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.0"
+                      path:
+                        dependency: "direct main"
+                        description:
+                          name: path
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.8.3"
+                      pedantic:
+                        dependency: transitive
+                        description:
+                          name: pedantic
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.11.1"
+                      pool:
+                        dependency: transitive
+                        description:
+                          name: pool
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.5.1"
+                      protobuf:
+                        dependency: "direct main"
+                        description:
+                          name: protobuf
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.1.4"
+                      pub_semver:
+                        dependency: transitive
+                        description:
+                          name: pub_semver
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.3"
+                      retry:
+                        dependency: "direct main"
+                        description:
+                          name: retry
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.0.0"
+                      shelf:
+                        dependency: transitive
+                        description:
+                          name: shelf
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.4.0"
+                      shelf_packages_handler:
+                        dependency: transitive
+                        description:
+                          name: shelf_packages_handler
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.0.1"
+                      shelf_static:
+                        dependency: transitive
+                        description:
+                          name: shelf_static
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.1.1"
+                      shelf_web_socket:
+                        dependency: transitive
+                        description:
+                          name: shelf_web_socket
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.0.3"
+                      source_map_stack_trace:
+                        dependency: transitive
+                        description:
+                          name: source_map_stack_trace
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.1"
+                      source_maps:
+                        dependency: transitive
+                        description:
+                          name: source_maps
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.10.11"
+                      source_span:
+                        dependency: transitive
+                        description:
+                          name: source_span
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.9.1"
+                      stack_trace:
+                        dependency: transitive
+                        description:
+                          name: stack_trace
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.11.0"
+                      stream_channel:
+                        dependency: transitive
+                        description:
+                          name: stream_channel
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.1"
+                      string_scanner:
+                        dependency: transitive
+                        description:
+                          name: string_scanner
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.2.0"
+                      term_glyph:
+                        dependency: transitive
+                        description:
+                          name: term_glyph
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.2.1"
+                      test:
+                        dependency: "direct dev"
+                        description:
+                          name: test
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.22.0"
+                      test_api:
+                        dependency: transitive
+                        description:
+                          name: test_api
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.4.16"
+                      test_core:
+                        dependency: transitive
+                        description:
+                          name: test_core
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.4.20"
+                      typed_data:
+                        dependency: transitive
+                        description:
+                          name: typed_data
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.3.1"
+                      vm_service:
+                        dependency: transitive
+                        description:
+                          name: vm_service
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "9.4.0"
+                      watcher:
+                        dependency: transitive
+                        description:
+                          name: watcher
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.0.2"
+                      web_socket_channel:
+                        dependency: transitive
+                        description:
+                          name: web_socket_channel
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.2.0"
+                      webkit_inspection_protocol:
+                        dependency: transitive
+                        description:
+                          name: webkit_inspection_protocol
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.2.0"
+                      yaml:
+                        dependency: transitive
+                        description:
+                          name: yaml
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.1.1"
+                    sdks:
+                      dart: ">=2.18.0 <3.0.0"
+                  content_encoding: utf-8
+                  deleted: false
+                  directory: /pub
+                  name: pubspec.lock
+                  operation: update
+                  support_file: false
+                  type: file
+            pr-title: Bump path from 1.8.1 to 1.8.3 in /pub
+            pr-body: |
+                Bumps [path](https://github.com/dart-lang/path) from 1.8.1 to 1.8.3.
+                <details>
+                <summary>Changelog</summary>
+                <p><em>Sourced from <a href="https://github.com/dart-lang/path/blob/master/CHANGELOG.md">path's changelog</a>.</em></p>
+                <blockquote>
+                <h2>1.8.3</h2>
+                <ul>
+                <li>Support up to 16 arguments in join function and up to 15 arguments in absolute function.</li>
+                </ul>
+                <h2>1.8.2</h2>
+                <ul>
+                <li>Enable the <code>avoid_dynamic_calls</code> lint.</li>
+                <li>Populate the pubspec <code>repository</code> field.</li>
+                </ul>
+                </blockquote>
+                </details>
+                <details>
+                <summary>Commits</summary>
+                <ul>
+                <li>See full diff in <a href="https://github.com/dart-lang/path/commits/1.8.3">compare view</a></li>
+                </ul>
+                </details>
+                <br />
+            commit-message: |-
+                Bump path from 1.8.1 to 1.8.3 in /pub
+
+                Bumps [path](https://github.com/dart-lang/path) from 1.8.1 to 1.8.3.
+                - [Changelog](https://github.com/dart-lang/path/blob/master/CHANGELOG.md)
+                - [Commits](https://github.com/dart-lang/path/commits/1.8.3)
+    - type: create_pull_request
+      expect:
+        data:
+            base-commit-sha: 48e9be2bc45b1336ef6088260fbe56a162c5678e
+            dependencies:
+                - name: retry
+                  previous-requirements:
+                    - file: pubspec.yaml
+                      groups:
+                        - direct
+                      requirement: ^2.0.0
+                      source:
+                        description:
+                            name: retry
+                            url: https://pub.dev
+                        type: hosted
+                  previous-version: 2.0.0
+                  requirements:
+                    - file: pubspec.yaml
+                      groups:
+                        - direct
+                      requirement: ^3.1.1
+                      source: null
+                  version: 3.1.1
+            updated-dependency-files:
+                - content: |
+                    name: dependabot_testcase
+                    environment:
+                      sdk: '>=2.12.0 <3.0.0'
+                    dependencies:
+                      collection: ^1.14.13 # Locked to 1.14.13, can update with no unlock.
+                      retry: ^3.1.1 # Can update with updated constraint, no further constraints.
+                      protobuf: 1.1.4 # Can update with updated constraint, only together with fixnum.
+                      fixnum: 0.10.11
+                      path: 1.8.1 # Already at latest
+                      http: "0.13.2" # < 0.13.3 has a security vulnerability: https://github.com/advisories/GHSA-4rgh-jx4f-qfcq
+
+                    dev_dependencies:
+                      test: ^1.16.5
+                  content_encoding: utf-8
+                  deleted: false
+                  directory: /pub
+                  name: pubspec.yaml
+                  operation: update
+                  support_file: false
+                  type: file
+                - content: |
+                    # Generated by pub
+                    # See https://dart.dev/tools/pub/glossary#lockfile
+                    packages:
+                      _fe_analyzer_shared:
+                        dependency: transitive
+                        description:
+                          name: _fe_analyzer_shared
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "50.0.0"
+                      analyzer:
+                        dependency: transitive
+                        description:
+                          name: analyzer
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "5.2.0"
+                      args:
+                        dependency: transitive
+                        description:
+                          name: args
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.3.1"
+                      async:
+                        dependency: transitive
+                        description:
+                          name: async
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.10.0"
+                      boolean_selector:
+                        dependency: transitive
+                        description:
+                          name: boolean_selector
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.1"
+                      collection:
+                        dependency: "direct main"
+                        description:
+                          name: collection
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.17.0"
+                      convert:
+                        dependency: transitive
+                        description:
+                          name: convert
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.1.1"
+                      coverage:
+                        dependency: transitive
+                        description:
+                          name: coverage
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.6.1"
+                      crypto:
+                        dependency: transitive
+                        description:
+                          name: crypto
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.0.2"
+                      file:
+                        dependency: transitive
+                        description:
+                          name: file
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "6.1.4"
+                      fixnum:
+                        dependency: "direct main"
+                        description:
+                          name: fixnum
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.10.11"
+                      frontend_server_client:
+                        dependency: transitive
+                        description:
+                          name: frontend_server_client
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.2.0"
+                      glob:
+                        dependency: transitive
+                        description:
+                          name: glob
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.1"
+                      http:
+                        dependency: "direct main"
+                        description:
+                          name: http
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.13.2"
+                      http_multi_server:
+                        dependency: transitive
+                        description:
+                          name: http_multi_server
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.2.1"
+                      http_parser:
+                        dependency: transitive
+                        description:
+                          name: http_parser
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "4.0.2"
+                      io:
+                        dependency: transitive
+                        description:
+                          name: io
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.0.3"
+                      js:
+                        dependency: transitive
+                        description:
+                          name: js
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.6.5"
+                      logging:
+                        dependency: transitive
+                        description:
+                          name: logging
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.1.0"
+                      matcher:
+                        dependency: transitive
+                        description:
+                          name: matcher
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.12.13"
+                      meta:
+                        dependency: transitive
+                        description:
+                          name: meta
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.8.0"
+                      mime:
+                        dependency: transitive
+                        description:
+                          name: mime
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.0.2"
+                      node_preamble:
+                        dependency: transitive
+                        description:
+                          name: node_preamble
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.0.1"
+                      package_config:
+                        dependency: transitive
+                        description:
+                          name: package_config
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.0"
+                      path:
+                        dependency: "direct main"
+                        description:
+                          name: path
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.8.1"
+                      pedantic:
+                        dependency: transitive
+                        description:
+                          name: pedantic
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.11.1"
+                      pool:
+                        dependency: transitive
+                        description:
+                          name: pool
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.5.1"
+                      protobuf:
+                        dependency: "direct main"
+                        description:
+                          name: protobuf
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.1.4"
+                      pub_semver:
+                        dependency: transitive
+                        description:
+                          name: pub_semver
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.3"
+                      retry:
+                        dependency: "direct main"
+                        description:
+                          name: retry
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.1.1"
+                      shelf:
+                        dependency: transitive
+                        description:
+                          name: shelf
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.4.0"
+                      shelf_packages_handler:
+                        dependency: transitive
+                        description:
+                          name: shelf_packages_handler
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.0.1"
+                      shelf_static:
+                        dependency: transitive
+                        description:
+                          name: shelf_static
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.1.1"
+                      shelf_web_socket:
+                        dependency: transitive
+                        description:
+                          name: shelf_web_socket
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.0.3"
+                      source_map_stack_trace:
+                        dependency: transitive
+                        description:
+                          name: source_map_stack_trace
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.1"
+                      source_maps:
+                        dependency: transitive
+                        description:
+                          name: source_maps
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.10.11"
+                      source_span:
+                        dependency: transitive
+                        description:
+                          name: source_span
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.9.1"
+                      stack_trace:
+                        dependency: transitive
+                        description:
+                          name: stack_trace
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.11.0"
+                      stream_channel:
+                        dependency: transitive
+                        description:
+                          name: stream_channel
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.1"
+                      string_scanner:
+                        dependency: transitive
+                        description:
+                          name: string_scanner
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.2.0"
+                      term_glyph:
+                        dependency: transitive
+                        description:
+                          name: term_glyph
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.2.1"
+                      test:
+                        dependency: "direct dev"
+                        description:
+                          name: test
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.22.0"
+                      test_api:
+                        dependency: transitive
+                        description:
+                          name: test_api
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.4.16"
+                      test_core:
+                        dependency: transitive
+                        description:
+                          name: test_core
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.4.20"
+                      typed_data:
+                        dependency: transitive
+                        description:
+                          name: typed_data
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.3.1"
+                      vm_service:
+                        dependency: transitive
+                        description:
+                          name: vm_service
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "9.4.0"
+                      watcher:
+                        dependency: transitive
+                        description:
+                          name: watcher
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.0.2"
+                      web_socket_channel:
+                        dependency: transitive
+                        description:
+                          name: web_socket_channel
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.2.0"
+                      webkit_inspection_protocol:
+                        dependency: transitive
+                        description:
+                          name: webkit_inspection_protocol
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.2.0"
+                      yaml:
+                        dependency: transitive
+                        description:
+                          name: yaml
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.1.1"
+                    sdks:
+                      dart: ">=2.18.0 <3.0.0"
+                  content_encoding: utf-8
+                  deleted: false
+                  directory: /pub
+                  name: pubspec.lock
+                  operation: update
+                  support_file: false
+                  type: file
+            pr-title: Bump retry from 2.0.0 to 3.1.1 in /pub
+            pr-body: |
+                Bumps [retry](https://github.com/google/dart-neats) from 2.0.0 to 3.1.1.
+                <details>
+                <summary>Commits</summary>
+                <ul>
+                <li><a href="https://github.com/google/dart-neats/commit/5e81a55a18c568d53c6329fcf268b197418ea196"><code>5e81a55</code></a> Add <code>topics</code> to retry (<a href="https://redirect.github.com/google/dart-neats/issues/200">#200</a>)</li>
+                <li><a href="https://github.com/google/dart-neats/commit/b0f8044ed8dd83963695e6d92ea4a336bf3c180e"><code>b0f8044</code></a> Add <code>topics</code> to pem (<a href="https://redirect.github.com/google/dart-neats/issues/199">#199</a>)</li>
+                <li><a href="https://github.com/google/dart-neats/commit/5119eba0db931caa37c207634f52f12d5ae4f4da"><code>5119eba</code></a> blast_repo fixes (<a href="https://redirect.github.com/google/dart-neats/issues/195">#195</a>)</li>
+                <li><a href="https://github.com/google/dart-neats/commit/a805b4b85413cbc56a38f014150bfb8ed337d924"><code>a805b4b</code></a> Latest CI actions (<a href="https://redirect.github.com/google/dart-neats/issues/194">#194</a>)</li>
+                <li><a href="https://github.com/google/dart-neats/commit/4c0fe94b04f87e9d4652e3e943da053f7c10102e"><code>4c0fe94</code></a> Fix usage of deprecated API from petitparser (<a href="https://redirect.github.com/google/dart-neats/issues/193">#193</a>)</li>
+                <li><a href="https://github.com/google/dart-neats/commit/3cdb108b6426ff61012739eae485c636c9d1550f"><code>3cdb108</code></a> Configure automated publishing</li>
+                <li><a href="https://github.com/google/dart-neats/commit/d5281ecaf75f6cd292b28f8c5e7d804f40b838c0"><code>d5281ec</code></a> Upgrade dependencies to be dart 3 ready (<a href="https://redirect.github.com/google/dart-neats/issues/192">#192</a>)</li>
+                <li><a href="https://github.com/google/dart-neats/commit/84f6baae9fcbd51e616540916c391aa563a44db7"><code>84f6baa</code></a> Fix package:vendor (<a href="https://redirect.github.com/google/dart-neats/issues/186">#186</a>)</li>
+                <li><a href="https://github.com/google/dart-neats/commit/3b567693a8560b9ca09ee3d2758bb4f01cd51b92"><code>3b56769</code></a> use latest mono_repo (<a href="https://redirect.github.com/google/dart-neats/issues/185">#185</a>)</li>
+                <li><a href="https://github.com/google/dart-neats/commit/a6ea208fa661aed3795c211a0b94b485fad0e464"><code>a6ea208</code></a> Drop shelf_router[_generator] (<a href="https://redirect.github.com/google/dart-neats/issues/182">#182</a>)</li>
+                <li>Additional commits viewable in <a href="https://github.com/google/dart-neats/compare/retry-v2.0.0...retry-3.1.1">compare view</a></li>
+                </ul>
+                </details>
+                <br />
+            commit-message: |-
+                Bump retry from 2.0.0 to 3.1.1 in /pub
+
+                Bumps [retry](https://github.com/google/dart-neats) from 2.0.0 to 3.1.1.
+                - [Commits](https://github.com/google/dart-neats/compare/retry-v2.0.0...retry-3.1.1)
+    - type: create_pull_request
+      expect:
+        data:
+            base-commit-sha: 48e9be2bc45b1336ef6088260fbe56a162c5678e
+            dependencies:
+                - name: test
+                  previous-requirements:
+                    - file: pubspec.yaml
+                      groups:
+                        - dev
+                      requirement: ^1.16.5
+                      source:
+                        description:
+                            name: test
+                            url: https://pub.dev
+                        type: hosted
+                  previous-version: 1.22.0
+                  requirements:
+                    - file: pubspec.yaml
+                      groups:
+                        - dev
+                      requirement: ^1.24.2
+                      source: null
+                  version: 1.24.2
+            updated-dependency-files:
+                - content: |
+                    name: dependabot_testcase
+                    environment:
+                      sdk: '>=2.12.0 <3.0.0'
+                    dependencies:
+                      collection: ^1.14.13 # Locked to 1.14.13, can update with no unlock.
+                      retry: ^2.0.0 # Can update with updated constraint, no further constraints.
+                      protobuf: 1.1.4 # Can update with updated constraint, only together with fixnum.
+                      fixnum: 0.10.11
+                      path: 1.8.1 # Already at latest
+                      http: "0.13.2" # < 0.13.3 has a security vulnerability: https://github.com/advisories/GHSA-4rgh-jx4f-qfcq
+
+                    dev_dependencies:
+                      test: ^1.24.2
+                  content_encoding: utf-8
+                  deleted: false
+                  directory: /pub
+                  name: pubspec.yaml
+                  operation: update
+                  support_file: false
+                  type: file
+                - content: |
+                    # Generated by pub
+                    # See https://dart.dev/tools/pub/glossary#lockfile
+                    packages:
+                      _fe_analyzer_shared:
+                        dependency: transitive
+                        description:
+                          name: _fe_analyzer_shared
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "50.0.0"
+                      analyzer:
+                        dependency: transitive
+                        description:
+                          name: analyzer
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "5.2.0"
+                      args:
+                        dependency: transitive
+                        description:
+                          name: args
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.3.1"
+                      async:
+                        dependency: transitive
+                        description:
+                          name: async
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.10.0"
+                      boolean_selector:
+                        dependency: transitive
+                        description:
+                          name: boolean_selector
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.1"
+                      collection:
+                        dependency: "direct main"
+                        description:
+                          name: collection
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.17.0"
+                      convert:
+                        dependency: transitive
+                        description:
+                          name: convert
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.1.1"
+                      coverage:
+                        dependency: transitive
+                        description:
+                          name: coverage
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.6.1"
+                      crypto:
+                        dependency: transitive
+                        description:
+                          name: crypto
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.0.2"
+                      file:
+                        dependency: transitive
+                        description:
+                          name: file
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "6.1.4"
+                      fixnum:
+                        dependency: "direct main"
+                        description:
+                          name: fixnum
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.10.11"
+                      frontend_server_client:
+                        dependency: transitive
+                        description:
+                          name: frontend_server_client
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.2.0"
+                      glob:
+                        dependency: transitive
+                        description:
+                          name: glob
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.1"
+                      http:
+                        dependency: "direct main"
+                        description:
+                          name: http
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.13.2"
+                      http_multi_server:
+                        dependency: transitive
+                        description:
+                          name: http_multi_server
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.2.1"
+                      http_parser:
+                        dependency: transitive
+                        description:
+                          name: http_parser
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "4.0.2"
+                      io:
+                        dependency: transitive
+                        description:
+                          name: io
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.0.3"
+                      js:
+                        dependency: transitive
+                        description:
+                          name: js
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.6.5"
+                      logging:
+                        dependency: transitive
+                        description:
+                          name: logging
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.1.0"
+                      matcher:
+                        dependency: transitive
+                        description:
+                          name: matcher
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.12.15"
+                      meta:
+                        dependency: transitive
+                        description:
+                          name: meta
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.8.0"
+                      mime:
+                        dependency: transitive
+                        description:
+                          name: mime
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.0.2"
+                      node_preamble:
+                        dependency: transitive
+                        description:
+                          name: node_preamble
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.0.1"
+                      package_config:
+                        dependency: transitive
+                        description:
+                          name: package_config
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.0"
+                      path:
+                        dependency: "direct main"
+                        description:
+                          name: path
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.8.1"
+                      pedantic:
+                        dependency: transitive
+                        description:
+                          name: pedantic
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.11.1"
+                      pool:
+                        dependency: transitive
+                        description:
+                          name: pool
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.5.1"
+                      protobuf:
+                        dependency: "direct main"
+                        description:
+                          name: protobuf
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.1.4"
+                      pub_semver:
+                        dependency: transitive
+                        description:
+                          name: pub_semver
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.3"
+                      retry:
+                        dependency: "direct main"
+                        description:
+                          name: retry
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.0.0"
+                      shelf:
+                        dependency: transitive
+                        description:
+                          name: shelf
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.4.0"
+                      shelf_packages_handler:
+                        dependency: transitive
+                        description:
+                          name: shelf_packages_handler
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.0.1"
+                      shelf_static:
+                        dependency: transitive
+                        description:
+                          name: shelf_static
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.1.1"
+                      shelf_web_socket:
+                        dependency: transitive
+                        description:
+                          name: shelf_web_socket
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.0.3"
+                      source_map_stack_trace:
+                        dependency: transitive
+                        description:
+                          name: source_map_stack_trace
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.1"
+                      source_maps:
+                        dependency: transitive
+                        description:
+                          name: source_maps
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.10.11"
+                      source_span:
+                        dependency: transitive
+                        description:
+                          name: source_span
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.9.1"
+                      stack_trace:
+                        dependency: transitive
+                        description:
+                          name: stack_trace
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.11.0"
+                      stream_channel:
+                        dependency: transitive
+                        description:
+                          name: stream_channel
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.1.1"
+                      string_scanner:
+                        dependency: transitive
+                        description:
+                          name: string_scanner
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.2.0"
+                      term_glyph:
+                        dependency: transitive
+                        description:
+                          name: term_glyph
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.2.1"
+                      test:
+                        dependency: "direct dev"
+                        description:
+                          name: test
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.24.2"
+                      test_api:
+                        dependency: transitive
+                        description:
+                          name: test_api
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.5.2"
+                      test_core:
+                        dependency: transitive
+                        description:
+                          name: test_core
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "0.5.2"
+                      typed_data:
+                        dependency: transitive
+                        description:
+                          name: typed_data
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.3.1"
+                      vm_service:
+                        dependency: transitive
+                        description:
+                          name: vm_service
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "9.4.0"
+                      watcher:
+                        dependency: transitive
+                        description:
+                          name: watcher
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.0.2"
+                      web_socket_channel:
+                        dependency: transitive
+                        description:
+                          name: web_socket_channel
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "2.2.0"
+                      webkit_inspection_protocol:
+                        dependency: transitive
+                        description:
+                          name: webkit_inspection_protocol
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "1.2.0"
+                      yaml:
+                        dependency: transitive
+                        description:
+                          name: yaml
+                          url: "https://pub.dev"
+                        source: hosted
+                        version: "3.1.1"
+                    sdks:
+                      dart: ">=2.18.0 <3.0.0"
+                  content_encoding: utf-8
+                  deleted: false
+                  directory: /pub
+                  name: pubspec.lock
+                  operation: update
+                  support_file: false
+                  type: file
+            pr-title: Bump test from 1.22.0 to 1.24.2 in /pub
+            pr-body: |
+                Bumps [test](https://github.com/dart-lang/test/tree/master/pkgs) from 1.22.0 to 1.24.2.
+                <details>
+                <summary>Commits</summary>
+                <ul>
+                <li><a href="https://github.com/dart-lang/test/commit/8f7682a58f1176cd1ff22ef7cc89fa9bb4858dbc"><code>8f7682a</code></a> Remove deprecation of test_api top level libraries (<a href="https://github.com/dart-lang/test/tree/master/pkgs/issues/1994">#1994</a>)</li>
+                <li><a href="https://github.com/dart-lang/test/commit/7151486cb05bf3b5dabe7f248e4fd3d5ae13e80e"><code>7151486</code></a> Add support for Microsoft Edge (<a href="https://github.com/dart-lang/test/tree/master/pkgs/issues/1992">#1992</a>)</li>
+                <li><a href="https://github.com/dart-lang/test/commit/c1d686aa9a0beeb39da9578285c746ac9e537a01"><code>c1d686a</code></a> Fix &quot;Improvements&quot; link in <code>package:checks</code> migration guide (<a href="https://github.com/dart-lang/test/tree/master/pkgs/issues/1991">#1991</a>)</li>
+                <li><a href="https://github.com/dart-lang/test/commit/8ea42987b0fee4a31ec97c101d0c66a461bf18f3"><code>8ea4298</code></a> Make tests compatible with Strict CSP (<a href="https://github.com/dart-lang/test/tree/master/pkgs/issues/1987">#1987</a>)</li>
+                <li><a href="https://github.com/dart-lang/test/commit/a01b185ea7939b0867361693d2a85d9865c876fd"><code>a01b185</code></a> More smoothly handle missing compiler info (<a href="https://github.com/dart-lang/test/tree/master/pkgs/issues/1980">#1980</a>)</li>
+                <li><a href="https://github.com/dart-lang/test/commit/b24b4668d8a5be769e7f0b93025f47d1f2271695"><code>b24b466</code></a> Support native assets (<a href="https://github.com/dart-lang/test/tree/master/pkgs/issues/1975">#1975</a>)</li>
+                <li><a href="https://github.com/dart-lang/test/commit/c382826790d37bca18fcfbded65e7acdea55c0c9"><code>c382826</code></a> Prepare to publish (<a href="https://github.com/dart-lang/test/tree/master/pkgs/issues/1974">#1974</a>)</li>
+                <li><a href="https://github.com/dart-lang/test/commit/cc0598b2c3bf3a7439f10f9542a8d01ff50b69e9"><code>cc0598b</code></a> Move to <code>expect</code> from <code>package:matcher</code> (<a href="https://github.com/dart-lang/test/tree/master/pkgs/issues/1969">#1969</a>)</li>
+                <li><a href="https://github.com/dart-lang/test/commit/0e5c028d239b8801581852aa31a19ecc9f64f500"><code>0e5c028</code></a> Only use environment variable for chrome (<a href="https://github.com/dart-lang/test/tree/master/pkgs/issues/1970">#1970</a>)</li>
+                <li><a href="https://github.com/dart-lang/test/commit/0b08d704c2a314d8446a30de75906e7991c6f21b"><code>0b08d70</code></a> Add a hooks_testing library (<a href="https://github.com/dart-lang/test/tree/master/pkgs/issues/1952">#1952</a>)</li>
+                <li>Additional commits viewable in <a href="https://github.com/dart-lang/test/commits/test_v1.24.2/pkgs">compare view</a></li>
+                </ul>
+                </details>
+                <br />
+            commit-message: |-
+                Bump test from 1.22.0 to 1.24.2 in /pub
+
+                Bumps [test](https://github.com/dart-lang/test/tree/master/pkgs) from 1.22.0 to 1.24.2.
+                - [Release notes](https://github.com/dart-lang/test/releases)
+                - [Commits](https://github.com/dart-lang/test/commits/test_v1.24.2/pkgs)
     - type: mark_as_processed
       expect:
         data:
-            base-commit-sha: 8b2c0d821028c531826db20ca22cffdd2cc05abf
+            base-commit-sha: 48e9be2bc45b1336ef6088260fbe56a162c5678e


### PR DESCRIPTION
see https://github.com/dependabot/dependabot-core/pull/7265

Summary:

```
updater | +------------------------------------------------------------------------------+
updater | |                     Changes to Dependabot Pull Requests                      |
updater | +---------+--------------------------------------------------------------------+
updater | | created | collection ( from 1.17.0 to 1.17.1 )                               |
updater | | created | fixnum ( from 0.10.11 to 1.1.0 ), protobuf ( from 1.1.4 to 2.1.0 ) |
updater | | created | http ( from 0.13.2 to 0.13.6 )                                     |
updater | | created | path ( from 1.8.1 to 1.8.3 )                                       |
updater | | created | retry ( from 2.0.0 to 3.1.1 )                                      |
updater | | created | test ( from 1.22.0 to 1.24.2 )                                     |
updater | +---------+--------------------------------------------------------------------+
```