### PR TITLE
update smoke tests to reflect nuget updater changes

### DIFF
--- a/tests/smoke-nuget-central-package-management.yaml
+++ b/tests/smoke-nuget-central-package-management.yaml
@@ -24,12 +24,12 @@ output:
             dependencies:
                 - name: Newtonsoft.Json
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/central-package-management/project.csproj
                       groups:
                         - dependencies
                       requirement: 13.0.1
                       source: null
-                    - file: Directory.Packages.props
+                    - file: /nuget/central-package-management/Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 13.0.1
@@ -45,36 +45,32 @@ output:
             dependencies:
                 - name: Newtonsoft.Json
                   previous-requirements:
-                    - file: project.csproj
+                    - file: /nuget/central-package-management/project.csproj
                       groups:
                         - dependencies
                       requirement: 13.0.1
                       source: null
-                    - file: Directory.Packages.props
+                    - file: /nuget/central-package-management/Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 13.0.1
                       source: null
                   previous-version: 13.0.1
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/central-package-management/project.csproj
                       groups:
                         - dependencies
                       requirement: 13.0.3
                       source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/newtonsoft.json/13.0.3/newtonsoft.json.nuspec
-                        source_url: null
+                        source_url: https://github.com/JamesNK/Newtonsoft.Json
                         type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
-                    - file: Directory.Packages.props
+                    - file: /nuget/central-package-management/Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 13.0.3
                       source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/newtonsoft.json/13.0.3/newtonsoft.json.nuspec
-                        source_url: null
+                        source_url: https://github.com/JamesNK/Newtonsoft.Json
                         type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
                   version: 13.0.3
             updated-dependency-files:
                 - content: |-

--- a/tests/smoke-nuget-central-package-management.yaml
+++ b/tests/smoke-nuget-central-package-management.yaml
@@ -12,6 +12,8 @@ input:
             repo: dependabot/smoke-tests
             directory: /nuget/central-package-management
             commit: 7dbbef7b02f40ddfa7d32fc3099caf19f370bb9b
+        experiments:
+            nuget_native_analysis: true
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN

--- a/tests/smoke-nuget-compatible-version.yaml
+++ b/tests/smoke-nuget-compatible-version.yaml
@@ -27,7 +27,7 @@ output:
                   version: 2.0.3
                 - name: Microsoft.AspNetCore.Authentication.JwtBearer
                   requirements:
-                    - file: project/project.csproj
+                    - file: /nuget/compatible-version/project/project.csproj
                       groups:
                         - dependencies
                       requirement: 6.0.0
@@ -61,22 +61,20 @@ output:
             dependencies:
                 - name: Microsoft.AspNetCore.Authentication.JwtBearer
                   previous-requirements:
-                    - file: project/project.csproj
+                    - file: /nuget/compatible-version/project/project.csproj
                       groups:
                         - dependencies
                       requirement: 6.0.0
                       source: null
                   previous-version: 6.0.0
                   requirements:
-                    - file: project/project.csproj
+                    - file: /nuget/compatible-version/project/project.csproj
                       groups:
                         - dependencies
                       requirement: 6.0.25
                       source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.authentication.jwtbearer/6.0.25/microsoft.aspnetcore.authentication.jwtbearer.nuspec
-                        source_url: null
+                        source_url: https://github.com/dotnet/aspnetcore
                         type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
                   version: 6.0.25
             updated-dependency-files:
                 - content: |-

--- a/tests/smoke-nuget-compatible-version.yaml
+++ b/tests/smoke-nuget-compatible-version.yaml
@@ -12,6 +12,8 @@ input:
             repo: dependabot/smoke-tests
             directory: /nuget/compatible-version
             commit: 7dbbef7b02f40ddfa7d32fc3099caf19f370bb9b
+        experiments:
+            nuget_native_analysis: true
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN

--- a/tests/smoke-nuget-dirs-proj.yaml
+++ b/tests/smoke-nuget-dirs-proj.yaml
@@ -24,12 +24,12 @@ output:
             dependencies:
                 - name: NuGet.Versioning
                   requirements:
-                    - file: project1/project.csproj
+                    - file: /nuget/dirs-proj/project1/project.csproj
                       groups:
                         - dependencies
                       requirement: 6.1.0
                       source: null
-                    - file: project2/project.csproj
+                    - file: /nuget/dirs-proj/project2/project.csproj
                       groups:
                         - dependencies
                       requirement: 6.1.0
@@ -46,36 +46,32 @@ output:
             dependencies:
                 - name: NuGet.Versioning
                   previous-requirements:
