### PR TITLE
generate suites automatically and from a reusable workflow

### DIFF
--- a/.github/workflows/cache-all.yml
+++ b/.github/workflows/cache-all.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   suites:
-    uses: dependabot/smoke-tests/.github/workflows/list-suites.yml@main
+    uses: dependabot/smoke-tests/.github/workflows/list-suites.yml@jakecoffman/reusable-suites-list
   e2e:
     runs-on: ubuntu-latest
     needs: suites

--- a/.github/workflows/cache-all.yml
+++ b/.github/workflows/cache-all.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   suites:
-    uses: dependabot/smoke-tests/.github/workflows/list-suites.yml@jakecoffman/reusable-suites-list
+    uses: dependabot/smoke-tests/.github/workflows/list-suites.yml
   e2e:
     runs-on: ubuntu-latest
     needs: suites

--- a/.github/workflows/cache-all.yml
+++ b/.github/workflows/cache-all.yml
@@ -9,47 +9,18 @@ env:
 
 
 jobs:
+  suites:
+    uses: dependabot/smoke-tests/.github/workflows/list-suites.yml@main
   e2e:
     runs-on: ubuntu-latest
+    needs: suites
     strategy:
       # Running serially since GitHub API doesn't like concurrent requests.
       max-parallel: 1
       fail-fast: false
       # Using a matrix so if 1 fails it can just be retried instead of restarting the whole job.
       matrix:
-        suite:
-          - { path: tests/smoke-actions.yaml, name: actions }
-          - { path: tests/smoke-bundler.yaml, name: bundler }
-          - { path: tests/smoke-bundler-group-rules.yaml, name: bundler-group-rules }
-          - { path: tests/smoke-bundler-group-vendoring.yaml, name: bundler-group-vendoring }
-          - { path: tests/smoke-cargo.yaml, name: cargo }
-          - { path: tests/smoke-composer.yaml, name: composer }
-          - { path: tests/smoke-docker.yaml, name: docker }
-          - { path: tests/smoke-elm.yaml, name: elm }
-          - { path: tests/smoke-go.yaml, name: go }
-          - { path: tests/smoke-go-close-pr.yaml, name: go-close }
-          - { path: tests/smoke-go-group-rules.yaml, name: go-group-rules }
-          - { path: tests/smoke-go-security.yaml, name: go-security }
-          - { path: tests/smoke-go-update-pr.yaml, name: go-update }
-          - { path: tests/smoke-gradle.yaml, name: gradle }
-          - { path: tests/smoke-gradle-version-catalog.yaml, name: gradle-version-catalog }
-          - { path: tests/smoke-hex.yaml, name: hex }
-          - { path: tests/smoke-maven.yaml, name: maven }
-          - { path: tests/smoke-npm.yaml, name: npm }
-          - { path: tests/smoke-npm-group-rules.yaml, name: npm-group-rules }
-          - { path: tests/smoke-npm-remove-transitive.yaml, name: npm-remove-transitive }
-          - { path: tests/smoke-nuget.yaml, name: nuget }
-          - { path: tests/smoke-pip.yaml, name: pip }
-          - { path: tests/smoke-pip-compile.yaml, name: pip-compile }
-          - { path: tests/smoke-pipenv.yaml, name: pipenv }
-          - { path: tests/smoke-pnpm.yaml, name: pnpm }
-          - { path: tests/smoke-poetry.yaml, name: poetry }
-          - { path: tests/smoke-pub.yaml, name: pub }
-          - { path: tests/smoke-submodules.yaml, name: submodules }
-          - { path: tests/smoke-terraform.yaml, name: terraform }
-          - { path: tests/smoke-yarn.yaml, name: yarn }
-          - { path: tests/smoke-yarn-berry.yaml, name: yarn-berry }
-          - { path: tests/smoke-yarn-berry-workspaces.yaml, name: yarn-berry-workspaces }
+        suite: ${{ fromJSON(needs.suites.outputs.suites) }}
     steps:
       - uses: actions/checkout@v3
 
@@ -60,10 +31,10 @@ jobs:
           ./dependabot --version
 
       # Not downloading the cache first, this job is to bust the cache for all ecosystems.
