### PR TITLE
Regenerate pipenv smoke tests to match current behavior

### DIFF
--- a/tests/smoke-pipenv.yaml
+++ b/tests/smoke-pipenv.yaml
@@ -115,11 +115,11 @@ output:
                         "default": {
                             "asgiref": {
                                 "hashes": [
-                                    "sha256:71e68008da809b957b7ee4b43dbccff33d1b23519fb8344e33f049897077afac",
-                                    "sha256:9567dfe7bd8d3c8c892227827c41cce860b368104c3431da67a0c5a65a949506"
+                                    "sha256:89b2ef2247e3b562a16eef663bc0e2e703ec6468e2fa8a5cd61cd449786d4f6e",
+                                    "sha256:9e0ce3aa93a819ba5b45120216b23878cf6e8525eb3848653452b4192b92afed"
                                 ],
                                 "markers": "python_version >= '3.7'",
-                                "version": "==3.6.0"
+                                "version": "==3.7.2"
                             },
                             "backports.zoneinfo": {
                                 "hashes": [
@@ -149,6 +149,7 @@ output:
                                     "sha256:ca54ebedfcbc60d191391efbf02ba68fb52165b8bf6ccd6fe71f098cac1fe59e"
                                 ],
                                 "index": "pypi",
+                                "markers": "python_version >= '3.8'",
                                 "version": "==4.0.6"
                             },
                             "numpy": {
@@ -183,15 +184,24 @@ output:
                                     "sha256:ecfdd68d334a6b97472ed032b5b37a30d8217c097acfff15e8452c710e775524"
                                 ],
                                 "index": "pypi",
+                                "markers": "python_version >= '3.8'",
                                 "version": "==1.23.2"
                             },
                             "sqlparse": {
                                 "hashes": [
-                                    "sha256:0323c0ec29cd52bceabc1b4d9d579e311f3e4961b98d174201d5622a23b85e34",
-                                    "sha256:69ca804846bb114d2ec380e4360a8a340db83f0ccf3afceeb1404df028f57268"
+                                    "sha256:5430a4fe2ac7d0f93e66f1efc6e1338a41884b7ddf2a350cedd20ccc4d9d28f3",
+                                    "sha256:d446183e84b8349fa3061f0fe7f06ca94ba65b426946ffebe6e3e8295332420c"
                                 ],
                                 "markers": "python_version >= '3.5'",
-                                "version": "==0.4.3"
+                                "version": "==0.4.4"
+                            },
+                            "typing-extensions": {
+                                "hashes": [
+                                    "sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0",
+                                    "sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef"
+                                ],
+                                "markers": "python_version < '3.11'",
+                                "version": "==4.8.0"
                             }
                         },
                         "develop": {}


### PR DESCRIPTION
We upgraded pipenv recently and this is the result the new pipenv version gives. We have not received any reports since we ugpraded so I'm assuming this change is actually a bug fix rather than a regression.

This patch was generated using `./script/run-one.sh tests/smoke-pipenv.yaml` from #129.