-                    - file: project1/project.csproj
+                    - file: /nuget/dirs-proj/project1/project.csproj
                       groups:
                         - dependencies
                       requirement: 6.1.0
                       source: null
-                    - file: project2/project.csproj
+                    - file: /nuget/dirs-proj/project2/project.csproj
                       groups:
                         - dependencies
                       requirement: 6.1.0
                       source: null
                   previous-version: 6.1.0
                   requirements:
-                    - file: project1/project.csproj
+                    - file: /nuget/dirs-proj/project1/project.csproj
                       groups:
                         - dependencies
                       requirement: 6.8.0
                       source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/nuget.versioning/6.8.0/nuget.versioning.nuspec
-                        source_url: null
+                        source_url: https://github.com/NuGet/NuGet.Client
                         type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
-                    - file: project2/project.csproj
+                    - file: /nuget/dirs-proj/project2/project.csproj
                       groups:
                         - dependencies
                       requirement: 6.8.0
                       source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/nuget.versioning/6.8.0/nuget.versioning.nuspec
-                        source_url: null
+                        source_url: https://github.com/NuGet/NuGet.Client
                         type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
                   version: 6.8.0
             updated-dependency-files:
                 - content: |-

--- a/tests/smoke-nuget-dirs-proj.yaml
+++ b/tests/smoke-nuget-dirs-proj.yaml
@@ -12,6 +12,8 @@ input:
             repo: dependabot/smoke-tests
             directory: /nuget/dirs-proj
             commit: 7dbbef7b02f40ddfa7d32fc3099caf19f370bb9b
+        experiments:
+            nuget_native_analysis: true
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN

--- a/tests/smoke-nuget-group-multidir.yaml
+++ b/tests/smoke-nuget-group-multidir.yaml
@@ -5,11 +5,11 @@ input:
             - dependency-type: direct
               update-type: all
         dependency-groups:
-          - name: nuget
-            applies-to: security-updates
-            rules:
-              patterns:
-                - '*'
+            - name: nuget
+              applies-to: security-updates
+              rules:
+                patterns:
+                  - '*'
         dependencies:
             - NuGet.Versioning
             - NuGet.Versioning
@@ -46,7 +46,7 @@ output:
             dependencies:
                 - name: NuGet.Versioning
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/multi-dir/foo/project.csproj
                       groups:
                         - dependencies
                       requirement: 6.1.0
@@ -54,7 +54,7 @@ output:
                   version: 6.1.0
                 - name: NuGet.Versioning
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/multi-dir/bar/project.csproj
                       groups:
                         - dependencies
                       requirement: 6.2.2
@@ -70,41 +70,37 @@ output:
             dependencies:
                 - name: NuGet.Versioning
                   previous-requirements:
-                    - file: project.csproj
+                    - file: /nuget/multi-dir/foo/project.csproj
                       groups:
                         - dependencies
                       requirement: 6.1.0
                       source: null
                   previous-version: 6.1.0
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/multi-dir/foo/project.csproj
                       groups:
                         - dependencies
                       requirement: 6.2.4
                       source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/nuget.versioning/6.2.4/nuget.versioning.nuspec
-                        source_url: null
+                        source_url: https://github.com/NuGet/NuGet.Client
                         type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
                   version: 6.2.4
                 - name: NuGet.Versioning
                   previous-requirements:
-                    - file: project.csproj
+                    - file: /nuget/multi-dir/bar/project.csproj
                       groups:
                         - dependencies
                       requirement: 6.2.2
                       source: null
                   previous-version: 6.2.2
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/multi-dir/bar/project.csproj
                       groups:
                         - dependencies
                       requirement: 6.2.4
                       source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/nuget.versioning/6.2.4/nuget.versioning.nuspec
-                        source_url: null
+                        source_url: https://github.com/NuGet/NuGet.Client
                         type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
                   version: 6.2.4
             updated-dependency-files:
                 - content: |

--- a/tests/smoke-nuget-group-multidir.yaml
+++ b/tests/smoke-nuget-group-multidir.yaml
@@ -34,6 +34,8 @@ input:
                 - /nuget/multi-dir/foo
                 - /nuget/multi-dir/bar
             commit: 015a266f4472fe15631f6e0d77517e7a9d471023
+        experiments:
+            nuget_native_analysis: true
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN

