### PR TITLE
Update smoke-go-group-rules

### DIFF
--- a/tests/smoke-go-group-rules.yaml
+++ b/tests/smoke-go-group-rules.yaml
@@ -237,6 +237,7 @@ output:
             pr-title: Bump the ruleset group in /go with 3 updates
             pr-body: |
                 Bumps the ruleset group in /go with 3 updates: [github.com/fatih/color](https://github.com/fatih/color), [github.com/inconshreveable/mousetrap](https://github.com/inconshreveable/mousetrap) and [golang.org/x/crypto](https://github.com/golang/crypto).
+
                 Updates `github.com/fatih/color` from 1.7.0 to 1.13.0
                 <details>
                 <summary>Release notes</summary>
@@ -309,6 +310,7 @@ output:
                 Bump the ruleset group in /go with 3 updates
 
                 Bumps the ruleset group in /go with 3 updates: [github.com/fatih/color](https://github.com/fatih/color), [github.com/inconshreveable/mousetrap](https://github.com/inconshreveable/mousetrap) and [golang.org/x/crypto](https://github.com/golang/crypto).
+
 
                 Updates `github.com/fatih/color` from 1.7.0 to 1.13.0
                 - [Release notes](https://github.com/fatih/color/releases)


### PR DESCRIPTION
Update the grouped go smoke test to include the newline added in https://github.com/dependabot/dependabot-core/pull/7401