### PR TITLE
Revert PR #212: Update Smoke Tests for Python Dependencies Versioning Strategy

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -4,7 +4,7 @@ name: Smoke
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
   pull_request:
-    branches: ["revert-212-kamil/update_smoke_test_for_updated_pip_increase_strategy"]
+    branches: ["main"]
   schedule:
     - cron: "0 * * * *"
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -4,7 +4,7 @@ name: Smoke
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
   pull_request:
-    branches: ["main"]
+    branches: ["revert-212-kamil/update_smoke_test_for_updated_pip_increase_strategy"]
   schedule:
     - cron: "0 * * * *"
 

--- a/tests/smoke-python-pip-compile.yaml
+++ b/tests/smoke-python-pip-compile.yaml
@@ -175,12 +175,12 @@ output:
                     - file: requirements.in
                       groups:
                         - dependencies
-                      requirement: '>=4.0.6,<5.0'
+                      requirement: '>=3.1,<5.0'
                       source: null
                   version: 4.0.6
             updated-dependency-files:
                 - content: |
-                    django>=4.0.6,<5.0
+                    django>=3.1,<5.0
                     numpy==1.23.0
                   content_encoding: utf-8
                   deleted: false

--- a/tests/smoke-python-pip.yaml
+++ b/tests/smoke-python-pip.yaml
@@ -84,12 +84,12 @@ output:
                     - file: requirements.txt
                       groups:
                         - dependencies
-                      requirement: '>=4.0.6,<5.0'
+                      requirement: '>=3.1,<5.0'
                       source: null
                   version: 4.0.6
             updated-dependency-files:
                 - content: |
-                    Django>=4.0.6,<5.0
+                    Django>=3.1,<5.0
                     requests
                     pyyaml
                     pytest
@@ -101,7 +101,7 @@ output:
                   operation: update
                   support_file: false
                   type: file
-            pr-title: Update django requirement from <4.0,>=3.1 to >=4.0.6,<5.0 in /pip
+            pr-title: Update django requirement from <4.0,>=3.1 to >=3.1,<5.0 in /pip
             pr-body: |
                 Updates the requirements on [django](https://github.com/django/django) to permit the latest version.
                 <details>
@@ -122,7 +122,7 @@ output:
                 </details>
                 <br />
             commit-message: |-
-                Update django requirement from <4.0,>=3.1 to >=4.0.6,<5.0 in /pip
+                Update django requirement from <4.0,>=3.1 to >=3.1,<5.0 in /pip
 
                 Updates the requirements on [django](https://github.com/django/django) to permit the latest version.
                 - [Commits](https://github.com/django/django/compare/3.1...4.0.6)


### PR DESCRIPTION
## Overview

This PR reverts the changes made in PR #212 that updated the smoke tests to match the revised "increase" versioning strategy for Python dependencies in Dependabot, as detailed in issue [#6631](https://github.com/dependabot/dependabot-core/issues/6631). The original update aligned the smoke tests with the changes introduced in Dependabot's main repository, which were reverted in PR #10194.

## Motivation

The changes in PR #212 were necessary to reflect the revised handling of version ranges in the pip ecosystem. However, due to the issues with the versioning strategy that prompted the revert of PR #10060, we need to revert the corresponding smoke tests to maintain consistency and ensure accurate testing.

## Issues Addressed

- Related to issue #6631 on incorrect version range behavior.
- Follows discussions from issue #6625 on dependency versioning.

## Special Notes

Reviewers should ensure that reverting these changes does not introduce any new issues and that the smoke tests continue to function correctly with the previous versioning strategy. This revert is to maintain consistency with the main repository's state post-revert of PR #10060.

## Verification

Smoke tests have been restored to their previous state and executed to confirm they pass and behave as expected with the original versioning strategy.