--- a/tests/smoke-nuget-peer-dependencies.yaml
+++ b/tests/smoke-nuget-peer-dependencies.yaml
@@ -42,7 +42,7 @@ output:
                   version: 2.2.0
                 - name: Microsoft.Extensions.Http
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/peer-dependencies/project.csproj
                       groups:
                         - dependencies
                       requirement: 2.2.0
@@ -50,7 +50,7 @@ output:
                   version: 2.2.0
                 - name: Microsoft.Extensions.Logging
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/peer-dependencies/project.csproj
                       groups:
                         - dependencies
                       requirement: 2.2.0
@@ -74,41 +74,37 @@ output:
             dependencies:
                 - name: Microsoft.Extensions.Http
                   previous-requirements:
-                    - file: project.csproj
+                    - file: /nuget/peer-dependencies/project.csproj
                       groups:
                         - dependencies
                       requirement: 2.2.0
                       source: null
                   previous-version: 2.2.0
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/peer-dependencies/project.csproj
                       groups:
                         - dependencies
                       requirement: 8.0.0
                       source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/microsoft.extensions.http/8.0.0/microsoft.extensions.http.nuspec
-                        source_url: null
+                        source_url: https://github.com/dotnet/runtime
                         type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
                   version: 8.0.0
                 - name: Microsoft.Extensions.Logging
                   previous-requirements:
-                    - file: project.csproj
+                    - file: /nuget/peer-dependencies/project.csproj
                       groups:
                         - dependencies
                       requirement: 2.2.0
                       source: null
                   previous-version: 2.2.0
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/peer-dependencies/project.csproj
                       groups:
                         - dependencies
                       requirement: 8.0.0
                       source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging/8.0.0/microsoft.extensions.logging.nuspec
-                        source_url: null
+                        source_url: https://github.com/dotnet/runtime
                         type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
                   version: 8.0.0
             updated-dependency-files:
                 - content: |-
@@ -291,22 +287,20 @@ output:
             dependencies:
                 - name: Microsoft.Extensions.Logging
                   previous-requirements:
-                    - file: project.csproj
+                    - file: /nuget/peer-dependencies/project.csproj
                       groups:
                         - dependencies
                       requirement: 2.2.0
                       source: null
                   previous-version: 2.2.0
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/peer-dependencies/project.csproj
                       groups:
                         - dependencies
                       requirement: 8.0.0
                       source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging/8.0.0/microsoft.extensions.logging.nuspec
-                        source_url: null
+                        source_url: https://github.com/dotnet/runtime
                         type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
                   version: 8.0.0
             updated-dependency-files:
                 - content: |-

--- a/tests/smoke-nuget-peer-dependencies.yaml
+++ b/tests/smoke-nuget-peer-dependencies.yaml
@@ -18,6 +18,8 @@ input:
             repo: dependabot/smoke-tests
             directory: /nuget/peer-dependencies
             commit: 7dbbef7b02f40ddfa7d32fc3099caf19f370bb9b
+        experiments:
+            nuget_native_analysis: true
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN

--- a/tests/smoke-nuget-potential-downgrade.yaml
+++ b/tests/smoke-nuget-potential-downgrade.yaml
@@ -55,12 +55,12 @@ output:
                   version: 17.6.3
                 - name: Microsoft.NET.Test.Sdk
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/potential-downgrade/project.csproj
                       groups:
                         - dependencies
                       requirement: 17.6.3
                       source: null
-                    - file: Directory.Packages.props
+                    - file: /nuget/potential-downgrade/Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 17.6.3
@@ -122,12 +122,12 @@ output:
                   version: 16.10.10
                 - name: Microsoft.VisualStudio.Sdk.TestFramework
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/potential-downgrade/project.csproj
                       groups:
                         - dependencies
                       requirement: 17.2.7
                       source: null
-                    - file: Directory.Packages.props
+                    - file: /nuget/potential-downgrade/Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 17.2.7
@@ -135,12 +135,12 @@ output:
                   version: 17.2.7
                 - name: Microsoft.VisualStudio.Sdk.TestFramework.Xunit
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/potential-downgrade/project.csproj
                       groups:
                         - dependencies
                       requirement: 17.2.7
                       source: null
-                    - file: Directory.Packages.props
+                    - file: /nuget/potential-downgrade/Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 17.2.7
@@ -148,7 +148,7 @@ output:
                   version: 17.2.7
                 - name: Microsoft.VisualStudio.Shell.15.0
                   requirements:
-                    - file: Directory.Packages.props
+                    - file: /nuget/potential-downgrade/Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 17.6.36389
@@ -183,12 +183,12 @@ output:
                   version: 5.0.0
                 - name: Moq
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/potential-downgrade/project.csproj
                       groups:
                         - dependencies
                       requirement: 4.18.2
                       source: null
