### PR TITLE
Use full names for Swift dependencies

### DIFF
--- a/tests/smoke-swift.yaml
+++ b/tests/smoke-swift.yaml
@@ -34,7 +34,7 @@ output:
       expect:
         data:
             dependencies:
-                - name: reactiveswift
+                - name: github.com/reactivecocoa/reactiveswift
                   requirements:
                     - file: Package.swift
                       groups:
@@ -49,7 +49,7 @@ output:
                         type: git
                         url: https://github.com/ReactiveCocoa/ReactiveSwift
                   version: 7.1.1
-                - name: quick
+                - name: github.com/quick/quick
                   requirements:
                     - file: Package.swift
                       groups:
@@ -64,7 +64,7 @@ output:
                         type: git
                         url: https://github.com/Quick/Quick.git
                   version: 4.0.0
-                - name: nimble
+                - name: github.com/quick/nimble
                   requirements:
                     - file: Package.swift
                       groups:
@@ -79,10 +79,10 @@ output:
                         type: git
                         url: https://github.com/Quick/Nimble.git
                   version: 9.2.1
-                - name: cwlpreconditiontesting
+                - name: github.com/mattgallagher/cwlpreconditiontesting
                   requirements: []
                   version: 2.1.0
-                - name: cwlcatchexception
+                - name: github.com/mattgallagher/cwlcatchexception
                   requirements: []
                   version: 2.1.1
             dependency_files:
@@ -93,7 +93,7 @@ output:
         data:
             base-commit-sha: 175645c35aab4115f8f57040af58178116145084
             dependencies:
-                - name: quick
+                - name: github.com/quick/quick
                   previous-requirements:
                     - file: Package.swift
                       groups:
@@ -206,12 +206,12 @@ output:
                   operation: update
                   support_file: false
                   type: file
-            pr-title: Bump quick from 4.0.0 to 7.2.0 in /swift
+            pr-title: Bump github.com/quick/quick from 4.0.0 to 7.2.0 in /swift
             pr-body: |