-      - name: Smoke ${{ matrix.suite.name }}
+      - name: Smoke ${{ matrix.suite }}
         env:
           LOCAL_GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./dependabot test -f=${{ matrix.suite.path }} --cache=cache
+        run: ./dependabot test -f=tests/smoke-${{ matrix.suite.path }}.yaml --cache=cache
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/cache-all.yml
+++ b/.github/workflows/cache-all.yml
@@ -34,9 +34,9 @@ jobs:
       - name: Smoke ${{ matrix.suite }}
         env:
           LOCAL_GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./dependabot test -f=tests/smoke-${{ matrix.suite.path }}.yaml --cache=cache
+        run: ./dependabot test -f=tests/smoke-${{ matrix.suite }}.yaml --cache=cache
 
       - uses: actions/upload-artifact@v3
         with:
-          name: cache-${{ matrix.suite.name }}
+          name: cache-${{ matrix.suite }}
           path: cache/

--- a/.github/workflows/cache-all.yml
+++ b/.github/workflows/cache-all.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   suites:
-    uses: dependabot/smoke-tests/.github/workflows/list-suites.yml
+    uses: ./.github/workflows/list-suites.yml
   e2e:
     runs-on: ubuntu-latest
     needs: suites

--- a/.github/workflows/cache-one.yml
+++ b/.github/workflows/cache-one.yml
@@ -11,40 +11,6 @@ on:
       package_manager:
         description: The package manager to use
         required: true
-        type: choice
-        options:
-          - actions
-          - bundler
-          - bundler-group-rules
-          - bundler-group-vendoring
-          - cargo
-          - composer
-          - docker
-          - elm
-          - go
-          - go-close-pr
-          - go-group-rules
-          - go-security
-          - go-update-pr
-          - gradle
-          - gradle-version-catalog
-          - hex
-          - maven
-          - npm
-          - npm-group-rules
-          - npm-remove-transitive
-          - nuget
-          - pip
-          - pip-compile
-          - pipenv
-          - pnpm
-          - poetry
-          - pub
-          - submodules
-          - terraform
-          - yarn
-          - yarn-berry
-          - yarn-berry-workspaces
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/list-suites.yml
+++ b/.github/workflows/list-suites.yml
@@ -1,0 +1,21 @@
+name: List Suites
+on:
+  workflow_call:
+    outputs:
+      suites:
+        description: List of suites to run from the tests/ directory
+        value: ${{ jobs.gather.outputs.suites }}
+jobs:
+  suites:
+    uses: dependabot/smoke-tests/.github/workflows/list-suites.yml@main
+  gather:
+    runs-on: ubuntu-latest
+    needs: suites
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get workflow names
+        id: suites
+        run: |
+          echo "suite=$(ls tests | sed 's/^tests\///' | sed 's/smoke-//' | sed 's/.yaml$//' | jq -R | jq -sc)" >> $GITHUB_OUTPUT
+    outputs:
+      suites: ${{ steps.suites.outputs.suite }}

--- a/.github/workflows/list-suites.yml
+++ b/.github/workflows/list-suites.yml
@@ -6,8 +6,6 @@ on:
         description: List of suites to run from the tests/ directory
         value: ${{ jobs.gather.outputs.suites }}
 jobs:
-  suites:
-    uses: dependabot/smoke-tests/.github/workflows/list-suites.yml@jakecoffman/reusable-suites-list
   gather:
     runs-on: ubuntu-latest
     needs: suites

--- a/.github/workflows/list-suites.yml
+++ b/.github/workflows/list-suites.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   gather:
     runs-on: ubuntu-latest
-    needs: suites
     steps:
       - uses: actions/checkout@v2
       - name: Get workflow names

--- a/.github/workflows/list-suites.yml
+++ b/.github/workflows/list-suites.yml
@@ -7,7 +7,7 @@ on:
         value: ${{ jobs.gather.outputs.suites }}
 jobs:
   suites:
-    uses: dependabot/smoke-tests/.github/workflows/list-suites.yml@main
+    uses: dependabot/smoke-tests/.github/workflows/list-suites.yml@jakecoffman/reusable-suites-list
   gather:
     runs-on: ubuntu-latest
     needs: suites

