### PR TITLE
create a workflow that regenerates a test and makes a PR

### DIFF
--- a/.github/workflows/regen.yml
+++ b/.github/workflows/regen.yml
@@ -1,0 +1,46 @@
+name: Regenerate test output
+
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+    inputs:
+      git-ref:
+        description: git ref
+        required: true
+        default: main
+      test_name:
+        description: The test name (e.g. go-group-rules)
+        required: true
+
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  cache_one:
+    runs-on: ubuntu-latest
+    name: Cache ${{ inputs.test_name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git-ref }}
+
+      - name: Download CLI
+        run: |
+          gh release download --repo dependabot/cli -p "*linux-amd64.tar.gz"
+          tar xzvf *.tar.gz >/dev/null 2>&1
+          ./dependabot --version
+
+      - name: Regen ${{ inputs.test_name }}
+        env:
+          LOCAL_GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./dependabot test -f=tests/smoke-${{ inputs.test_name }}.yaml -o tests/smoke-${{ inputs.test_name }}.yaml
+
+      - name: Commit changes and create PR
+        run: |
+            git config --global user.email "${{ github.triggering_actor }}@github.com"
+            git config --global user.name "${{ github.triggering_actor }}"
+            git add tests/smoke-${{ inputs.test_name }}.yaml
+            git checkout -b regen-${{ inputs.test_name }}-${{ github.run_number }}
+            git commit -m "Regenerate ${{ inputs.test_name }} test output"
+            git push origin regen-${{ inputs.test_name }}-${{ github.run_number }}
+            gh pr create --title "Regenerate ${{ inputs.test_name }} test output" \
+               --body "Requested by @${{ github.triggering_actor }}"


### PR DESCRIPTION
Sometimes due to a cache failure, or a code change, we need to regenerate the test without a cache. This job does the work for us without needing to launch a Codespace or updating things locally.

I think I will need to merge this to test it? If I recall, you can't kick off an Action that's in a branch until it also is on the default branch.
