### PR TITLE
fix broken smoke test

### DIFF
--- a/tests/smoke-bundler-version-multidir.yaml
+++ b/tests/smoke-bundler-version-multidir.yaml
@@ -148,7 +148,7 @@ output:
                           mini_portile2 (~> 2.8.2)
                           racc (~> 1.4)
                         racc (1.7.3)
-                        rack (2.2.8)
+                        rack (2.2.8.1)
                         rack-protection (3.1.0)
                           rack (~> 2.2, >= 2.2.4)
                         ruby2_keywords (0.0.5)


### PR DESCRIPTION
The test started failing 17 hours ago, no clear reason why except a new version of rack was released. I'll recache the test. 