-                    - file: Directory.Packages.props
+                    - file: /nuget/potential-downgrade/Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 4.18.2
@@ -265,12 +265,12 @@ output:
                   version: 2.4.18
                 - name: xunit
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/potential-downgrade/project.csproj
                       groups:
                         - dependencies
                       requirement: 2.5.0
                       source: null
-                    - file: Directory.Packages.props
+                    - file: /nuget/potential-downgrade/Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 2.5.0
@@ -293,12 +293,12 @@ output:
                   version: 2.5.0
                 - name: xunit.runner.visualstudio
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/potential-downgrade/project.csproj
                       groups:
                         - dependencies
                       requirement: 2.5.0
                       source: null
-                    - file: Directory.Packages.props
+                    - file: /nuget/potential-downgrade/Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 2.5.0
@@ -309,7 +309,7 @@ output:
                   version: 1.4.13
                 - name: Microsoft.VisualStudio.Text.Data
                   requirements:
-                    - file: Directory.Packages.props
+                    - file: /nuget/potential-downgrade/Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 17.6.268
@@ -326,36 +326,32 @@ output:
             dependencies:
                 - name: Microsoft.VisualStudio.Sdk.TestFramework.Xunit
                   previous-requirements:
-                    - file: project.csproj
+                    - file: /nuget/potential-downgrade/project.csproj
                       groups:
                         - dependencies
                       requirement: 17.2.7
                       source: null
-                    - file: Directory.Packages.props
+                    - file: /nuget/potential-downgrade/Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 17.2.7
                       source: null
                   previous-version: 17.2.7
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/potential-downgrade/project.csproj
                       groups:
                         - dependencies
                       requirement: 17.6.16
                       source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/microsoft.visualstudio.sdk.testframework.xunit/17.6.16/microsoft.visualstudio.sdk.testframework.xunit.nuspec
-                        source_url: null
+                        source_url: https://github.com/microsoft/vssdktestfx
                         type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
-                    - file: Directory.Packages.props
+                    - file: /nuget/potential-downgrade/Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 17.6.16
                       source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/microsoft.visualstudio.sdk.testframework.xunit/17.6.16/microsoft.visualstudio.sdk.testframework.xunit.nuspec
-                        source_url: null
+                        source_url: https://github.com/microsoft/vssdktestfx
                         type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
                   version: 17.6.16
             updated-dependency-files:
                 - content: |

--- a/tests/smoke-nuget-potential-downgrade.yaml
+++ b/tests/smoke-nuget-potential-downgrade.yaml
@@ -22,6 +22,8 @@ input:
             repo: dependabot/smoke-tests
             directory: /nuget/potential-downgrade
             commit: c28157d6e1e0304bbde1ae81227f5a789033fe9d
+        experiments:
+            nuget_native_analysis: true
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN

--- a/tests/smoke-nuget-props-and-targets.yaml
+++ b/tests/smoke-nuget-props-and-targets.yaml
@@ -27,12 +27,12 @@ output:
             dependencies:
                 - name: NuGet.Versioning
                   requirements:
-                    - file: Directory.Build.props
+                    - file: /nuget/props-and-targets/Directory.Build.props
                       groups:
                         - dependencies
                       requirement: 6.1.0
                       source: null
-                    - file: project.csproj
+                    - file: /nuget/props-and-targets/project.csproj
                       groups:
                         - dependencies
                       requirement: 6.1.0
@@ -40,12 +40,12 @@ output:
                   version: 6.1.0
                 - name: Microsoft.CodeAnalysis.Analyzers
                   requirements:
-                    - file: Directory.Build.targets
+                    - file: /nuget/props-and-targets/Directory.Build.targets
                       groups:
                         - dependencies
                       requirement: 3.3.0
                       source: null
-                    - file: project.csproj
+                    - file: /nuget/props-and-targets/project.csproj
                       groups:
                         - dependencies
                       requirement: 3.3.0
@@ -62,36 +62,32 @@ output:
             dependencies:
                 - name: NuGet.Versioning
                   previous-requirements:
-                    - file: Directory.Build.props
+                    - file: /nuget/props-and-targets/Directory.Build.props
                       groups:
                         - dependencies
                       requirement: 6.1.0
                       source: null
-                    - file: project.csproj
+                    - file: /nuget/props-and-targets/project.csproj
                       groups:
                         - dependencies
                       requirement: 6.1.0
                       source: null
                   previous-version: 6.1.0
                   requirements:
