### PR TITLE
Ignore smoke tests from yamllint check

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,6 +1,9 @@
 ---
 extends: default
 
+ignore:
+  - tests/
+
 rules:
   braces: {min-spaces-inside: 0, max-spaces-inside: 1}
   brackets: {min-spaces-inside: 0, max-spaces-inside: 1}


### PR DESCRIPTION
These files are generated, and they do not match our style. Leave them alone.