### PR TITLE
Allow `on` as a YAML key

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -19,3 +19,5 @@ rules:
     # We could downgrade the line length error to a warning, but for now it clutters the output too much.
     # max: 120
     # level: warning
+  truthy:
+    allowed-values: ['true', 'false', 'on']


### PR DESCRIPTION
The default values are `true` and `false`. Adding `on` to allow GitHub Actions workflow triggers to not flag.

| Before | After |
|--------|--------|
| https://github.com/dependabot/smoke-tests/pull/186 |https://github.com/dependabot/smoke-tests/pull/188 |
| <img width="1018" alt="image" src="https://github.com/dependabot/smoke-tests/assets/5278382/4a036f4a-a5ec-4403-8e42-3d954d475de9"> | <img width="970" alt="image" src="https://github.com/dependabot/smoke-tests/assets/5278382/16dfcbb8-4cfe-4a42-9e43-2718a8dffcc0"> | 