### PR TITLE
Support specifying a custom `git ref`

### DIFF
--- a/.github/workflows/cache-all.yml
+++ b/.github/workflows/cache-all.yml
@@ -1,8 +1,13 @@
-# Runs all smoke tests individually to refill caches after a change to how caching works.
+# Runs all smoke tests individually to refill caches. Useful after modifying how caching works.
 name: Cache all (SLOW!)
 
 on:
   workflow_dispatch:
+    inputs:
+      git-ref:
+        description: git ref
+        required: true
+        default: main
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -52,6 +57,8 @@ jobs:
           - { path: tests/smoke-yarn-berry-workspaces.yaml, name: yarn-berry-workspaces }
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.git-ref }}
 
       - name: Download CLI
         run: |


### PR DESCRIPTION
This feature is already used in the `cache-one.yml` workflow. It's typically not useful for cache all, but I'd like to merge the cache all and cache one workflows, so this aligns their one behavior difference (other than specifying which package manager).