### PR TITLE
Include groupId in release note summary

### DIFF
--- a/tests/smoke-maven.yaml
+++ b/tests/smoke-maven.yaml
@@ -203,7 +203,7 @@ output:
                 Bumps [org.springframework.boot:spring-boot-starter-parent](https://github.com/spring-projects/spring-boot) from 1.5.9.RELEASE to 2.7.2.
                 <details>
                 <summary>Release notes</summary>
-                <p><em>Sourced from <a href="https://github.com/spring-projects/spring-boot/releases">spring-boot-starter-parent's releases</a>.</em></p>
+                <p><em>Sourced from <a href="https://github.com/spring-projects/spring-boot/releases">org.springframework.boot:spring-boot-starter-parent's releases</a>.</em></p>
                 <blockquote>
                 <h2>v2.7.2</h2>
                 <h2>:lady_beetle: Bug Fixes</h2>


### PR DESCRIPTION
We missed this in #59 