### PR TITLE
Remove unused npm feature flags

### DIFF
--- a/tests/smoke-npm-remove-transitive.yaml
+++ b/tests/smoke-npm-remove-transitive.yaml
@@ -9,8 +9,6 @@ input:
         dependencies:
             - '@dependabot-fixtures/npm-transitive-dependency'
         experiments:
-            npm-transitive-dependency-removal: true
-            npm-transitive-security-updates: true
             record-ecosystem-versions: true
         ignore-conditions:
             - dependency-name: '@dependabot-fixtures/npm-remove-dependency'

--- a/tests/smoke-yarn-berry-workspaces.yaml
+++ b/tests/smoke-yarn-berry-workspaces.yaml
@@ -5,7 +5,6 @@ input:
             - dependency-name: '@types/lodash'
               update-type: all
         experiments:
-            npm-transitive-dependency-removal: true
             record-ecosystem-versions: true
         ignore-conditions:
             - dependency-name: '@types/lodash'


### PR DESCRIPTION
Cleans up some feature flags that are no longer necessary.

npm-transitive-dependency-removal was removed in:
https://github.com/dependabot/dependabot-core/pull/8359/