### PR TITLE
Migrate to the new `record_ecosystem_versions` endpoint

### DIFF
--- a/tests/smoke-bundler-group-rules.yaml
+++ b/tests/smoke-bundler-group-rules.yaml
@@ -35,12 +35,12 @@ input:
           type: git_source
           username: x-access-token
 output:
-    - type: record_package_manager_version
+    - type: record_ecosystem_versions
       expect:
         data:
-            ecosystem: deprecated
-            package-managers:
-                bundler: "2"
+            ecosystem_versions:
+                package_managers:
+                    bundler: "2"
     - type: update_dependency_list
       expect:
         data:

--- a/tests/smoke-bundler-group-vendoring.yaml
+++ b/tests/smoke-bundler-group-vendoring.yaml
@@ -36,12 +36,12 @@ input:
           type: git_source
           username: x-access-token
 output:
-    - type: record_package_manager_version
+    - type: record_ecosystem_versions
       expect:
         data:
-            ecosystem: deprecated
-            package-managers:
-                bundler: "2"
+            ecosystem_versions:
+                package_managers:
+                    bundler: "2"
     - type: update_dependency_list
       expect:
         data:

--- a/tests/smoke-bundler.yaml
+++ b/tests/smoke-bundler.yaml
@@ -27,12 +27,12 @@ input:
           type: git_source
           username: x-access-token
 output:
-    - type: record_package_manager_version
+    - type: record_ecosystem_versions
       expect:
         data:
-            ecosystem: deprecated
-            package-managers:
-                bundler: "2"
+            ecosystem_versions:
+                package_managers:
+                    bundler: "2"
     - type: update_dependency_list
       expect:
         data:

--- a/tests/smoke-cargo.yaml
+++ b/tests/smoke-cargo.yaml
@@ -32,12 +32,12 @@ input:
           type: git_source
           username: x-access-token
 output:
-    - type: record_package_manager_version
+    - type: record_ecosystem_versions
       expect:
         data:
-            ecosystem: deprecated
-            package-managers:
-                cargo: default
+            ecosystem_versions:
+                package_managers:
+                    cargo: default
     - type: update_dependency_list
       expect:
         data:

--- a/tests/smoke-go-close-pr.yaml
+++ b/tests/smoke-go-close-pr.yaml
@@ -21,12 +21,12 @@ input:
           type: git_source
           username: x-access-token
 output:
-    - type: record_package_manager_version
+    - type: record_ecosystem_versions
       expect:
         data:
-            ecosystem: deprecated
-            package-managers:
-                gomod: "1.12"
+            ecosystem_versions:
+                package_managers:
+                    gomod: "1.12"
     - type: update_dependency_list
       expect:
         data:

--- a/tests/smoke-go-group-rules.yaml
+++ b/tests/smoke-go-group-rules.yaml
@@ -43,12 +43,12 @@ input:
           type: git_source
           username: x-access-token
 output:
-    - type: record_package_manager_version
+    - type: record_ecosystem_versions
       expect:
         data:
-            ecosystem: deprecated
-            package-managers:
-                gomod: "1.12"
+            ecosystem_versions:
+                package_managers:
+                    gomod: "1.12"
     - type: update_dependency_list
       expect:
         data:

--- a/tests/smoke-go-security.yaml
+++ b/tests/smoke-go-security.yaml
@@ -32,12 +32,12 @@ input:
           type: git_source
           username: x-access-token
 output:
-    - type: record_package_manager_version
+    - type: record_ecosystem_versions
       expect:
         data:
-            ecosystem: deprecated
-            package-managers:
-                gomod: "1.12"
+            ecosystem_versions:
+                package_managers:
+                    gomod: "1.12"
     - type: update_dependency_list
       expect:
         data:

--- a/tests/smoke-go-update-pr.yaml
+++ b/tests/smoke-go-update-pr.yaml
@@ -31,12 +31,12 @@ input:
           type: git_source
           username: x-access-token
 output:
-    - type: record_package_manager_version
+    - type: record_ecosystem_versions
       expect:
         data:
-            ecosystem: deprecated
-            package-managers:
-                gomod: "1.12"
+            ecosystem_versions:
+                package_managers:
+                    gomod: "1.12"
     - type: update_dependency_list
       expect:
         data:

