### PR TITLE
removes the unused grouped-update boolean

### DIFF
--- a/tests/smoke-actions.yaml
+++ b/tests/smoke-actions.yaml
@@ -5,7 +5,6 @@ input:
             - dependency-name: actions/setup-go
             - dependency-name: actions/setup-ruby
             - dependency-name: actions/setup-node
-        grouped-update: true
         dependency-groups:
             - name: setup
               rules:

--- a/tests/smoke-bundler-group-multidir.yaml
+++ b/tests/smoke-bundler-group-multidir.yaml
@@ -38,7 +38,6 @@ input:
               patched-versions: []
               unaffected-versions: []
         security-updates-only: true
-        grouped-update: true
         source:
             provider: github
             repo: dependabot/smoke-tests

--- a/tests/smoke-bundler-group-rules.yaml
+++ b/tests/smoke-bundler-group-rules.yaml
@@ -4,7 +4,6 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
-        grouped-update: true
         dependency-groups:
             - name: ruleset
               rules:

--- a/tests/smoke-bundler-group-vendoring.yaml
+++ b/tests/smoke-bundler-group-vendoring.yaml
@@ -4,7 +4,6 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
-        grouped-update: true
         dependency-groups:
             - name: ruleset
               rules:

--- a/tests/smoke-bundler-version-multidir.yaml
+++ b/tests/smoke-bundler-version-multidir.yaml
@@ -4,7 +4,6 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
-        grouped-update: true
         dependency-groups:
             - name: bundler_pkgs
               rules:

--- a/tests/smoke-cargo-group-multidir.yaml
+++ b/tests/smoke-cargo-group-multidir.yaml
@@ -41,7 +41,6 @@ input:
               patched-versions: []
               unaffected-versions: []
         security-updates-only: true
-        grouped-update: true
         source:
             provider: github
             repo: dependabot/smoke-tests

--- a/tests/smoke-cargo-version-multidir.yaml
+++ b/tests/smoke-cargo-version-multidir.yaml
@@ -4,7 +4,6 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
-        grouped-update: true
         dependency-groups:
             - name: cargo_pkgs
               rules:

--- a/tests/smoke-composer.yaml
+++ b/tests/smoke-composer.yaml
@@ -3,7 +3,6 @@ input:
         package-manager: composer
         allowed-updates:
             - update-type: all
-        grouped-update: true
         dependency-groups:
             - name: phpstan
               rules:

--- a/tests/smoke-docker-version-multidir.yaml
+++ b/tests/smoke-docker-version-multidir.yaml
@@ -3,7 +3,6 @@ input:
         package-manager: docker
         allowed-updates:
             - update-type: all
-        grouped-update: true
         dependency-groups:
             - name: dotnet-docker
               rules:

--- a/tests/smoke-go-group-multidir.yaml
+++ b/tests/smoke-go-group-multidir.yaml
@@ -26,7 +26,6 @@ input:
               patched-versions: []
               unaffected-versions: []
         security-updates-only: true
-        grouped-update: true
         dependency-groups:
           - name: go_modules group
             applies-to: security-updates

--- a/tests/smoke-go-group-rules.yaml
+++ b/tests/smoke-go-group-rules.yaml
@@ -4,7 +4,6 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
-        grouped-update: true
         dependency-groups:
             - name: ruleset
               rules:

--- a/tests/smoke-go-group-security.yaml
+++ b/tests/smoke-go-group-security.yaml
@@ -4,7 +4,6 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
-        grouped-update: true
         dependencies:
             - rsc.io/quote
             - rsc.io/qr

--- a/tests/smoke-go-update-security-multidir.yaml
+++ b/tests/smoke-go-update-security-multidir.yaml
@@ -39,7 +39,6 @@ input:
               patched-versions: []
               unaffected-versions: []
         security-updates-only: true
-        grouped-update: true
         source:
             provider: github
             repo: dependabot/smoke-tests

--- a/tests/smoke-go-update-version-multidir.yaml
+++ b/tests/smoke-go-update-version-multidir.yaml
@@ -4,7 +4,6 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
-        grouped-update: true
         dependency-groups:
             - name: go-pkgs
               rules:

--- a/tests/smoke-go-version-multidir.yaml
+++ b/tests/smoke-go-version-multidir.yaml
@@ -4,7 +4,6 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
-        grouped-update: true
         dependency-groups:
             - name: go-pkgs
               rules:

