### PR TITLE
update npm multidir based on new logic

### DIFF
--- a/tests/smoke-npm-group-multidir.yaml
+++ b/tests/smoke-npm-group-multidir.yaml
@@ -4,6 +4,11 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
+        dependency-groups:
+            - name: npm_and_yarn group
+              rules:
+                patterns:
+                    - '*'
         dependencies:
             - '@dependabot/dummy-pkg-a'
             - '@dependabot/dummy-pkg-b'
@@ -38,11 +43,6 @@ input:
               patched-versions: []
               unaffected-versions: []
         security-updates-only: true
-        dependency-groups:
-          - name: npm_and_yarn group
-            rules:
-              patterns:
-                - "*"
         source:
             provider: github
             repo: dependabot/smoke-tests
@@ -50,9 +50,6 @@ input:
                 - /npm/multi-dir/foo
                 - /npm/multi-dir/bar
             commit: b430c0e13597246f5e81d6c4adab35602c1ddf3d
-        credentials-metadata:
-            - host: github.com
-              type: git_source
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN
@@ -134,6 +131,11 @@ output:
                         type: registry
                         url: https://registry.npmjs.org
                   version: 1.3.0
+                - name: '@dependabot/dummy-pkg-a'
+                  previous-requirements: []
+                  previous-version: 1.1.0
+                  requirements: []
+                  version: 2.0.0
                 - name: left-pad
                   previous-requirements:
                     - file: package.json
@@ -269,6 +271,8 @@ output:
                 </details>
                 <br />
 
+                Updates `@dependabot/dummy-pkg-a` from 1.1.0 to 2.0.0
+
                 Updates `left-pad` from 1.0.0 to 1.3.0
                 <details>
                 <summary>Commits</summary>
@@ -290,6 +294,8 @@ output:
 
                 Updates `left-pad` from 1.0.0 to 1.3.0
                 - [Commits](https://github.com/stevemao/left-pad/commits/v1.3.0)
+
+                Updates `@dependabot/dummy-pkg-a` from 1.1.0 to 2.0.0
 
                 Updates `left-pad` from 1.0.0 to 1.3.0
                 - [Commits](https://github.com/stevemao/left-pad/commits/v1.3.0)


### PR DESCRIPTION
[Changes to the updater](https://github.com/dependabot/dependabot-core/pull/8803) means it now is picking up that the bump to dummy-pkg-b also bumped dummy-pkg-a since it has a dependency on it. 