### PR TITLE
fix multidir definition input errors

### DIFF
--- a/tests/smoke-go-update-security-multidir.yaml
+++ b/tests/smoke-go-update-security-multidir.yaml
@@ -54,6 +54,7 @@ input:
             branch: main
             commit: fb37fe61a7462139c74f2fc7e80400b325d066a0
         updating-a-pull-request: true
+        dependency-group-to-refresh: go_modules group
         credentials-metadata:
             - host: github.com
               type: git_source

--- a/tests/smoke-python-group-multidir.yaml
+++ b/tests/smoke-python-group-multidir.yaml
@@ -30,7 +30,7 @@ input:
               unaffected-versions: []
         security-updates-only: true
         dependency-groups:
-          - name: python group
+          - name: pip group
             rules:
               patterns:
                 - "*"


### PR DESCRIPTION
follow on to #167

In tests/smoke-python-group-multidir.yaml I used the wrong group name.

In tests/smoke-go-update-security-multidir.yaml the test is technically invalid because it didn't specify the group to refresh.