### PR TITLE
Fix ignore condition for bundler group rules test

### DIFF
--- a/tests/smoke-bundler-group-rules.yaml
+++ b/tests/smoke-bundler-group-rules.yaml
@@ -16,7 +16,7 @@ input:
         ignore-conditions:
             - dependency-name: rubocop
               source: tests/smoke-bundler-group-rules.yaml
-              version-requirement: = 1.55.1
+              version-requirement: '>1.59.0'
         source:
             provider: github
             repo: dependabot/smoke-tests
@@ -25,9 +25,6 @@ input:
             hostname: github.com
             api-endpoint: https://api.github.com/
         commit-message-options: {}
-        credentials-metadata:
-            - host: github.com
-              type: git_source
         max-updater-run-time: 2700
     credentials:
         - host: github.com

--- a/tests/smoke-bundler-group-vendoring.yaml
+++ b/tests/smoke-bundler-group-vendoring.yaml
@@ -26,9 +26,6 @@ input:
             api-endpoint: https://api.github.com/
         vendor-dependencies: true
         commit-message-options: {}
-        credentials-metadata:
-            - host: github.com
-              type: git_source
         max-updater-run-time: 2700
     credentials:
         - host: github.com

--- a/tests/smoke-bundler.yaml
+++ b/tests/smoke-bundler.yaml
@@ -18,9 +18,6 @@ input:
             repo: dependabot/smoke-tests
             directory: /
             commit: 832e37c1a7a4ef89feb9dc7cfa06f62205191994
-        credentials-metadata:
-            - host: github.com
-              type: git_source
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN


### PR DESCRIPTION
So that we get more consistent results regardless of rubocop releases.