### PR TITLE
Update Composer `plugin-api-version` to 2.6.0

### DIFF
--- a/composer/composer.lock
+++ b/composer/composer.lock
@@ -180,5 +180,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer/vendor/phpstan/phpstan-strict-rules/build-cs/composer.lock
+++ b/composer/vendor/phpstan/phpstan-strict-rules/build-cs/composer.lock
@@ -318,5 +318,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/tests/smoke-composer.yaml
+++ b/tests/smoke-composer.yaml
@@ -322,7 +322,7 @@ output:
                         "prefer-lowest": false,
                         "platform": [],
                         "platform-dev": [],
-                        "plugin-api-version": "2.3.0"
+                        "plugin-api-version": "2.6.0"
                     }
                   content_encoding: utf-8
                   deleted: false
@@ -601,7 +601,7 @@ output:
                         "prefer-lowest": false,
                         "platform": [],
                         "platform-dev": [],
-                        "plugin-api-version": "2.3.0"
+                        "plugin-api-version": "2.6.0"
                     }
                   content_encoding: utf-8
                   deleted: false


### PR DESCRIPTION
This is to support newer versions of Composer. See also https://github.com/dependabot/dependabot-core/pull/8299