### PR TITLE
cleanup test inputs

### DIFF
--- a/tests/smoke-bundler-group-multidir.yaml
+++ b/tests/smoke-bundler-group-multidir.yaml
@@ -38,6 +38,7 @@ input:
               patched-versions: []
               unaffected-versions: []
         security-updates-only: true
+        grouped-update: true
         dependency-groups:
           - name: bundler group
             rules:
@@ -50,9 +51,6 @@ input:
                 - /bundler/multi-dir/foo
                 - /bundler/multi-dir/bar
             commit: cd6542cb2b99fce3a1c506446e22e32d79d1b2b7
-        credentials-metadata:
-            - host: github.com
-              type: git_source
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN

--- a/tests/smoke-bundler-group-rules.yaml
+++ b/tests/smoke-bundler-group-rules.yaml
@@ -4,6 +4,7 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
+        grouped-update: true
         dependency-groups:
             - name: ruleset
               rules:

--- a/tests/smoke-bundler-group-vendoring.yaml
+++ b/tests/smoke-bundler-group-vendoring.yaml
@@ -4,6 +4,7 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
+        grouped-update: true
         dependency-groups:
             - name: ruleset
               rules:

--- a/tests/smoke-bundler-version-multidir.yaml
+++ b/tests/smoke-bundler-version-multidir.yaml
@@ -4,6 +4,7 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
+        grouped-update: true
         dependency-groups:
             - name: bundler_pkgs
               rules:
@@ -24,15 +25,10 @@ input:
         source:
             provider: github
             repo: dependabot/smoke-tests
-            directory: /
             directories:
                 - /bundler/multi-dir/foo
                 - /bundler/multi-dir/bar
-            branch: main
             commit: cd6542cb2b99fce3a1c506446e22e32d79d1b2b7
-        credentials-metadata:
-            - host: github.com
-              type: git_source
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN

--- a/tests/smoke-cargo-group-multidir.yaml
+++ b/tests/smoke-cargo-group-multidir.yaml
@@ -41,6 +41,7 @@ input:
               patched-versions: []
               unaffected-versions: []
         security-updates-only: true
+        grouped-update: true
         dependency-groups:
           - name: cargo group
             rules:
@@ -53,9 +54,6 @@ input:
                 - /cargo/multi-dir/foo
                 - /cargo/multi-dir/bar
             commit: f5a4b0925beceaec208805533ac98637967df794
-        credentials-metadata:
-            - host: github.com
-              type: git_source
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN

--- a/tests/smoke-cargo-version-multidir.yaml
+++ b/tests/smoke-cargo-version-multidir.yaml
@@ -4,6 +4,7 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
+        grouped-update: true
         dependency-groups:
             - name: cargo_pkgs
               rules:
@@ -25,15 +26,11 @@ input:
         source:
             provider: github
             repo: dependabot/smoke-tests
-            directory: /
             directories:
                 - /cargo/multi-dir/foo
                 - /cargo/multi-dir/bar
             branch: main
             commit: f5a4b0925beceaec208805533ac98637967df794
-        credentials-metadata:
-            - host: github.com
-              type: git_source
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN

--- a/tests/smoke-docker-version-multidir.yaml
+++ b/tests/smoke-docker-version-multidir.yaml
@@ -3,6 +3,7 @@ input:
         package-manager: docker
         allowed-updates:
             - update-type: all
+        grouped-update: true
         dependency-groups:
             - name: dotnet-docker
               rules:
@@ -19,15 +20,11 @@ input:
         source:
             provider: github
             repo: dependabot/smoke-tests
-            directory: /
             directories:
                 - /docker/multi-dir/dotnet6/
                 - /docker/multi-dir/dotnet7/
             branch: main
             commit: ddc5e5b3b87ac2534d882168044bf970158b31bd
-        credentials-metadata:
-            - host: github.com
-              type: git_source
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN

--- a/tests/smoke-go-group-multidir.yaml
+++ b/tests/smoke-go-group-multidir.yaml
@@ -32,6 +32,7 @@ input:
               patched-versions: []
               unaffected-versions: []
         security-updates-only: true
+        grouped-update: true
         dependency-groups:
           - name: go_modules group
             rules:
@@ -44,9 +45,6 @@ input:
                 - /go/multi-dir/foo
                 - /go/multi-dir/bar
             commit: fb37fe61a7462139c74f2fc7e80400b325d066a0
-        credentials-metadata:
-            - host: github.com
-              type: git_source
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN

--- a/tests/smoke-go-group-rules.yaml
+++ b/tests/smoke-go-group-rules.yaml
@@ -4,6 +4,7 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
+        grouped-update: true
         dependency-groups:
             - name: ruleset
               rules:
@@ -33,9 +34,6 @@ input:
             repo: dependabot/smoke-tests
             directory: /go
             commit: d0f596d2e699a04cdbff5cfefcd4353d17534056
