### PR TITLE
Update smoke-go-close-pr.yaml

### DIFF
--- a/tests/smoke-go-close-pr.yaml
+++ b/tests/smoke-go-close-pr.yaml
@@ -1,6 +1,9 @@
 input:
     job:
         package-manager: go_modules
+        allowed-updates:
+            - dependency-type: direct
+              update-type: all
         dependencies:
             - none
         experiments:


### PR DESCRIPTION
We [expect allowed_updates](https://github.com/dependabot/dependabot-core/blob/main/updater/lib/dependabot/job.rb#L86) as a mandatory key in the job definition containing an array.

This test worked as the execution path for closing a PR happened to avoid ever referencing it, but with some changes in https://github.com/dependabot/dependabot-core/pull/7548 we now early-evaluate group configuration group configuration which results in us referencing it. 