-                    - file: Directory.Build.props
+                    - file: /nuget/props-and-targets/Directory.Build.props
                       groups:
                         - dependencies
                       requirement: 6.8.0
                       source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/nuget.versioning/6.8.0/nuget.versioning.nuspec
-                        source_url: null
+                        source_url: https://github.com/NuGet/NuGet.Client
                         type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
-                    - file: project.csproj
+                    - file: /nuget/props-and-targets/project.csproj
                       groups:
                         - dependencies
                       requirement: 6.8.0
                       source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/nuget.versioning/6.8.0/nuget.versioning.nuspec
-                        source_url: null
+                        source_url: https://github.com/NuGet/NuGet.Client
                         type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
                   version: 6.8.0
             updated-dependency-files:
                 - content: |-
@@ -137,36 +133,32 @@ output:
             dependencies:
                 - name: Microsoft.CodeAnalysis.Analyzers
                   previous-requirements:
-                    - file: Directory.Build.targets
+                    - file: /nuget/props-and-targets/Directory.Build.targets
                       groups:
                         - dependencies
                       requirement: 3.3.0
                       source: null
-                    - file: project.csproj
+                    - file: /nuget/props-and-targets/project.csproj
                       groups:
                         - dependencies
                       requirement: 3.3.0
                       source: null
                   previous-version: 3.3.0
                   requirements:
-                    - file: Directory.Build.targets
+                    - file: /nuget/props-and-targets/Directory.Build.targets
                       groups:
                         - dependencies
                       requirement: 3.3.4
                       source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.analyzers/3.3.4/microsoft.codeanalysis.analyzers.nuspec
-                        source_url: null
+                        source_url: https://github.com/dotnet/roslyn-analyzers
                         type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
-                    - file: project.csproj
+                    - file: /nuget/props-and-targets/project.csproj
                       groups:
                         - dependencies
                       requirement: 3.3.4
                       source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.analyzers/3.3.4/microsoft.codeanalysis.analyzers.nuspec
-                        source_url: null
+                        source_url: https://github.com/dotnet/roslyn-analyzers
                         type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
                   version: 3.3.4
             updated-dependency-files:
                 - content: |-

--- a/tests/smoke-nuget-props-and-targets.yaml
+++ b/tests/smoke-nuget-props-and-targets.yaml
@@ -15,6 +15,8 @@ input:
             repo: dependabot/smoke-tests
             directory: /nuget/props-and-targets
             commit: 7dbbef7b02f40ddfa7d32fc3099caf19f370bb9b
+        experiments:
+            nuget_native_analysis: true
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN

--- a/tests/smoke-nuget-resolvability.yaml
+++ b/tests/smoke-nuget-resolvability.yaml
@@ -27,17 +27,17 @@ output:
             dependencies:
                 - name: AspNetCore.HealthChecks.Rabbitmq
                   requirements:
-                    - file: A/A.csproj
+                    - file: /nuget/resolvability/A/A.csproj
                       groups:
                         - dependencies
                       requirement: 5.0.2
                       source: null
-                    - file: B/B.csproj
+                    - file: /nuget/resolvability/B/B.csproj
                       groups:
                         - dependencies
                       requirement: 5.0.2
                       source: null
-                    - file: Directory.Packages.props
+                    - file: /nuget/resolvability/Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 5.0.2
@@ -51,12 +51,12 @@ output:
                   version: 5.0.0
                 - name: Microsoft.Extensions.Diagnostics.HealthChecks
                   requirements:
-                    - file: B/B.csproj
+                    - file: /nuget/resolvability/B/B.csproj
                       groups:
                         - dependencies
                       requirement: 5.0.17
                       source: null
-                    - file: Directory.Packages.props
+                    - file: /nuget/resolvability/Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 5.0.17
@@ -94,83 +94,73 @@ output:
             dependencies:
                 - name: AspNetCore.HealthChecks.Rabbitmq
                   previous-requirements:
-                    - file: A/A.csproj
+                    - file: /nuget/resolvability/A/A.csproj
                       groups:
                         - dependencies
                       requirement: 5.0.2
                       source: null
-                    - file: B/B.csproj
+                    - file: /nuget/resolvability/B/B.csproj
                       groups:
                         - dependencies
                       requirement: 5.0.2
                       source: null
-                    - file: Directory.Packages.props
+                    - file: /nuget/resolvability/Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 5.0.2
                       source: null
                   previous-version: 5.0.2
                   requirements:
