### PR TITLE
regenerate bundler smoke tests

### DIFF
--- a/tests/smoke-bundler-group-rules.yaml
+++ b/tests/smoke-bundler-group-rules.yaml
@@ -175,7 +175,7 @@ output:
                         json (2.7.1)
                         language_server-protocol (3.17.0.3)
                         parallel (1.24.0)
-                        parser (3.2.2.4)
+                        parser (3.3.0.0)
                           ast (~> 2.4.1)
                           racc
                         racc (1.7.3)

--- a/tests/smoke-bundler-group-vendoring.yaml
+++ b/tests/smoke-bundler-group-vendoring.yaml
@@ -157,7 +157,7 @@ output:
                         json (2.7.1)
                         language_server-protocol (3.17.0.3)
                         parallel (1.24.0)
-                        parser (3.2.2.4)
+                        parser (3.3.0.0)
                           ast (~> 2.4.1)
                           racc
                         racc (1.7.3)
@@ -275,11 +275,11 @@ output:
                   support_file: false
                   type: file
                   mode: "100644"
-                - content: 82d7108b1cfd24d377dd4eb8f97a828dcfdaf76d2ffe0a8266c0f45891b678ee
+                - content: 8fc2af5bb5e2cdc83f389d6b64d16f13115dcd573920fef341fbba356a1596c9
                   content_encoding: sha256
                   deleted: false
                   directory: /bundler-vendored
-                  name: vendor/cache/parser-3.2.2.4.gem
+                  name: vendor/cache/parser-3.3.0.0.gem
                   operation: create
                   support_file: false
                   type: file

--- a/tests/smoke-bundler.yaml
+++ b/tests/smoke-bundler.yaml
@@ -162,7 +162,7 @@ output:
                         json (2.7.1)
                         netaddr (2.0.1)
                         parallel (1.24.0)
-                        parser (3.2.2.4)
+                        parser (3.3.0.0)
                           ast (~> 2.4.1)
                           racc
                         racc (1.7.3)


### PR DESCRIPTION
@deivid-rodriguez did you happen to recache these after #164? If so then Bundler learned new ways to evade the caching in 2.5 😄  