### PR TITLE
Remove the target branch for nuget tests

### DIFF
--- a/tests/smoke-nuget-central-package-management.yaml
+++ b/tests/smoke-nuget-central-package-management.yaml
@@ -11,7 +11,7 @@ input:
             provider: github
             repo: dependabot/smoke-tests
             directory: /nuget/central-package-management
-            branch: brbayes/new-nuget-smoke-tests
+            branch: main
             commit: 7dbbef7b02f40ddfa7d32fc3099caf19f370bb9b
         credentials-metadata:
             - host: github.com

--- a/tests/smoke-nuget-central-package-management.yaml
+++ b/tests/smoke-nuget-central-package-management.yaml
@@ -11,7 +11,6 @@ input:
             provider: github
             repo: dependabot/smoke-tests
             directory: /nuget/central-package-management
-            branch: main
             commit: 7dbbef7b02f40ddfa7d32fc3099caf19f370bb9b
         credentials-metadata:
             - host: github.com

--- a/tests/smoke-nuget-compatible-version.yaml
+++ b/tests/smoke-nuget-compatible-version.yaml
@@ -11,7 +11,7 @@ input:
             provider: github
             repo: dependabot/smoke-tests
             directory: /nuget/compatible-version
-            branch: brbayes/new-nuget-smoke-tests
+            branch: main
             commit: 7dbbef7b02f40ddfa7d32fc3099caf19f370bb9b
         credentials-metadata:
             - host: github.com

--- a/tests/smoke-nuget-compatible-version.yaml
+++ b/tests/smoke-nuget-compatible-version.yaml
@@ -11,7 +11,6 @@ input:
             provider: github
             repo: dependabot/smoke-tests
             directory: /nuget/compatible-version
-            branch: main
             commit: 7dbbef7b02f40ddfa7d32fc3099caf19f370bb9b
         credentials-metadata:
             - host: github.com

--- a/tests/smoke-nuget-dirs-proj.yaml
+++ b/tests/smoke-nuget-dirs-proj.yaml
@@ -11,7 +11,6 @@ input:
             provider: github
             repo: dependabot/smoke-tests
             directory: /nuget/dirs-proj
-            branch: main
             commit: 7dbbef7b02f40ddfa7d32fc3099caf19f370bb9b
         credentials-metadata:
             - host: github.com

--- a/tests/smoke-nuget-dirs-proj.yaml
+++ b/tests/smoke-nuget-dirs-proj.yaml
@@ -11,7 +11,7 @@ input:
             provider: github
             repo: dependabot/smoke-tests
             directory: /nuget/dirs-proj
-            branch: brbayes/new-nuget-smoke-tests
+            branch: main
             commit: 7dbbef7b02f40ddfa7d32fc3099caf19f370bb9b
         credentials-metadata:
             - host: github.com

--- a/tests/smoke-nuget-peer-dependencies.yaml
+++ b/tests/smoke-nuget-peer-dependencies.yaml
@@ -17,7 +17,6 @@ input:
             provider: github
             repo: dependabot/smoke-tests
             directory: /nuget/peer-dependencies
-            branch: main
             commit: 7dbbef7b02f40ddfa7d32fc3099caf19f370bb9b
         credentials-metadata:
             - host: github.com

--- a/tests/smoke-nuget-peer-dependencies.yaml
+++ b/tests/smoke-nuget-peer-dependencies.yaml
@@ -17,7 +17,7 @@ input:
             provider: github
             repo: dependabot/smoke-tests
             directory: /nuget/peer-dependencies
-            branch: brbayes/new-nuget-smoke-tests
+            branch: main
             commit: 7dbbef7b02f40ddfa7d32fc3099caf19f370bb9b
         credentials-metadata:
             - host: github.com

--- a/tests/smoke-nuget-potential-downgrade.yaml
+++ b/tests/smoke-nuget-potential-downgrade.yaml
@@ -21,7 +21,6 @@ input:
             provider: github
             repo: dependabot/smoke-tests
             directory: /nuget/potential-downgrade
-            branch: main
             commit: c28157d6e1e0304bbde1ae81227f5a789033fe9d
         credentials-metadata:
             - host: github.com

