### PR TITLE
adding explicit group definitions to grouped updates

### DIFF
--- a/tests/smoke-bundler-group-multidir.yaml
+++ b/tests/smoke-bundler-group-multidir.yaml
@@ -38,6 +38,11 @@ input:
               patched-versions: []
               unaffected-versions: []
         security-updates-only: true
+        dependency-groups:
+          - name: bundler group
+            rules:
+              patterns:
+                - "*"
         source:
             provider: github
             repo: dependabot/smoke-tests

--- a/tests/smoke-cargo-group-multidir.yaml
+++ b/tests/smoke-cargo-group-multidir.yaml
@@ -41,6 +41,11 @@ input:
               patched-versions: []
               unaffected-versions: []
         security-updates-only: true
+        dependency-groups:
+          - name: cargo group
+            rules:
+              patterns:
+                - "*"
         source:
             provider: github
             repo: dependabot/smoke-tests

--- a/tests/smoke-go-group-multidir.yaml
+++ b/tests/smoke-go-group-multidir.yaml
@@ -32,6 +32,11 @@ input:
               patched-versions: []
               unaffected-versions: []
         security-updates-only: true
+        dependency-groups:
+          - name: go_modules group
+            rules:
+              patterns:
+                - "*"
         source:
             provider: github
             repo: dependabot/smoke-tests

--- a/tests/smoke-go-group-security.yaml
+++ b/tests/smoke-go-group-security.yaml
@@ -24,6 +24,11 @@ input:
               patched-versions: []
               unaffected-versions: []
         security-updates-only: true
+        dependency-groups:
+          - name: go_modules group
+            rules:
+              patterns:
+                - "*"
         source:
             provider: github
             repo: dependabot/smoke-tests

--- a/tests/smoke-go-update-security-multidir.yaml
+++ b/tests/smoke-go-update-security-multidir.yaml
@@ -39,6 +39,11 @@ input:
               patched-versions: []
               unaffected-versions: []
         security-updates-only: true
+        dependency-groups:
+          - name: go_modules group
+            rules:
+              patterns:
+                - "*"
         source:
             provider: github
             repo: dependabot/smoke-tests

--- a/tests/smoke-gradle-group-multidir.yaml
+++ b/tests/smoke-gradle-group-multidir.yaml
@@ -32,6 +32,11 @@ input:
               patched-versions: []
               unaffected-versions: []
         security-updates-only: true
+        dependency-groups:
+          - name: gradle group
+            rules:
+              patterns:
+                - "*"
         source:
             provider: github
             repo: dependabot/smoke-tests

--- a/tests/smoke-maven-group-multidir.yaml
+++ b/tests/smoke-maven-group-multidir.yaml
@@ -20,6 +20,11 @@ input:
               patched-versions: []
               unaffected-versions: []
         security-updates-only: true
+        dependency-groups:
+          - name: maven group
+            rules:
+              patterns:
+                - "*"
         source:
             provider: github
             repo: dependabot/smoke-tests

--- a/tests/smoke-npm-group-multidir.yaml
+++ b/tests/smoke-npm-group-multidir.yaml
@@ -38,6 +38,11 @@ input:
               patched-versions: []
               unaffected-versions: []
         security-updates-only: true
+        dependency-groups:
+          - name: npm_and_yarn group
+            rules:
+              patterns:
+                - "*"
         source:
             provider: github
             repo: dependabot/smoke-tests

--- a/tests/smoke-nuget-group-multidir.yaml
+++ b/tests/smoke-nuget-group-multidir.yaml
@@ -20,6 +20,11 @@ input:
               patched-versions: []
               unaffected-versions: []
         security-updates-only: true
+        dependency-groups:
+          - name: nuget group
+            rules:
+              patterns:
+                - "*"
         source:
             provider: github
             repo: dependabot/smoke-tests

--- a/tests/smoke-python-group-multidir.yaml
+++ b/tests/smoke-python-group-multidir.yaml
@@ -29,6 +29,11 @@ input:
               patched-versions: []
               unaffected-versions: []
         security-updates-only: true
+        dependency-groups:
+          - name: python group
+            rules:
+              patterns:
+                - "*"
         source:
             provider: github
             repo: dependabot/smoke-tests


### PR DESCRIPTION
In the current Core code these are created on-the-fly but now we want to be able to define them externally.