### PR TITLE
update nuget smoke test dependency files

### DIFF
--- a/tests/smoke-nuget-central-package-management.yaml
+++ b/tests/smoke-nuget-central-package-management.yaml
@@ -29,11 +29,6 @@ output:
                         - dependencies
                       requirement: 13.0.1
                       source: null
-                    - file: Directory.Packages.props
-                      groups:
-                        - dependencies
-                      requirement: 13.0.1
-                      source: null
                   version: 13.0.1
                 - name: Microsoft.CSharp
                   requirements: []
@@ -215,23 +210,9 @@ output:
                         - dependencies
                       requirement: 13.0.1
                       source: null
-                    - file: Directory.Packages.props
-                      groups:
-                        - dependencies
-                      requirement: 13.0.1
-                      source: null
                   previous-version: 13.0.1
                   requirements:
                     - file: project.csproj
-                      groups:
-                        - dependencies
-                      requirement: 13.0.3
-                      source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/newtonsoft.json/13.0.3/newtonsoft.json.nuspec
-                        source_url: null
-                        type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
-                    - file: Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 13.0.3

--- a/tests/smoke-nuget-potential-downgrade.yaml
+++ b/tests/smoke-nuget-potential-downgrade.yaml
@@ -39,20 +39,10 @@ output:
                         - dependencies
                       requirement: 17.6.3
                       source: null
-                    - file: Directory.Packages.props
-                      groups:
-                        - dependencies
-                      requirement: 17.6.3
-                      source: null
                   version: 17.6.3
                 - name: Microsoft.VisualStudio.Sdk.TestFramework
                   requirements:
                     - file: project.csproj
-                      groups:
-                        - dependencies
-                      requirement: 17.2.7
-                      source: null
-                    - file: Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 17.2.7
@@ -65,20 +55,10 @@ output:
                         - dependencies
                       requirement: 17.2.7
                       source: null
-                    - file: Directory.Packages.props
-                      groups:
-                        - dependencies
-                      requirement: 17.2.7
-                      source: null
                   version: 17.2.7
                 - name: Moq
                   requirements:
                     - file: project.csproj
-                      groups:
-                        - dependencies
-                      requirement: 4.18.2
-                      source: null
-                    - file: Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 4.18.2
@@ -91,20 +71,10 @@ output:
                         - dependencies
                       requirement: 2.5.0
                       source: null
-                    - file: Directory.Packages.props
-                      groups:
-                        - dependencies
-                      requirement: 2.5.0
-                      source: null
                   version: 2.5.0
                 - name: xunit
                   requirements:
                     - file: project.csproj
-                      groups:
-                        - dependencies
-                      requirement: 2.5.0
-                      source: null
-                    - file: Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 2.5.0
@@ -351,13 +321,8 @@ output:
                   requirements: []
                   version: 6.0.0
                 - name: Microsoft.VisualStudio.Shell.15.0
-                  requirements:
-                    - file: Directory.Packages.props
-                      groups:
-                        - dependencies
-                      requirement: 17.6.36389
-                      source: null
-                  version: 17.6.36389
+                  requirements: []
+                  version: 17.2.32505.113
                 - name: Microsoft.VisualStudio.Shell.Framework
                   requirements: []
                   version: 17.2.32505.113
@@ -535,32 +500,6 @@ output:
                 - name: xunit.abstractions
                   requirements: []
                   version: 2.0.2
-                - name: Microsoft.VisualStudio.Text.Data
-                  requirements:
-                    - file: Directory.Packages.props
-                      groups:
-                        - dependencies
-                      requirement: 17.6.268
-                      source: null
-                  version: 17.6.268
-                - name: Microsoft.IO.Redist
-                  requirements: []
-                  version: 6.0.0
-                - name: System.Drawing.Common
-                  requirements: []
-                  version: 7.0.0
-                - name: Microsoft.Win32.SystemEvents
-                  requirements: []
-                  version: 7.0.0
-                - name: System.Security.Cryptography.ProtectedData
-                  requirements: []
-                  version: 7.0.0
-                - name: Microsoft.NET.StringTools
-                  requirements: []
-                  version: 17.4.0
-                - name: Microsoft.VisualStudio.CoreUtility
-                  requirements: []
-                  version: 17.6.268
             dependency_files:
                 - /nuget/potential-downgrade/project.csproj
                 - /nuget/potential-downgrade/Directory.Packages.props
