### PR TITLE
Add missing pip-compile ignores

### DIFF
--- a/tests/smoke-pip-compile.yaml
+++ b/tests/smoke-pip-compile.yaml
@@ -6,6 +6,14 @@ input:
         ignore-conditions:
             - dependency-name: django
               version-requirement: '>4.0.6'
+            - dependency-name: asgiref
+              version-requirement: '>3.6.0'
+            - dependency-name: numpy
+              version-requirement: '>1.24.1'
+            - dependency-name: pytz
+              version-requirement: '>2022.7'
+            - dependency-name: sqlparse
+              version-requirement: '>0.4.3'
         source:
             provider: github
             repo: dependabot/smoke-tests


### PR DESCRIPTION
I guess the python upgrades let these go higher.

References: https://github.com/dependabot/dependabot-core/actions/runs/5901380694/job/16007458420?pr=7843.