### PR TITLE
Fix regenerating smoke tests while keeping cache

### DIFF
--- a/script/run-one.sh
+++ b/script/run-one.sh
@@ -6,7 +6,7 @@ if [ "$2" = "--with-cache" ]
 then
   suite=$(echo "$1" | sed -e "s/^tests\/smoke-//" -e "s/\.yaml$//")
   rm -rf cache
-  source script/download-cache.sh $suite
+  script/download-cache.sh "$suite"
   dependabot test -f "$1" -o "$1" --cache cache
 else
   dependabot test -f "$1" -o "$1"


### PR DESCRIPTION
Using source to generate the cache makes the script exit too soon since the script is run in the same shell and explicitly uses `exit`.