-                    - file: A/A.csproj
+                    - file: /nuget/resolvability/A/A.csproj
                       groups:
                         - dependencies
                       requirement: 7.0.0
                       source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/aspnetcore.healthchecks.rabbitmq/7.0.0/aspnetcore.healthchecks.rabbitmq.nuspec
-                        source_url: null
+                        source_url: https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks
                         type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
-                    - file: B/B.csproj
+                    - file: /nuget/resolvability/B/B.csproj
                       groups:
                         - dependencies
                       requirement: 7.0.0
                       source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/aspnetcore.healthchecks.rabbitmq/7.0.0/aspnetcore.healthchecks.rabbitmq.nuspec
-                        source_url: null
+                        source_url: https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks
                         type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
-                    - file: Directory.Packages.props
+                    - file: /nuget/resolvability/Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 7.0.0
                       source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/aspnetcore.healthchecks.rabbitmq/7.0.0/aspnetcore.healthchecks.rabbitmq.nuspec
-                        source_url: null
+                        source_url: https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks
                         type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
                   version: 7.0.0
                 - name: Microsoft.Extensions.Diagnostics.HealthChecks
                   previous-requirements:
-                    - file: B/B.csproj
+                    - file: /nuget/resolvability/B/B.csproj
                       groups:
                         - dependencies
                       requirement: 5.0.17
                       source: null
-                    - file: Directory.Packages.props
+                    - file: /nuget/resolvability/Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 5.0.17
                       source: null
                   previous-version: 5.0.17
                   requirements:
-                    - file: B/B.csproj
+                    - file: /nuget/resolvability/B/B.csproj
                       groups:
                         - dependencies
                       requirement: 7.0.9
                       source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics.healthchecks/7.0.9/microsoft.extensions.diagnostics.healthchecks.nuspec
-                        source_url: null
+                        source_url: https://github.com/dotnet/aspnetcore
                         type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
-                    - file: Directory.Packages.props
+                    - file: /nuget/resolvability/Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 7.0.9
                       source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics.healthchecks/7.0.9/microsoft.extensions.diagnostics.healthchecks.nuspec
-                        source_url: null
+                        source_url: https://github.com/dotnet/aspnetcore
                         type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
                   version: 7.0.9
             updated-dependency-files:
                 - content: |-
@@ -292,36 +282,32 @@ output:
             dependencies:
                 - name: Microsoft.Extensions.Diagnostics.HealthChecks
                   previous-requirements:
-                    - file: B/B.csproj
+                    - file: /nuget/resolvability/B/B.csproj
                       groups:
                         - dependencies
                       requirement: 5.0.17
                       source: null
-                    - file: Directory.Packages.props
+                    - file: /nuget/resolvability/Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 5.0.17
                       source: null
                   previous-version: 5.0.17
                   requirements:
-                    - file: B/B.csproj
+                    - file: /nuget/resolvability/B/B.csproj
                       groups:
                         - dependencies
                       requirement: 7.0.9
                       source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics.healthchecks/7.0.9/microsoft.extensions.diagnostics.healthchecks.nuspec
-                        source_url: null
+                        source_url: https://github.com/dotnet/aspnetcore
                         type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
-                    - file: Directory.Packages.props
+                    - file: /nuget/resolvability/Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 7.0.9
                       source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/microsoft.extensions.diagnostics.healthchecks/7.0.9/microsoft.extensions.diagnostics.healthchecks.nuspec
-                        source_url: null
+                        source_url: https://github.com/dotnet/aspnetcore
                         type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
                   version: 7.0.9
             updated-dependency-files:
                 - content: |-

--- a/tests/smoke-nuget-resolvability.yaml
+++ b/tests/smoke-nuget-resolvability.yaml
@@ -15,6 +15,8 @@ input:
             repo: dependabot/smoke-tests
             directory: /nuget/resolvability
             commit: 1204ab6852a4872bbb0ba4fff1343fefb39663d6
+        experiments:
+            nuget_native_analysis: true
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN

--- a/tests/smoke-nuget-sdk-implicit-deps.yaml
+++ b/tests/smoke-nuget-sdk-implicit-deps.yaml
@@ -40,7 +40,7 @@ output:
                   version: 5.0.0
                 - name: Mongo2Go
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/sdk-implicit-deps/project.csproj
                       groups:
                         - dependencies
                       requirement: 3.1.3

