### PR TITLE
Lock PNPM version in smoke test

### DIFF
--- a/pnpm/package.json
+++ b/pnpm/package.json
@@ -18,5 +18,6 @@
   "main": "lib/pkg.js",
   "devDependencies": {
     "eslint-plugin-yml": "1.5.0"
-  }
+  },
+  "packageManager": "pnpm@8.3.1"
 }


### PR DESCRIPTION
To make the test more stable