### PR TITLE
Fix ignore rule to not match all files with Dependabot in their name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # dependabot temp directory
 tmp
 # avoid checking in downloaded cli
-dependabot*
+/dependabot*
 # vscode generates this on load
 obj
 # avoid checking local cache dir


### PR DESCRIPTION
I was adding a NuGet smoke test and I was banging my head against the wall because it just wouldn't work.

Turns out my test case included a file named `DependabotRepro.sln`, but did not get committed but it was gitignored.