-                Bumps [quick](https://github.com/Quick/Quick) from 4.0.0 to 7.2.0.
+                Bumps [github.com/quick/quick](https://github.com/Quick/Quick) from 4.0.0 to 7.2.0.
                 <details>
                 <summary>Release notes</summary>
-                <p><em>Sourced from <a href="https://github.com/Quick/Quick/releases">quick's releases</a>.</em></p>
+                <p><em>Sourced from <a href="https://github.com/Quick/Quick/releases">github.com/quick/quick's releases</a>.</em></p>
                 <blockquote>
                 <h2>v7.2.0 - TestState property wrapper</h2>
                 <h1>Highlight</h1>
@@ -272,9 +272,9 @@ output:
                 </details>
                 <br />
             commit-message: |-
-                Bump quick from 4.0.0 to 7.2.0 in /swift
+                Bump github.com/quick/quick from 4.0.0 to 7.2.0 in /swift
 
-                Bumps [quick](https://github.com/Quick/Quick) from 4.0.0 to 7.2.0.
+                Bumps [github.com/quick/quick](https://github.com/Quick/Quick) from 4.0.0 to 7.2.0.
                 - [Release notes](https://github.com/Quick/Quick/releases)
                 - [Commits](https://github.com/Quick/Quick/compare/v4.0.0...v7.2.0)
     - type: create_pull_request
@@ -282,7 +282,7 @@ output:
         data:
             base-commit-sha: 175645c35aab4115f8f57040af58178116145084
             dependencies:
-                - name: nimble
+                - name: github.com/quick/nimble
                   previous-requirements:
                     - file: Package.swift
                       groups:
@@ -395,12 +395,12 @@ output:
                   operation: update
                   support_file: false
                   type: file
-            pr-title: Bump nimble from 9.2.1 to 12.2.0 in /swift
+            pr-title: Bump github.com/quick/nimble from 9.2.1 to 12.2.0 in /swift
             pr-body: |
-                Bumps [nimble](https://github.com/Quick/Nimble) from 9.2.1 to 12.2.0.
+                Bumps [github.com/quick/nimble](https://github.com/Quick/Nimble) from 9.2.1 to 12.2.0.
                 <details>
                 <summary>Release notes</summary>
-                <p><em>Sourced from <a href="https://github.com/Quick/Nimble/releases">nimble's releases</a>.</em></p>
+                <p><em>Sourced from <a href="https://github.com/Quick/Nimble/releases">github.com/quick/nimble's releases</a>.</em></p>
                 <blockquote>
                 <h2>v12.2.0</h2>
                 <h1>Highlights</h1>
@@ -472,9 +472,9 @@ output:
                 </details>
                 <br />
             commit-message: |-
-                Bump nimble from 9.2.1 to 12.2.0 in /swift
+                Bump github.com/quick/nimble from 9.2.1 to 12.2.0 in /swift
 
-                Bumps [nimble](https://github.com/Quick/Nimble) from 9.2.1 to 12.2.0.
+                Bumps [github.com/quick/nimble](https://github.com/Quick/Nimble) from 9.2.1 to 12.2.0.
                 - [Release notes](https://github.com/Quick/Nimble/releases)
                 - [Commits](https://github.com/Quick/Nimble/compare/v9.2.1...v12.2.0)
     - type: create_pull_request
@@ -482,7 +482,7 @@ output:
         data:
             base-commit-sha: 175645c35aab4115f8f57040af58178116145084
             dependencies:
-                - name: cwlpreconditiontesting
+                - name: github.com/mattgallagher/cwlpreconditiontesting
                   previous-requirements: []
                   previous-version: 2.1.0
                   requirements: []
@@ -548,9 +548,9 @@ output:
                   operation: update
                   support_file: false
                   type: file
-            pr-title: Bump cwlpreconditiontesting from 2.1.0 to 2.1.2 in /swift
+            pr-title: Bump github.com/mattgallagher/cwlpreconditiontesting from 2.1.0 to 2.1.2 in /swift
             pr-body: |
-                Bumps [cwlpreconditiontesting](https://github.com/mattgallagher/CwlPreconditionTesting) from 2.1.0 to 2.1.2.
+                Bumps [github.com/mattgallagher/cwlpreconditiontesting](https://github.com/mattgallagher/CwlPreconditionTesting) from 2.1.0 to 2.1.2.
                 <details>
                 <summary>Commits</summary>
                 <ul>
@@ -569,16 +569,16 @@ output:
                 </details>
                 <br />
             commit-message: |-
-                Bump cwlpreconditiontesting from 2.1.0 to 2.1.2 in /swift
+                Bump github.com/mattgallagher/cwlpreconditiontesting in /swift
 
-                Bumps [cwlpreconditiontesting](https://github.com/mattgallagher/CwlPreconditionTesting) from 2.1.0 to 2.1.2.
+                Bumps [github.com/mattgallagher/cwlpreconditiontesting](https://github.com/mattgallagher/CwlPreconditionTesting) from 2.1.0 to 2.1.2.
                 - [Commits](https://github.com/mattgallagher/CwlPreconditionTesting/compare/2.1.0...2.1.2)
     - type: create_pull_request
       expect:
         data:
             base-commit-sha: 175645c35aab4115f8f57040af58178116145084
             dependencies:
-                - name: cwlcatchexception
+                - name: github.com/mattgallagher/cwlcatchexception
                   previous-requirements: []
                   previous-version: 2.1.1
                   requirements: []
@@ -644,9 +644,9 @@ output:
                   operation: update
                   support_file: false
                   type: file
-            pr-title: Bump cwlcatchexception from 2.1.1 to 2.1.2 in /swift
+            pr-title: Bump github.com/mattgallagher/cwlcatchexception from 2.1.1 to 2.1.2 in /swift
             pr-body: |
-                Bumps [cwlcatchexception](https://github.com/mattgallagher/CwlCatchException) from 2.1.1 to 2.1.2.
+                Bumps [github.com/mattgallagher/cwlcatchexception](https://github.com/mattgallagher/CwlCatchException) from 2.1.1 to 2.1.2.
                 <details>
                 <summary>Commits</summary>
                 <ul>
@@ -663,9 +663,9 @@ output:
                 </details>
                 <br />
             commit-message: |-
-                Bump cwlcatchexception from 2.1.1 to 2.1.2 in /swift
+                Bump github.com/mattgallagher/cwlcatchexception in /swift
 
-                Bumps [cwlcatchexception](https://github.com/mattgallagher/CwlCatchException) from 2.1.1 to 2.1.2.
+                Bumps [github.com/mattgallagher/cwlcatchexception](https://github.com/mattgallagher/CwlCatchException) from 2.1.1 to 2.1.2.
                 - [Commits](https://github.com/mattgallagher/CwlCatchException/compare/2.1.1...2.1.2)
     - type: mark_as_processed
       expect:


### PR DESCRIPTION
So that names match what Advisories and Dependency Graph use.

This is a companion to https://github.com/dependabot/dependabot-core/pull/7648.