### PR TITLE
Update composer test to include metrics

### DIFF
--- a/tests/smoke-composer.yaml
+++ b/tests/smoke-composer.yaml
@@ -35,6 +35,12 @@ input:
           type: git_source
           username: x-access-token
 output:
+    - type: record_ecosystem_versions
+      expect:
+        data:
+            ecosystem_versions:
+                package_managers:
+                    composer: "2"
     - type: update_dependency_list
       expect:
         data:


### PR DESCRIPTION
`composer` now records a metric:
* https://github.com/dependabot/dependabot-core/pull/7323