--- a/.github/workflows/refresh-artifacts.yml
+++ b/.github/workflows/refresh-artifacts.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   suites:
-    uses: dependabot/smoke-tests/.github/workflows/list-suites.yml@main
+    uses: dependabot/smoke-tests/.github/workflows/list-suites.yml@jakecoffman/reusable-suites-list
   refresh:
     runs-on: ubuntu-latest
     needs: suites

--- a/.github/workflows/refresh-artifacts.yml
+++ b/.github/workflows/refresh-artifacts.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   suites:
-    uses: dependabot/smoke-tests/.github/workflows/list-suites.yml@jakecoffman/reusable-suites-list
+    uses: dependabot/smoke-tests/.github/workflows/list-suites.yml
   refresh:
     runs-on: ubuntu-latest
     needs: suites

--- a/.github/workflows/refresh-artifacts.yml
+++ b/.github/workflows/refresh-artifacts.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   suites:
-    uses: dependabot/smoke-tests/.github/workflows/list-suites.yml
+    uses: ./.github/workflows/list-suites.yml
   refresh:
     runs-on: ubuntu-latest
     needs: suites

--- a/.github/workflows/refresh-artifacts.yml
+++ b/.github/workflows/refresh-artifacts.yml
@@ -10,43 +10,15 @@ env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
+  suites:
+    uses: dependabot/smoke-tests/.github/workflows/list-suites.yml@main
   refresh:
     runs-on: ubuntu-latest
+    needs: suites
     strategy:
       fail-fast: false
       matrix:
-        suite:
-          - actions
-          - bundler
-          - bundler-group-rules
-          - bundler-group-vendoring
-          - cargo
-          - composer
-          - docker
-          - elm
-          - go
-          - go-close-pr
-          - go-security
-          - go-update-pr
-          - gradle
-          - gradle-version-catalog
-          - hex
-          - maven
-          - npm
-          - npm-group-rules
-          - npm-remove-transitive
-          - nuget
-          - pip
-          - pip-compile
-          - pipenv
-          - pnpm
-          - poetry
-          - pub
-          - submodules
-          - terraform
-          - yarn
-          - yarn-berry
-          - yarn-berry-workspaces
+        suite: ${{ fromJSON(needs.suites.outputs.suites) }}
     steps:
       - uses: actions/checkout@v3
       - name: Download artifacts

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   suites:
-    uses: dependabot/smoke-tests/.github/workflows/list-suites.yml
+    uses: ./.github/workflows/list-suites.yml
   smoke:
     runs-on: ubuntu-latest
     needs: suites

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -12,44 +12,15 @@ env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
+  suites:
+    uses: dependabot/smoke-tests/.github/workflows/list-suites.yml@main
   smoke:
     runs-on: ubuntu-latest
+    needs: suites
     strategy:
       fail-fast: false
       matrix:
-        suite:
-          - actions
-          - bundler
-          - bundler-group-rules
-          - bundler-group-vendoring
-          - cargo
-          - composer
-          - docker
-          - elm
-          - go
-          - go-close-pr
-          - go-group-rules
-          - go-security
-          - go-update-pr
-          - gradle
-          - gradle-version-catalog
-          - hex
-          - maven
-          - npm
-          - npm-group-rules
-          - npm-remove-transitive
-          - nuget
-          - pip
-          - pip-compile
-          - pipenv
-          - pnpm
-          - poetry
-          - pub
-          - submodules
-          - terraform
-          - yarn
-          - yarn-berry
-          - yarn-berry-workspaces
+        suite: ${{ fromJSON(needs.suites.outputs.suites) }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   suites:
-    uses: dependabot/smoke-tests/.github/workflows/list-suites.yml@main
+    uses: dependabot/smoke-tests/.github/workflows/list-suites.yml@jakecoffman/reusable-suites-list
   smoke:
     runs-on: ubuntu-latest
     needs: suites

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   suites:
-    uses: dependabot/smoke-tests/.github/workflows/list-suites.yml@jakecoffman/reusable-suites-list
+    uses: dependabot/smoke-tests/.github/workflows/list-suites.yml
   smoke:
     runs-on: ubuntu-latest
     needs: suites


### PR DESCRIPTION
At the risk of overcomplicating things, I thought it might be nice if when adding a new test we didn't have to go to N workflow files and add the new test name.

Using a reusable workflow file, this automatically generates the suites from the test files themselves.