### PR TITLE
expose uncached tests

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -32,7 +32,12 @@ jobs:
 
       # Download the Proxy cache. The job is ideally 100% cached so no real calls are made.
       - name: Download artifacts
-        run: script/download-cache.sh ${{ matrix.suite }}
+        run: |
+          script/download-cache.sh ${{ matrix.suite }}
+          # If the previous command failed, and this is a scheduled run, fail the job.
+          if [ $? -ne 0 ] && [ "${{ github.event_name }}" == "schedule" ]; then
+              exit 1
+          fi
 
       - name: ${{ matrix.suite }}
         env:

--- a/script/download-cache.sh
+++ b/script/download-cache.sh
@@ -7,7 +7,13 @@ fi
 retry=0
 until [ "$retry" -ge 5 ]
 do
-  gh run download --repo dependabot/smoke-tests --name cache-"$1" --dir cache && break
+  gh run download --repo dependabot/smoke-tests --name cache-"$1" --dir cache
+  if [ $? -eq 0 ]; then
+    exit 0
+  fi
   retry=$((retry+1))
   sleep 1
 done
+
+echo "Failed to download cache"
+exit 1


### PR DESCRIPTION
If a test is not cached, it will eventually fail once one of the dependencies gets a new release.

This PR exposes the uncached tests by failing when the artifact download fails, so we can run the cache job before it starts failing.

It might also be wise to automatically run the cache job when merging a new test to main but this seemed like a good first step.