### PR TITLE
fix Go smoke tests

### DIFF
--- a/tests/smoke-go-security.yaml
+++ b/tests/smoke-go-security.yaml
@@ -115,6 +115,7 @@ output:
                   operation: update
                   support_file: false
                   type: file
+                  mode: "100644"
                 - content: |
                     github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
                     github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=

--- a/tests/smoke-go-update-pr.yaml
+++ b/tests/smoke-go-update-pr.yaml
@@ -100,6 +100,7 @@ output:
                   operation: update
                   support_file: false
                   type: file
+                  mode: "100644"
                 - content: |
                     github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
                     github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=


### PR DESCRIPTION
There's a bug in the Go FileFetcher that https://github.com/dependabot/dependabot-core/pull/8309 is mitigating, so we need to fix these tests. 