--- a/tests/smoke-nuget-sdk-implicit-deps.yaml
+++ b/tests/smoke-nuget-sdk-implicit-deps.yaml
@@ -22,6 +22,8 @@ input:
             repo: dependabot/smoke-tests
             directory: /nuget/sdk-implicit-deps
             commit: 7dbbef7b02f40ddfa7d32fc3099caf19f370bb9b
+        experiments:
+            nuget_native_analysis: true
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN

--- a/tests/smoke-nuget-transitive-pinning.yaml
+++ b/tests/smoke-nuget-transitive-pinning.yaml
@@ -40,12 +40,12 @@ output:
                   version: 5.0.0
                 - name: Mongo2Go
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/transitive-pinning/project.csproj
                       groups:
                         - dependencies
                       requirement: 3.1.3
                       source: null
-                    - file: Directory.Packages.props
+                    - file: /nuget/transitive-pinning/Directory.Packages.props
                       groups:
                         - dependencies
                       requirement: 3.1.3

--- a/tests/smoke-nuget-transitive-pinning.yaml
+++ b/tests/smoke-nuget-transitive-pinning.yaml
@@ -22,6 +22,8 @@ input:
             repo: dependabot/smoke-tests
             directory: /nuget/transitive-pinning
             commit: 7dbbef7b02f40ddfa7d32fc3099caf19f370bb9b
+        experiments:
+            nuget_native_analysis: true
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN

--- a/tests/smoke-nuget-version-multidir.yaml
+++ b/tests/smoke-nuget-version-multidir.yaml
@@ -47,7 +47,7 @@ output:
                   version: 2.2.0
                 - name: Microsoft.Extensions.Logging
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/multi-dir/foo/project.csproj
                       groups:
                         - dependencies
                       requirement: 2.2.0
@@ -64,7 +64,7 @@ output:
                   version: 2.2.0
                 - name: NuGet.Versioning
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/multi-dir/foo/project.csproj
                       groups:
                         - dependencies
                       requirement: 6.1.0
@@ -84,7 +84,7 @@ output:
                   version: 2.2.0
                 - name: Microsoft.Extensions.Http
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/multi-dir/bar/project.csproj
                       groups:
                         - dependencies
                       requirement: 2.2.0
@@ -104,7 +104,7 @@ output:
                   version: 2.2.0
                 - name: NuGet.Versioning
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/multi-dir/bar/project.csproj
                       groups:
                         - dependencies
                       requirement: 6.2.2
@@ -120,79 +120,71 @@ output:
             dependencies:
                 - name: Microsoft.Extensions.Logging
                   previous-requirements:
-                    - file: project.csproj
+                    - file: /nuget/multi-dir/foo/project.csproj
                       groups:
                         - dependencies
                       requirement: 2.2.0
                       source: null
                   previous-version: 2.2.0
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/multi-dir/foo/project.csproj
                       groups:
                         - dependencies
                       requirement: 8.0.0
                       source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging/8.0.0/microsoft.extensions.logging.nuspec
-                        source_url: null
+                        source_url: https://github.com/dotnet/runtime
                         type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
                   version: 8.0.0
                 - name: NuGet.Versioning
                   previous-requirements:
-                    - file: project.csproj
+                    - file: /nuget/multi-dir/foo/project.csproj
                       groups:
                         - dependencies
                       requirement: 6.1.0
                       source: null
                   previous-version: 6.1.0
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/multi-dir/foo/project.csproj
                       groups:
                         - dependencies
                       requirement: 6.8.0
                       source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/nuget.versioning/6.8.0/nuget.versioning.nuspec
-                        source_url: null
+                        source_url: https://github.com/NuGet/NuGet.Client
                         type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
                   version: 6.8.0
                 - name: NuGet.Versioning
                   previous-requirements:
-                    - file: project.csproj
+                    - file: /nuget/multi-dir/bar/project.csproj
                       groups:
                         - dependencies
                       requirement: 6.2.2
                       source: null
                   previous-version: 6.2.2
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/multi-dir/bar/project.csproj
                       groups:
                         - dependencies
                       requirement: 6.8.0
                       source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/nuget.versioning/6.8.0/nuget.versioning.nuspec
-                        source_url: null
+                        source_url: https://github.com/NuGet/NuGet.Client
                         type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
                   version: 6.8.0
                 - name: Microsoft.Extensions.Http
                   previous-requirements:
-                    - file: project.csproj
+                    - file: /nuget/multi-dir/bar/project.csproj
                       groups:
                         - dependencies
                       requirement: 2.2.0
                       source: null
                   previous-version: 2.2.0
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/multi-dir/bar/project.csproj
                       groups:
                         - dependencies
                       requirement: 8.0.0
                       source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/microsoft.extensions.http/8.0.0/microsoft.extensions.http.nuspec
