### PR TITLE
Updated the absolute versions as constraints, to raise the PR.

### DIFF
--- a/composer/composer.json
+++ b/composer/composer.json
@@ -1,10 +1,10 @@
 {
     "require": {
-        "phpmailer/phpmailer": "5.2.2"
+        "phpmailer/phpmailer": ">=5.2.2"
     },
     "require-dev": {
-        "phpstan/phpstan": "1.10.23",
-        "phpstan/phpstan-strict-rules": "1.5.0"
+        "phpstan/phpstan": ">=1.10.23",
+        "phpstan/phpstan-strict-rules": ">=1.5.0"
     },
     "repositories": [
         {


### PR DESCRIPTION
Composer.json is containing absolute version of the dependency, Here in this PR, it is updated to the version constraints. (So it can be updated by `composer update <dep-name>:<dep-version>`)

This is the fix for smoke test failure on [PR](https://github.com/dependabot/dependabot-core/actions/runs/9778266574/job/26994727400?pr=10119)

This test ensures after the changes below ignore conditions in tests/smoke-composer.yaml are respected by dependabot core.

```
  - dependency-name: phpstan/phpstan
    source: tests/smoke-composer.yaml
    version-requirement: '>1.10.25'
  - dependency-name: phpstan/phpstan-strict-rules
    source: tests/smoke-composer.yaml
    version-requirement: '>1.5.1'
  - dependency-name: phpmailer/phpmailer
    source: tests/smoke-composer.yaml
    version-requirement: '>6.8.0'
```

Expectation is:  With the above ignore condition in tests/smoke-composer.yaml, latest _available_version will be calculated. and so that dependabot will  update phpmailer/phpmailer to 6.8.0, and phpstan/phpstan to 1.10.25,

but phpstan/phpstan-strict-rules will fail as 1.5.1 is not the valid version

For example for phpmailer/phpmailer 
latest version from registry 6.9.1 (as per 03/07/2024)
latest available version 6.8.0 (as per above ignore condition)
so the dependabot core update checker will run 
```terminal
composer update  phpmailer/phpmailer:6.8.0
```
and find the latest_resolvable_version = 6.8.0
and file_updater will raise the PR for update from 5.2.2 (current version composer.json) to 6.8.0 (latest_resolvable_version)

similarly for phpstan/phpstan from 1.10.23 to 1.10.25

So I have updated input (composer.json) as per the expected result(tests/smoke-composer.yaml). 
FYI @abdulapopoola @jakecoffman @jurre 