-        credentials-metadata:
-            - host: github.com
-              type: git_source
         max-updater-run-time: 2700
     credentials:
         - host: github.com

--- a/tests/smoke-go-group-security.yaml
+++ b/tests/smoke-go-group-security.yaml
@@ -4,6 +4,7 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
+        grouped-update: true
         dependency-groups:
             - name: go_modules group
               rules:

--- a/tests/smoke-go-version-multidir.yaml
+++ b/tests/smoke-go-version-multidir.yaml
@@ -4,6 +4,7 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
+        grouped-update: true
         dependency-groups:
             - name: go-pkgs
               rules:
@@ -26,15 +27,11 @@ input:
         source:
             provider: github
             repo: dependabot/smoke-tests
-            directory: /
             directories:
                 - /go/multi-dir/foo
                 - /go/multi-dir/bar
             branch: main
             commit: fb37fe61a7462139c74f2fc7e80400b325d066a0
-        credentials-metadata:
-            - host: github.com
-              type: git_source
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN

--- a/tests/smoke-gradle-group-multidir.yaml
+++ b/tests/smoke-gradle-group-multidir.yaml
@@ -32,6 +32,7 @@ input:
               patched-versions: []
               unaffected-versions: []
         security-updates-only: true
+        grouped-update: true
         dependency-groups:
           - name: gradle group
             rules:
@@ -44,9 +45,6 @@ input:
                 - /gradle/multi-dir/foo
                 - /gradle/multi-dir/bar
             commit: bdc8fd5e4980081b086bcfcb2c4746c43e4b789d
-        credentials-metadata:
-            - host: github.com
-              type: git_source
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN

--- a/tests/smoke-gradle-version-multidir.yaml
+++ b/tests/smoke-gradle-version-multidir.yaml
@@ -4,6 +4,7 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
+        grouped-update: true
         dependency-groups:
             - name: gradle_pkgs
               rules:
@@ -29,15 +30,11 @@ input:
         source:
             provider: github
             repo: dependabot/smoke-tests
-            directory: /
             directories:
                 - /gradle/multi-dir/foo
                 - /gradle/multi-dir/bar
             branch: main
             commit: bdc8fd5e4980081b086bcfcb2c4746c43e4b789d
-        credentials-metadata:
-            - host: github.com
-              type: git_source
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN

--- a/tests/smoke-maven-group-multidir.yaml
+++ b/tests/smoke-maven-group-multidir.yaml
@@ -20,6 +20,7 @@ input:
               patched-versions: []
               unaffected-versions: []
         security-updates-only: true
+        grouped-update: true
         dependency-groups:
           - name: maven group
             rules:
@@ -32,9 +33,6 @@ input:
                 - /maven/multi-dir/foo
                 - /maven/multi-dir/bar
             commit: 56600671ab2495ed67614624740292fb5d54e4f4
-        credentials-metadata:
-            - host: github.com
-              type: git_source
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN

--- a/tests/smoke-maven-version-multidir.yaml
+++ b/tests/smoke-maven-version-multidir.yaml
@@ -4,6 +4,7 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
+        grouped-update: true
         dependency-groups:
             - name: maven_pkgs
               rules:
@@ -19,15 +20,11 @@ input:
         source:
             provider: github
             repo: dependabot/smoke-tests
-            directory: /
             directories:
                 - /maven/multi-dir/foo
                 - /maven/multi-dir/bar
             branch: main
             commit: 56600671ab2495ed67614624740292fb5d54e4f4
-        credentials-metadata:
-            - host: github.com
-              type: git_source
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN

--- a/tests/smoke-npm-group-multidir.yaml
+++ b/tests/smoke-npm-group-multidir.yaml
@@ -4,6 +4,7 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
+        grouped-update: true
         dependency-groups:
             - name: npm_and_yarn group
               rules:

--- a/tests/smoke-npm-group-multiple.yaml
+++ b/tests/smoke-npm-group-multiple.yaml
@@ -3,6 +3,7 @@ input:
         package-manager: npm_and_yarn
         allowed-updates:
             - update-type: all
+        grouped-update: true
         dependency-groups:
             - name: patch
               rules:
@@ -23,8 +24,6 @@ input:
                 update-types:
                     - major
         experiments:
-            grouped-updates-experimental-rules: true
-            grouped-updates-prototype: true
             record-ecosystem-versions: true
         ignore-conditions:
             - dependency-name: none
@@ -33,9 +32,6 @@ input:
             repo: dependabot/smoke-tests
             directory: /npm/angular
             commit: 6cc5e623c6cb8284ce363010c05690f4661164dd
-        credentials-metadata:
-            - host: github.com
-              type: git_source
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN

