### PR TITLE
Adapt expectation to `pipenv upgrade`

### DIFF
--- a/tests/smoke-pipenv.yaml
+++ b/tests/smoke-pipenv.yaml
@@ -184,8 +184,14 @@ output:
                                     "sha256:ecfdd68d334a6b97472ed032b5b37a30d8217c097acfff15e8452c710e775524"
                                 ],
                                 "index": "pypi",
-                                "markers": "python_version >= '3.8'",
                                 "version": "==1.23.2"
+                            },
+                            "pytz": {
+                                "hashes": [
+                                    "sha256:220f481bdafa09c3955dfbdddb7b57780e9a94f5127e35456a48589b9e0c0197",
+                                    "sha256:cea221417204f2d1a2aa03ddae3e867921971d0d76f14d87abb4414415bbdcf5"
+                                ],
+                                "version": "==2022.2.1"
                             },
                             "sqlparse": {
                                 "hashes": [


### PR DESCRIPTION
In https://github.com/dependabot/dependabot-core/pull/8312 we'll be migrating to use `pipenv upgrade` under the hood.

This works better, it's simpler, and avoids issues with undesired unrelated transitive dependency upgrades.

However, it has the gotcha that it does not clean up unused dependencies after it's run.

I think this is a more minor issue than what we fix by adopting it, and unlikely to cause problems. I reported upstream [here](https://github.com/pypa/pipenv/issues/6002).

For now, I think the best thing we can do is adapt our expectation.

I checked that this branch is already passing against the pipenv upgrade with https://github.com/dependabot/dependabot-core/pull/8312/commits/1e6f35b76a0ba679ad92e623772f59da6b1df94a.