--- a/tests/smoke-go.yaml
+++ b/tests/smoke-go.yaml
@@ -34,12 +34,12 @@ input:
           type: git_source
           username: x-access-token
 output:
-    - type: record_package_manager_version
+    - type: record_ecosystem_versions
       expect:
         data:
-            ecosystem: deprecated
-            package-managers:
-                gomod: "1.12"
+            ecosystem_versions:
+                package_managers:
+                    gomod: "1.12"
     - type: update_dependency_list
       expect:
         data:

--- a/tests/smoke-npm-group-rules.yaml
+++ b/tests/smoke-npm-group-rules.yaml
@@ -40,12 +40,12 @@ input:
           type: git_source
           username: x-access-token
 output:
-    - type: record_package_manager_version
+    - type: record_ecosystem_versions
       expect:
         data:
-            ecosystem: deprecated
-            package-managers:
-                npm: 8
+            ecosystem_versions:
+                package_managers:
+                    npm: 8
     - type: update_dependency_list
       expect:
         data:

--- a/tests/smoke-npm-remove-transitive.yaml
+++ b/tests/smoke-npm-remove-transitive.yaml
@@ -25,12 +25,12 @@ input:
             directory: /npm/removed
             commit: 4e5e081d77a06dd5092a65e161c1142fbec372bd
 output:
-    - type: record_package_manager_version
+    - type: record_ecosystem_versions
       expect:
         data:
-            ecosystem: deprecated
-            package-managers:
-                npm: 8
+            ecosystem_versions:
+                package_managers:
+                    npm: 8
     - type: update_dependency_list
       expect:
         data:

--- a/tests/smoke-npm.yaml
+++ b/tests/smoke-npm.yaml
@@ -32,12 +32,12 @@ input:
           type: git_source
           username: x-access-token
 output:
-    - type: record_package_manager_version
+    - type: record_ecosystem_versions
       expect:
         data:
-            ecosystem: deprecated
-            package-managers:
-                npm: 8
+            ecosystem_versions:
+                package_managers:
+                    npm: 8
     - type: update_dependency_list
       expect:
         data:

--- a/tests/smoke-pnpm.yaml
+++ b/tests/smoke-pnpm.yaml
@@ -23,12 +23,12 @@ input:
           type: git_source
           username: x-access-token
 output:
-    - type: record_package_manager_version
+    - type: record_ecosystem_versions
       expect:
         data:
-            ecosystem: deprecated
-            package-managers:
-                pnpm: 8.3.1
+            ecosystem_versions:
+                package_managers:
+                    pnpm: 8.3.1
     - type: update_dependency_list
       expect:
         data:

--- a/tests/smoke-yarn-berry-workspaces.yaml
+++ b/tests/smoke-yarn-berry-workspaces.yaml
@@ -31,12 +31,12 @@ input:
           type: git_source
           username: x-access-token
 output:
-    - type: record_package_manager_version
+    - type: record_ecosystem_versions
       expect:
         data:
-            ecosystem: deprecated
-            package-managers:
-                yarn: 3.3.1
+            ecosystem_versions:
+                package_managers:
+                    yarn: 3.3.1
     - type: update_dependency_list
       expect:
         data:

--- a/tests/smoke-yarn-berry.yaml
+++ b/tests/smoke-yarn-berry.yaml
@@ -22,12 +22,12 @@ input:
           type: git_source
           username: x-access-token
 output:
-    - type: record_package_manager_version
+    - type: record_ecosystem_versions
       expect:
         data:
-            ecosystem: deprecated
-            package-managers:
-                yarn: 3.3.0
+            ecosystem_versions:
+                package_managers:
+                    yarn: 3.3.0
     - type: update_dependency_list
       expect:
         data:

--- a/tests/smoke-yarn.yaml
+++ b/tests/smoke-yarn.yaml
@@ -26,12 +26,12 @@ input:
           type: git_source
           username: x-access-token
 output:
-    - type: record_package_manager_version
+    - type: record_ecosystem_versions
       expect:
         data:
-            ecosystem: deprecated
-            package-managers:
-                yarn: 1
+            ecosystem_versions:
+                package_managers:
+                    yarn: 1
     - type: update_dependency_list
       expect:
         data:


### PR DESCRIPTION
As of https://github.com/dependabot/dependabot-core/pull/7517 we're now using a `record_ecosystem_versions` endpoint instead of `record_package_manager_versions`.

So this updates the test expectations accordingly.