### PR TITLE
Improve `run-all.sh` script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ tmp
 dependabot*
 # vscode generates this on load
 obj
+# avoid checking local cache dir
+cache

--- a/script/run-all.sh
+++ b/script/run-all.sh
@@ -2,8 +2,7 @@
 
 # This script is useful for regenerating all of the smoke tests running locally.
 
-declare -a arr=("actions" "bundler-group-rules" "bundler-group-vendoring" "bundler" "cargo" "composer" "docker" "elm" "go" "go-group-rules" "gradle" "hex" "maven" "npm" "npm-group-rules" "nuget" "pip" "pip-compile" "pipenv" "poetry" "pub" "submodules" "terraform")
-for eco in "${arr[@]}"
+for f in tests/*.yaml
 do
-  dependabot test -f "tests/smoke-$eco.yaml" -o "tests/smoke-$eco.yaml"
+  dependabot test -f "$f" -o "$f"
 done

--- a/script/run-all.sh
+++ b/script/run-all.sh
@@ -4,5 +4,13 @@
 
 for f in tests/*.yaml
 do
-  dependabot test -f "$f" -o "$f"
+  if [ "$1" = "--with-cache" ]
+  then
+    suite=$(echo "$f" | sed -e "s/^tests\/smoke-//" -e "s/\.yaml$//")
+    rm -rf cache
+    source script/download-cache.sh $suite
+    dependabot test -f "$f" -o "$f" --cache cache
+  else
+    dependabot test -f "$f" -o "$f"
+  fi
 done


### PR DESCRIPTION
* Don't keep a hardcoded list of smoke tests and loop through all of them automatically instead.
* Allow optionally downloading and using the existing cache of network calls.