### PR TITLE
found more invalid test inputs, align to recent changes

### DIFF
--- a/tests/smoke-actions.yaml
+++ b/tests/smoke-actions.yaml
@@ -5,6 +5,7 @@ input:
             - dependency-name: actions/setup-go
             - dependency-name: actions/setup-ruby
             - dependency-name: actions/setup-node
+        grouped-update: true
         dependency-groups:
             - name: setup
               rules:

--- a/tests/smoke-composer.yaml
+++ b/tests/smoke-composer.yaml
@@ -3,6 +3,7 @@ input:
         package-manager: composer
         allowed-updates:
             - update-type: all
+        grouped-update: true
         dependency-groups:
             - name: phpstan
               rules:

--- a/tests/smoke-go-update-security-multidir.yaml
+++ b/tests/smoke-go-update-security-multidir.yaml
@@ -39,6 +39,7 @@ input:
               patched-versions: []
               unaffected-versions: []
         security-updates-only: true
+        grouped-update: true
         source:
             provider: github
             repo: dependabot/smoke-tests

--- a/tests/smoke-go-update-version-multidir.yaml
+++ b/tests/smoke-go-update-version-multidir.yaml
@@ -4,6 +4,7 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
+        grouped-update: true
         dependency-groups:
             - name: go-pkgs
               rules:
@@ -39,7 +40,6 @@ input:
         source:
             provider: github
             repo: dependabot/smoke-tests
-            directory: /
             directories:
                 - /go/multi-dir/foo
                 - /go/multi-dir/bar


### PR DESCRIPTION
- All grouped updates must have `grouped-update: true`
- Either `directory` or `directories` must be specified, but not both!