@@ -577,23 +516,9 @@ output:
                         - dependencies
                       requirement: 17.2.7
                       source: null
-                    - file: Directory.Packages.props
-                      groups:
-                        - dependencies
-                      requirement: 17.2.7
-                      source: null
                   previous-version: 17.2.7
                   requirements:
                     - file: project.csproj
-                      groups:
-                        - dependencies
-                      requirement: 17.6.16
-                      source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/microsoft.visualstudio.sdk.testframework.xunit/17.6.16/microsoft.visualstudio.sdk.testframework.xunit.nuspec
-                        source_url: null
-                        type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
-                    - file: Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 17.6.16

--- a/tests/smoke-nuget-resolvability.yaml
+++ b/tests/smoke-nuget-resolvability.yaml
@@ -37,20 +37,10 @@ output:
                         - dependencies
                       requirement: 5.0.2
                       source: null
-                    - file: Directory.Packages.props
-                      groups:
-                        - dependencies
-                      requirement: 5.0.2
-                      source: null
                   version: 5.0.2
                 - name: Microsoft.Extensions.Diagnostics.HealthChecks
                   requirements:
                     - file: B/B.csproj
-                      groups:
-                        - dependencies
-                      requirement: 5.0.17
-                      source: null
-                    - file: Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 5.0.17
@@ -266,11 +256,6 @@ output:
                         - dependencies
                       requirement: 5.0.2
                       source: null
-                    - file: Directory.Packages.props
-                      groups:
-                        - dependencies
-                      requirement: 5.0.2
-                      source: null
                   previous-version: 5.0.2
                   requirements:
                     - file: A/A.csproj
@@ -291,15 +276,6 @@ output:
                         source_url: null
                         type: nuget_repo
                         url: https://api.nuget.org/v3/index.json
-                    - file: Directory.Packages.props
-                      groups:
-                        - dependencies
-                      requirement: 7.0.0
-                      source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/aspnetcore.healthchecks.rabbitmq/7.0.0/aspnetcore.healthchecks.rabbitmq.nuspec
-                        source_url: null
-                        type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
                   version: 7.0.0
                 - name: Microsoft.Extensions.Diagnostics.HealthChecks
                   previous-requirements:
@@ -308,23 +284,9 @@ output:
                         - dependencies
                       requirement: 5.0.17
                       source: null
-                    - file: Directory.Packages.props
-                      groups:
-                        - dependencies
-                      requirement: 5.0.17
-                      source: null
                   previous-version: 5.0.17
                   requirements:
                     - file: B/B.csproj
-                      groups:
-                        - dependencies
-                      requirement: 7.0.9
-                      source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics.healthchecks/7.0.9/microsoft.extensions.diagnostics.healthchecks.nuspec
-                        source_url: null
-                        type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
-                    - file: Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 7.0.9
@@ -459,23 +421,9 @@ output:
                         - dependencies
                       requirement: 5.0.17
                       source: null
-                    - file: Directory.Packages.props
-                      groups:
-                        - dependencies
-                      requirement: 5.0.17
-                      source: null
                   previous-version: 5.0.17
                   requirements:
                     - file: B/B.csproj
-                      groups:
-                        - dependencies
-                      requirement: 7.0.9
-                      source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics.healthchecks/7.0.9/microsoft.extensions.diagnostics.healthchecks.nuspec
-                        source_url: null
-                        type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
-                    - file: Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 7.0.9

--- a/tests/smoke-nuget-transitive-pinning.yaml
+++ b/tests/smoke-nuget-transitive-pinning.yaml
@@ -39,11 +39,6 @@ output:
                         - dependencies
                       requirement: 3.1.3
                       source: null
-                    - file: Directory.Packages.props
-                      groups:
-                        - dependencies
-                      requirement: 3.1.3
-                      source: null
                   version: 3.1.3
                 - name: Microsoft.Extensions.Logging.Abstractions
                   requirements: []


### PR DESCRIPTION
The file `Directory.Packages.props` is no longer explicitly listed as a dependency file.  This is due to the dependency ultimately needing to be declared in a `.csproj` file (or something imported by it) and it requires a value for the `<TargetFramework>` property, which a `Directory.Packages.props` file does not contain.

The resultant PR is still the same, though, and _may_ end up modifying the package version in `Directory.Packages.props`.

This corresponds to dependabot/dependabot-core#9347 and must be taken in parallel.