--- a/tests/smoke-nuget-potential-downgrade.yaml
+++ b/tests/smoke-nuget-potential-downgrade.yaml
@@ -21,7 +21,7 @@ input:
             provider: github
             repo: dependabot/smoke-tests
             directory: /nuget/potential-downgrade
-            branch: brbayes/new-nuget-smoke-tests
+            branch: main
             commit: c28157d6e1e0304bbde1ae81227f5a789033fe9d
         credentials-metadata:
             - host: github.com

--- a/tests/smoke-nuget-props-and-targets.yaml
+++ b/tests/smoke-nuget-props-and-targets.yaml
@@ -14,7 +14,7 @@ input:
             provider: github
             repo: dependabot/smoke-tests
             directory: /nuget/props-and-targets
-            branch: brbayes/new-nuget-smoke-tests
+            branch: main
             commit: 7dbbef7b02f40ddfa7d32fc3099caf19f370bb9b
         credentials-metadata:
             - host: github.com

--- a/tests/smoke-nuget-props-and-targets.yaml
+++ b/tests/smoke-nuget-props-and-targets.yaml
@@ -14,7 +14,6 @@ input:
             provider: github
             repo: dependabot/smoke-tests
             directory: /nuget/props-and-targets
-            branch: main
             commit: 7dbbef7b02f40ddfa7d32fc3099caf19f370bb9b
         credentials-metadata:
             - host: github.com

--- a/tests/smoke-nuget-sdk-implicit-deps.yaml
+++ b/tests/smoke-nuget-sdk-implicit-deps.yaml
@@ -21,7 +21,7 @@ input:
             provider: github
             repo: dependabot/smoke-tests
             directory: /nuget/sdk-implicit-deps
-            branch: brbayes/new-nuget-smoke-tests
+            branch: main
             commit: 7dbbef7b02f40ddfa7d32fc3099caf19f370bb9b
         credentials-metadata:
             - host: github.com

--- a/tests/smoke-nuget-sdk-implicit-deps.yaml
+++ b/tests/smoke-nuget-sdk-implicit-deps.yaml
@@ -21,7 +21,6 @@ input:
             provider: github
             repo: dependabot/smoke-tests
             directory: /nuget/sdk-implicit-deps
-            branch: main
             commit: 7dbbef7b02f40ddfa7d32fc3099caf19f370bb9b
         credentials-metadata:
             - host: github.com

--- a/tests/smoke-nuget-transitive-pinning.yaml
+++ b/tests/smoke-nuget-transitive-pinning.yaml
@@ -21,7 +21,7 @@ input:
             provider: github
             repo: dependabot/smoke-tests
             directory: /nuget/transitive-pinning
-            branch: brbayes/new-nuget-smoke-tests
+            branch: main
             commit: 7dbbef7b02f40ddfa7d32fc3099caf19f370bb9b
         credentials-metadata:
             - host: github.com

--- a/tests/smoke-nuget-transitive-pinning.yaml
+++ b/tests/smoke-nuget-transitive-pinning.yaml
@@ -21,7 +21,6 @@ input:
             provider: github
             repo: dependabot/smoke-tests
             directory: /nuget/transitive-pinning
-            branch: main
             commit: 7dbbef7b02f40ddfa7d32fc3099caf19f370bb9b
         credentials-metadata:
             - host: github.com

--- a/tests/smoke-nuget-version-property.yaml
+++ b/tests/smoke-nuget-version-property.yaml
@@ -11,7 +11,6 @@ input:
             provider: github
             repo: dependabot/smoke-tests
             directory: /nuget/version-property
-            branch: main
             commit: 7dbbef7b02f40ddfa7d32fc3099caf19f370bb9b
         credentials-metadata:
             - host: github.com

--- a/tests/smoke-nuget-version-property.yaml
+++ b/tests/smoke-nuget-version-property.yaml
@@ -11,7 +11,7 @@ input:
             provider: github
             repo: dependabot/smoke-tests
             directory: /nuget/version-property
-            branch: brbayes/new-nuget-smoke-tests
+            branch: main
             commit: 7dbbef7b02f40ddfa7d32fc3099caf19f370bb9b
         credentials-metadata:
             - host: github.com


### PR DESCRIPTION
This resets the target branch for the new nuget tests now that they have been checked in.