### PR TITLE
Ensure we have the go-group-rules test in our cache workflows

### DIFF
--- a/.github/workflows/cache-all.yml
+++ b/.github/workflows/cache-all.yml
@@ -28,6 +28,7 @@ jobs:
           - { path: tests/smoke-elm.yaml, name: elm }
           - { path: tests/smoke-go.yaml, name: go }
           - { path: tests/smoke-go-close-pr.yaml, name: go-close }
+          - { path: tests/smoke-go-group-rules.yaml, name: go-group-rules }
           - { path: tests/smoke-go-security.yaml, name: go-security }
           - { path: tests/smoke-go-update-pr.yaml, name: go-update }
           - { path: tests/smoke-gradle.yaml, name: gradle }

--- a/.github/workflows/cache-one.yml
+++ b/.github/workflows/cache-one.yml
@@ -23,6 +23,7 @@ on:
           - elm
           - go
           - go-close-pr
+          - go-group-rules
           - go-security
           - go-update-pr
           - gradle

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -28,9 +28,9 @@ jobs:
           - elm
           - go
           - go-close-pr
+          - go-group-rules
           - go-security
           - go-update-pr
-          - go-group-rules
           - gradle
           - gradle-version-catalog
           - hex


### PR DESCRIPTION
Update our cache workflows to add a missing test - we haven't needed to recache these yet, but this will ensure we can when we need to