--- a/tests/smoke-gradle-group-multidir.yaml
+++ b/tests/smoke-gradle-group-multidir.yaml
@@ -32,7 +32,6 @@ input:
               patched-versions: []
               unaffected-versions: []
         security-updates-only: true
-        grouped-update: true
         source:
             provider: github
             repo: dependabot/smoke-tests

--- a/tests/smoke-gradle-version-multidir.yaml
+++ b/tests/smoke-gradle-version-multidir.yaml
@@ -4,7 +4,6 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
-        grouped-update: true
         dependency-groups:
             - name: gradle_pkgs
               rules:

--- a/tests/smoke-maven-group-multidir.yaml
+++ b/tests/smoke-maven-group-multidir.yaml
@@ -4,7 +4,6 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
-        grouped-update: true
         dependencies:
             - org.springframework.boot:spring-boot-starter-parent
             - org.springframework.boot:spring-boot-starter-parent

--- a/tests/smoke-maven-version-multidir.yaml
+++ b/tests/smoke-maven-version-multidir.yaml
@@ -4,7 +4,6 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
-        grouped-update: true
         dependency-groups:
             - name: maven_pkgs
               rules:

--- a/tests/smoke-npm-group-multidir.yaml
+++ b/tests/smoke-npm-group-multidir.yaml
@@ -4,7 +4,6 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
-        grouped-update: true
         dependencies:
             - '@dependabot/dummy-pkg-a'
             - '@dependabot/dummy-pkg-b'

--- a/tests/smoke-npm-group-multiple.yaml
+++ b/tests/smoke-npm-group-multiple.yaml
@@ -3,7 +3,6 @@ input:
         package-manager: npm_and_yarn
         allowed-updates:
             - update-type: all
-        grouped-update: true
         dependency-groups:
             - name: patch
               rules:

--- a/tests/smoke-npm-group-rules.yaml
+++ b/tests/smoke-npm-group-rules.yaml
@@ -3,7 +3,6 @@ input:
         package-manager: npm_and_yarn
         allowed-updates:
             - update-type: all
-        grouped-update: true
         dependency-groups:
             - name: ruleset
               rules:

--- a/tests/smoke-npm-group-semver.yaml
+++ b/tests/smoke-npm-group-semver.yaml
@@ -3,7 +3,6 @@ input:
         package-manager: npm_and_yarn
         allowed-updates:
             - update-type: all
-        grouped-update: true
         dependency-groups:
             - name: not major
               rules:

--- a/tests/smoke-npm-group-transitive.yaml
+++ b/tests/smoke-npm-group-transitive.yaml
@@ -3,7 +3,6 @@ input:
         package-manager: npm_and_yarn
         allowed-updates:
             - update-type: indirect
-        grouped-update: true
         dependency-groups:
             - name: ruleset
               rules:

--- a/tests/smoke-npm-version-multidir.yaml
+++ b/tests/smoke-npm-version-multidir.yaml
@@ -4,7 +4,6 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
-        grouped-update: true
         dependency-groups:
             - name: npm_pkgs
               rules:

--- a/tests/smoke-nuget-group-multidir.yaml
+++ b/tests/smoke-nuget-group-multidir.yaml
@@ -4,7 +4,6 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
-        grouped-update: true
         dependencies:
             - NuGet.Versioning
             - NuGet.Versioning

--- a/tests/smoke-nuget-version-multidir.yaml
+++ b/tests/smoke-nuget-version-multidir.yaml
@@ -4,7 +4,6 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
-        grouped-update: true
         dependency-groups:
             - name: nuget_pkgs
               rules:

--- a/tests/smoke-python-group-multidir.yaml
+++ b/tests/smoke-python-group-multidir.yaml
@@ -29,7 +29,6 @@ input:
               patched-versions: []
               unaffected-versions: []
         security-updates-only: true
-        grouped-update: true
         source:
             provider: github
             repo: dependabot/smoke-tests

--- a/tests/smoke-python-version-multidir.yaml
+++ b/tests/smoke-python-version-multidir.yaml
@@ -4,7 +4,6 @@ input:
         allowed-updates:
             - dependency-type: direct
               update-type: all
-        grouped-update: true
         dependency-groups:
             - name: python_pkgs
               rules:


### PR DESCRIPTION
We decided that the Updater (dependabot-core) would decide if the update is grouped, so no need to pass a grouped-update flag from the API.