### PR TITLE
don't fail on error

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -33,6 +33,7 @@ jobs:
       # Download the Proxy cache. The job is ideally 100% cached so no real calls are made.
       - name: Download artifacts
         run: |
+          set +e
           script/download-cache.sh ${{ matrix.suite }}
           # If the previous command failed, and this is a scheduled run, fail the job.
           if [ $? -ne 0 ] && [ "${{ github.event_name }}" == "schedule" ]; then


### PR DESCRIPTION
Fix for #157, GItHub automatically sets `set -e` so have to `set +e` to not fail when the cache fails to download so we can conditionally check the error code and fail if it's a scheduled run.