--- a/tests/smoke-npm-group-rules.yaml
+++ b/tests/smoke-npm-group-rules.yaml
@@ -3,6 +3,7 @@ input:
         package-manager: npm_and_yarn
         allowed-updates:
             - update-type: all
+        grouped-update: true
         dependency-groups:
             - name: ruleset
               rules:
@@ -11,7 +12,6 @@ input:
                     - fetch-factory
                     - lodash
         experiments:
-            grouped-updates-prototype: true
             record-ecosystem-versions: true
         ignore-conditions:
             - dependency-name: axios
@@ -31,9 +31,6 @@ input:
             repo: dependabot/smoke-tests
             directory: /npm
             commit: d15ce2f331fa91f5ebb82da530dc7f3d69c64e6e
-        credentials-metadata:
-            - host: github.com
-              type: git_source
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN

--- a/tests/smoke-npm-group-semver.yaml
+++ b/tests/smoke-npm-group-semver.yaml
@@ -3,6 +3,7 @@ input:
         package-manager: npm_and_yarn
         allowed-updates:
             - update-type: all
+        grouped-update: true
         dependency-groups:
             - name: not major
               rules:
@@ -20,9 +21,6 @@ input:
             repo: dependabot/smoke-tests
             directory: /npm/semver
             commit: deb769e795beb877414bdc5aea2df16d4ff8d4df
-        credentials-metadata:
-            - host: github.com
-              type: git_source
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN

--- a/tests/smoke-npm-group-transitive.yaml
+++ b/tests/smoke-npm-group-transitive.yaml
@@ -3,13 +3,13 @@ input:
         package-manager: npm_and_yarn
         allowed-updates:
             - update-type: indirect
+        grouped-update: true
         dependency-groups:
             - name: ruleset
               rules:
                 patterns:
                     - '@hapi/*'
         experiments:
-            grouped-updates-prototype: true
             record-ecosystem-versions: true
         ignore-conditions:
             - dependency-name: '@hapi/hoek'
@@ -32,9 +32,6 @@ input:
             repo: dependabot/smoke-tests
             directory: /npm/transitive
             commit: dde3e21e99b5237377d6e8a4858615e293bfacc4
-        credentials-metadata:
-            - host: github.com
-              type: git_source
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN

--- a/tests/smoke-npm-version-multidir.yaml
+++ b/tests/smoke-npm-version-multidir.yaml
@@ -4,6 +4,7 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
+        grouped-update: true
         dependency-groups:
             - name: npm_pkgs
               rules:
@@ -24,15 +25,10 @@ input:
         source:
             provider: github
             repo: dependabot/smoke-tests
-            directory: /
             directories:
                 - /npm/multi-dir/foo
                 - /npm/multi-dir/bar
-            branch: main
             commit: b430c0e13597246f5e81d6c4adab35602c1ddf3d
-        credentials-metadata:
-            - host: github.com
-              type: git_source
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN

--- a/tests/smoke-nuget-group-multidir.yaml
+++ b/tests/smoke-nuget-group-multidir.yaml
@@ -4,6 +4,7 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
+        grouped-update: true
         dependency-groups:
             - name: nuget group
               rules:

--- a/tests/smoke-nuget-version-multidir.yaml
+++ b/tests/smoke-nuget-version-multidir.yaml
@@ -4,6 +4,7 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
+        grouped-update: true
         dependency-groups:
             - name: nuget_pkgs
               rules:
@@ -19,7 +20,6 @@ input:
         source:
             provider: github
             repo: dependabot/smoke-tests
-            directory: /
             directories:
                 - /nuget/multi-dir/foo
                 - /nuget/multi-dir/bar

--- a/tests/smoke-python-group-multidir.yaml
+++ b/tests/smoke-python-group-multidir.yaml
@@ -29,6 +29,7 @@ input:
               patched-versions: []
               unaffected-versions: []
         security-updates-only: true
+        grouped-update: true
         dependency-groups:
           - name: pip group
             rules:
@@ -41,9 +42,6 @@ input:
                 - /pip/multi-dir/foo
                 - /pip/multi-dir/bar
             commit: 7b8e1971f18f6a47430796ec0e430e005d2d97f3
-        credentials-metadata:
-            - host: github.com
-              type: git_source
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN

--- a/tests/smoke-python-version-multidir.yaml
+++ b/tests/smoke-python-version-multidir.yaml
@@ -4,6 +4,7 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
+        grouped-update: true
         dependency-groups:
             - name: python_pkgs
               rules:
@@ -24,7 +25,6 @@ input:
         source:
             provider: github
             repo: dependabot/smoke-tests
-            directory: /
             directories:
                 - /pip/multi-dir/foo
                 - /pip/multi-dir/bar


### PR DESCRIPTION
The cleanup involved:
- Setting `grouped-update: true` for all grouped updates
- Removing the unused `credentials-metadata`
- Removing `directory` for multi-dir tests
- Removing unused experiments