### PR TITLE
Directory.Packages.props test for NuGet

### DIFF
--- a/nuget/directory-packages-props/Directory.Packages.props
+++ b/nuget/directory-packages-props/Directory.Packages.props
@@ -1,0 +1,10 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="FSharp.Core" Version="[7.0.400]" />
+    <PackageVersion Include="NuGet.Versioning" Version="6.1.0" />
+  </ItemGroup>
+</Project>

--- a/nuget/directory-packages-props/project/project.fsproj
+++ b/nuget/directory-packages-props/project/project.fsproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+   <PackageReference Include="FSharp.Core" />
+   <PackageReference Include="NuGet.Versioning" />
+  </ItemGroup>
+
+</Project>

--- a/tests/smoke-nuget-directory-packages-props.yaml
+++ b/tests/smoke-nuget-directory-packages-props.yaml
@@ -1,0 +1,33 @@
+input:
+    job:
+        package-manager: nuget
+        allowed-updates:
+            - update-type: all
+        ignore-conditions:
+            - dependency-name: NuGet.Versioning
+              source: tests/smoke-nuget-directory-packages-props.yaml
+              version-requirement: '>6.2.2'
+        source:
+            provider: github
+            repo: dependabot/smoke-tests
+            directory: /nuget/directory-packages-props
+            commit: 832e37c1a7a4ef89feb9dc7cfa06f62205191994
+        credentials-metadata:
+            - host: github.com
+              type: git_source
+    credentials:
+        - host: github.com
+          password: $LOCAL_GITHUB_ACCESS_TOKEN
+          type: git_source
+          username: x-access-token
+output:
+    - type: record_update_job_error
+      expect:
+        data:
+            error-type: dependency_file_not_found
+            error-details:
+                file-path: /nuget/directory-packages-props/<anything>.(cs|vb|fs)proj
+    - type: mark_as_processed
+      expect:
+        data:
+            base-commit-sha: 832e37c1a7a4ef89feb9dc7cfa06f62205191994


### PR DESCRIPTION
Hi all,

I discovered today that Dependabot supports `Directory.Packages.props` files when using NuGet.
This really rocks folks!

Soon afterwards, I discovered that lock files aren't supported yet.
https://github.com/dependabot/dependabot-core/pull/6031 seems to be very close to solving that.
The last message in that conversation speaks of smoke tests which lead me here.

I was hoping to add one for `Directory.Packages.props` and later add another one for lock files.
However, I'm already a bit lost on the setup. Could I get some pointers here, please?

Thanks a bunch!