-                        source_url: null
+                        source_url: https://github.com/dotnet/runtime
                         type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
                   version: 8.0.0
             updated-dependency-files:
                 - content: |

--- a/tests/smoke-nuget-version-multidir.yaml
+++ b/tests/smoke-nuget-version-multidir.yaml
@@ -23,6 +23,8 @@ input:
                 - /nuget/multi-dir/foo
                 - /nuget/multi-dir/bar
             commit: 2c4f15887b3829988403e4bbe7fcb4c222ad0f72
+        experiments:
+            nuget_native_analysis: true
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN

--- a/tests/smoke-nuget-version-property.yaml
+++ b/tests/smoke-nuget-version-property.yaml
@@ -27,7 +27,7 @@ output:
                   version: 2.0.3
                 - name: Newtonsoft.Json
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/version-property/project.csproj
                       groups:
                         - dependencies
                       metadata:
@@ -45,7 +45,7 @@ output:
             dependencies:
                 - name: Newtonsoft.Json
                   previous-requirements:
-                    - file: project.csproj
+                    - file: /nuget/version-property/project.csproj
                       groups:
                         - dependencies
                       metadata:
@@ -54,17 +54,15 @@ output:
                       source: null
                   previous-version: 13.0.1
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/version-property/project.csproj
                       groups:
                         - dependencies
                       metadata:
                         property_name: NewtonsoftJsonPackageVersion
                       requirement: 13.0.3
                       source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/newtonsoft.json/13.0.3/newtonsoft.json.nuspec
-                        source_url: null
+                        source_url: https://github.com/JamesNK/Newtonsoft.Json
                         type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
                   version: 13.0.3
             updated-dependency-files:
                 - content: |-

--- a/tests/smoke-nuget-version-property.yaml
+++ b/tests/smoke-nuget-version-property.yaml
@@ -12,6 +12,8 @@ input:
             repo: dependabot/smoke-tests
             directory: /nuget/version-property
             commit: 7dbbef7b02f40ddfa7d32fc3099caf19f370bb9b
+        experiments:
+            nuget_native_analysis: true
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN

--- a/tests/smoke-nuget.yaml
+++ b/tests/smoke-nuget.yaml
@@ -24,7 +24,7 @@ output:
             dependencies:
                 - name: NuGet.Versioning
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/project.csproj
                       groups:
                         - dependencies
                       requirement: 6.1.0
@@ -39,22 +39,20 @@ output:
             dependencies:
                 - name: NuGet.Versioning
                   previous-requirements:
-                    - file: project.csproj
+                    - file: /nuget/project.csproj
                       groups:
                         - dependencies
                       requirement: 6.1.0
                       source: null
                   previous-version: 6.1.0
                   requirements:
-                    - file: project.csproj
+                    - file: /nuget/project.csproj
                       groups:
                         - dependencies
                       requirement: 6.2.2
                       source:
-                        nuspec_url: https://api.nuget.org/v3-flatcontainer/nuget.versioning/6.2.2/nuget.versioning.nuspec
-                        source_url: null
+                        source_url: https://github.com/NuGet/NuGet.Client
                         type: nuget_repo
-                        url: https://api.nuget.org/v3/index.json
                   version: 6.2.2
             updated-dependency-files:
                 - content: |

--- a/tests/smoke-nuget.yaml
+++ b/tests/smoke-nuget.yaml
@@ -12,6 +12,8 @@ input:
             repo: dependabot/smoke-tests
             directory: /nuget
             commit: 832e37c1a7a4ef89feb9dc7cfa06f62205191994
+        experiments:
+            nuget_native_analysis: true
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN


### PR DESCRIPTION
The NuGet updater reports its dependencies slightly differently now, so this PR needs to be taken in lock-step with:
* dependabot/dependabot-core#10025

The first change is that the full path of the dependency files is reported.  This is necessary because it's entirely possible in a multi-directory update for each directory to have a file with the same name, e.g., `Directory.Build.props`.  The earlier behavior of only reporting the file name could result in ambiguities in which file actually contained the relevant dependencies.

The second change is that we no longer report `nuspec_url` for each dependency because that value was simply transformed via the Ruby code into a repo URL (or project or license URL, in that order) and then eventually reported as `source_url`.  I instead do all of that work in the C# tool using the official NuGet APIs and return that directly in the `source_url` field.