### PR TITLE
Update the yarn smoke tests to latest versions

### DIFF
--- a/tests/smoke-yarn-berry.yaml
+++ b/tests/smoke-yarn-berry.yaml
@@ -3468,9 +3468,9 @@ output:
                       linkType: hard
 
                     "jquery@npm:^3.6.3":
-                      version: 3.6.3
-                      resolution: "jquery@npm:3.6.3"
-                      checksum: 0fd366bdcaa0c84a7a8751ce20f8192290141913978b5059574426d9b01f4365daa675f95aab3eec94fd794d27b08d32078a2236bef404b8ba78073009988ce6
+                      version: 3.7.0
+                      resolution: "jquery@npm:3.7.0"
+                      checksum: 907785e133afc427650a131af5fccef66a404885037513b3d4d7d63aee6409bcc32a39836868c60e59b05aa0fb8ace8961c18b2ee3ffdf6ffdb571d6d7cd88ff
                       languageName: node
                       linkType: hard
 
@@ -4680,7 +4680,7 @@ output:
                               "packageLocation": "./",\
                               "packageDependencies": [\
                                 ["jest", "virtual:8985bfe6ba677cda0766851544d123cd66efc4326d803dd08493411985e1db9c85edd1c7fb51a4ae1887d7d47a1f703440aea94071abef14051e5ccdcf33d172#npm:28.1.3"],\
-                                ["jquery", "npm:3.6.3"],\
+                                ["jquery", "npm:3.7.0"],\
                                 ["ts-jest", "virtual:8985bfe6ba677cda0766851544d123cd66efc4326d803dd08493411985e1db9c85edd1c7fb51a4ae1887d7d47a1f703440aea94071abef14051e5ccdcf33d172#npm:28.0.8"],\
                                 ["typescript", "patch:typescript@npm%3A4.9.3#~builtin<compat/typescript>::version=4.9.3&hash=d73830"]\
                               ],\
@@ -7796,10 +7796,10 @@ output:
                             }]\
                           ]],\
                           ["jquery", [\
-                            ["npm:3.6.3", {\
-                              "packageLocation": "./.yarn/cache/jquery-npm-3.6.3-cbc34d2330-0fd366bdca.zip/node_modules/jquery/",\
+                            ["npm:3.7.0", {\
+                              "packageLocation": "./.yarn/cache/jquery-npm-3.7.0-a02a382bf4-907785e133.zip/node_modules/jquery/",\
                               "packageDependencies": [\
-                                ["jquery", "npm:3.6.3"]\
+                                ["jquery", "npm:3.7.0"]\
                               ],\
                               "linkType": "HARD"\
                             }]\
@@ -9116,7 +9116,7 @@ output:
                               "packageDependencies": [\
                                 ["yarn", "workspace:."],\
                                 ["jest", "virtual:8985bfe6ba677cda0766851544d123cd66efc4326d803dd08493411985e1db9c85edd1c7fb51a4ae1887d7d47a1f703440aea94071abef14051e5ccdcf33d172#npm:28.1.3"],\
-                                ["jquery", "npm:3.6.3"],\
+                                ["jquery", "npm:3.7.0"],\
                                 ["ts-jest", "virtual:8985bfe6ba677cda0766851544d123cd66efc4326d803dd08493411985e1db9c85edd1c7fb51a4ae1887d7d47a1f703440aea94071abef14051e5ccdcf33d172#npm:28.0.8"],\
                                 ["typescript", "patch:typescript@npm%3A4.9.3#~builtin<compat/typescript>::version=4.9.3&hash=d73830"]\
                               ],\
@@ -19609,11 +19609,11 @@ output:
                   operation: delete
                   support_file: false
                   type: file
-                - content: 0921285c41b278c7279c2e734a3e052170022b962c92aaa0958bb94a341fe89b
+                - content: ceb7f1d53c8e5bc226cb7551ed7a4bc2a8d7db19fe53eb43f44137cf722a95eb
                   content_encoding: sha256
                   deleted: false
                   directory: /yarn-berry
-                  name: .yarn/cache/jquery-npm-3.6.3-cbc34d2330-0fd366bdca.zip
+                  name: .yarn/cache/jquery-npm-3.7.0-a02a382bf4-907785e133.zip
                   operation: create
                   support_file: false
                   type: file

--- a/tests/smoke-yarn.yaml
+++ b/tests/smoke-yarn.yaml
@@ -192,7 +192,7 @@ output:
                         object-keys "^1.1.1"
                         regexp.prototype.flags "^1.2.0"
 
-                    define-properties@^1.1.3:
+                    define-properties@^1.1.3, define-properties@^1.2.0:
                       version "1.2.0"
                       resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.2.0.tgz#52988570670c9eacedd8064f4a990f2405849bd5"
                       integrity sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==
@@ -234,18 +234,19 @@ output:
                       resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
                       integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
-                    functions-have-names@^1.2.2:
+                    functions-have-names@^1.2.3:
                       version "1.2.3"
                       resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
                       integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
                     get-intrinsic@^1.0.2, get-intrinsic@^1.1.1:
-                      version "1.2.0"
-                      resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.0.tgz#7ad1dc0535f3a2904bba075772763e5051f6d05f"
-                      integrity sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==
+                      version "1.2.1"
+                      resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.1.tgz#d295644fed4505fc9cde952c37ee12b477a83d82"
+                      integrity sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==
                       dependencies:
                         function-bind "^1.1.1"
                         has "^1.0.3"
+                        has-proto "^1.0.1"
                         has-symbols "^1.0.3"
 
                     has-property-descriptors@^1.0.0:
@@ -254,6 +255,11 @@ output:
                       integrity sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==
                       dependencies:
                         get-intrinsic "^1.1.1"
+
+                    has-proto@^1.0.1:
+                      version "1.0.1"
+                      resolved "https://registry.yarnpkg.com/has-proto/-/has-proto-1.0.1.tgz#1885c1305538958aff469fef37937c22795408e0"
+                      integrity sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==
 
                     has-symbols@^1.0.2, has-symbols@^1.0.3:
                       version "1.0.3"
@@ -390,13 +396,13 @@ output:
                         strict-uri-encode "^1.0.0"
 
                     regexp.prototype.flags@^1.2.0:
-                      version "1.4.3"
-                      resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz#87cab30f80f66660181a3bb7bf5981a872b367ac"
-                      integrity sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==
+                      version "1.5.0"
+                      resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz#fe7ce25e7e4cca8db37b6634c8a2c7009199b9cb"
+                      integrity sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==
                       dependencies:
                         call-bind "^1.0.2"
-                        define-properties "^1.1.3"
-                        functions-have-names "^1.2.2"
+                        define-properties "^1.2.0"
+                        functions-have-names "^1.2.3"
 
                     "safer-buffer@>= 2.1.2 < 3.0.0":
                       version "2.1.2"


### PR DESCRIPTION
It looks like our yarn caches have moved ahead from the checked-in test files, so this PR refreshes the two failing tests.

The yarn specs may still fail on this branch, if they do we will need to run `cache-one` for:
- smoke-yarn.yml
- smoke-yarn-berry.yml

Afterwards, both tests should pass and we can merge for main to go 🍏 