### PR TITLE
remove most multidir test groups

### DIFF
--- a/tests/smoke-bundler-group-multidir.yaml
+++ b/tests/smoke-bundler-group-multidir.yaml
@@ -39,11 +39,6 @@ input:
               unaffected-versions: []
         security-updates-only: true
         grouped-update: true
-        dependency-groups:
-          - name: bundler group
-            rules:
-              patterns:
-                - "*"
         source:
             provider: github
             repo: dependabot/smoke-tests

--- a/tests/smoke-cargo-group-multidir.yaml
+++ b/tests/smoke-cargo-group-multidir.yaml
@@ -42,11 +42,6 @@ input:
               unaffected-versions: []
         security-updates-only: true
         grouped-update: true
-        dependency-groups:
-          - name: cargo group
-            rules:
-              patterns:
-                - "*"
         source:
             provider: github
             repo: dependabot/smoke-tests

--- a/tests/smoke-go-group-multidir.yaml
+++ b/tests/smoke-go-group-multidir.yaml
@@ -29,6 +29,7 @@ input:
         grouped-update: true
         dependency-groups:
           - name: go_modules group
+            applies-to: security-updates
             rules:
               patterns:
                 - rsc.io/qr

--- a/tests/smoke-go-update-security-multidir.yaml
+++ b/tests/smoke-go-update-security-multidir.yaml
@@ -39,11 +39,6 @@ input:
               patched-versions: []
               unaffected-versions: []
         security-updates-only: true
-        dependency-groups:
-          - name: go_modules group
-            rules:
-              patterns:
-                - "*"
         source:
             provider: github
             repo: dependabot/smoke-tests

--- a/tests/smoke-maven-group-multidir.yaml
+++ b/tests/smoke-maven-group-multidir.yaml
@@ -21,11 +21,6 @@ input:
               unaffected-versions: []
         security-updates-only: true
         grouped-update: true
-        dependency-groups:
-          - name: maven group
-            rules:
-              patterns:
-                - "*"
         source:
             provider: github
             repo: dependabot/smoke-tests

--- a/tests/smoke-npm-group-multidir.yaml
+++ b/tests/smoke-npm-group-multidir.yaml
@@ -5,11 +5,6 @@ input:
             - dependency-type: direct
               update-type: all
         grouped-update: true
-        dependency-groups:
-            - name: npm_and_yarn group
-              rules:
-                patterns:
-                    - '*'
         dependencies:
             - '@dependabot/dummy-pkg-a'
             - '@dependabot/dummy-pkg-b'

--- a/tests/smoke-nuget-group-multidir.yaml
+++ b/tests/smoke-nuget-group-multidir.yaml
@@ -5,11 +5,6 @@ input:
             - dependency-type: direct
               update-type: all
         grouped-update: true
-        dependency-groups:
-            - name: nuget group
-              rules:
-                patterns:
-                    - '*'
         dependencies:
             - NuGet.Versioning
         ignore-conditions:

--- a/tests/smoke-python-group-multidir.yaml
+++ b/tests/smoke-python-group-multidir.yaml
@@ -30,11 +30,6 @@ input:
               unaffected-versions: []
         security-updates-only: true
         grouped-update: true
-        dependency-groups:
-          - name: pip group
-            rules:
-              patterns:
-                - "*"
         source:
             provider: github
             repo: dependabot/smoke-tests


### PR DESCRIPTION
In a previous change I added these groups to the multidir tests, but now we're creating default groups for security updates so it's not needed:
- https://github.com/dependabot/dependabot-core/pull/8742

And now in https://github.com/dependabot/dependabot-core/pull/9040 we're going to either need to remove these or set the `applies-to` field.

I'm removing most of them, but adding `applies-to` in `tests/smoke-go-group-multidir.yaml` since it's a more complex scenario.