### PR TITLE
Add and update smoke tests for NuGet transitive dependency handling

### DIFF
--- a/nuget/top-level-only/dep-is-top-level/dep-is-top-level.csproj
+++ b/nuget/top-level-only/dep-is-top-level/dep-is-top-level.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- Newtonsoft.Json/12.0.1 is a top-level dependency and will be updated -->
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
+  </ItemGroup>
+</Project>

--- a/nuget/top-level-only/dep-is-transitive/dep-is-transitive.csproj
+++ b/nuget/top-level-only/dep-is-transitive/dep-is-transitive.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- Newtonsoft.Json/12.0.1 is a transitive dependency and will not be updated -->
+    <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
+  </ItemGroup>
+</Project>

--- a/nuget/top-level-only/top-level-only.sln
+++ b/nuget/top-level-only/top-level-only.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.35027.167
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dep-is-top-level", "dep-is-top-level\dep-is-top-level.csproj", "{4A3B8D8A-A585-4593-8AF3-DED05AE3C40F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dep-is-transitive", "dep-is-transitive\dep-is-transitive.csproj", "{271E533C-8A44-4572-8C18-CD65A79F8658}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4A3B8D8A-A585-4593-8AF3-DED05AE3C40F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4A3B8D8A-A585-4593-8AF3-DED05AE3C40F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4A3B8D8A-A585-4593-8AF3-DED05AE3C40F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4A3B8D8A-A585-4593-8AF3-DED05AE3C40F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{271E533C-8A44-4572-8C18-CD65A79F8658}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{271E533C-8A44-4572-8C18-CD65A79F8658}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{271E533C-8A44-4572-8C18-CD65A79F8658}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{271E533C-8A44-4572-8C18-CD65A79F8658}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {EE5BDEF7-1D4D-4773-9659-FC4A3846CD6D}
+	EndGlobalSection
+EndGlobal

--- a/tests/smoke-nuget-central-package-management.yaml
+++ b/tests/smoke-nuget-central-package-management.yaml
@@ -29,11 +29,15 @@ output:
                     - file: /nuget/central-package-management/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 13.0.1
                       source: null
                     - file: /nuget/central-package-management/Directory.Packages.props
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 13.0.1
                       source: null
                   version: 13.0.1
@@ -50,11 +54,17 @@ output:
                     - file: /nuget/central-package-management/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 13.0.1
                       requirement: 13.0.1
                       source: null
                     - file: /nuget/central-package-management/Directory.Packages.props
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 13.0.1
                       requirement: 13.0.1
                       source: null
                   previous-version: 13.0.1
@@ -62,6 +72,9 @@ output:
                     - file: /nuget/central-package-management/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 13.0.1
                       requirement: 13.0.3
                       source:
                         source_url: https://github.com/JamesNK/Newtonsoft.Json
@@ -69,6 +82,9 @@ output:
                     - file: /nuget/central-package-management/Directory.Packages.props
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 13.0.1
                       requirement: 13.0.3
                       source:
                         source_url: https://github.com/JamesNK/Newtonsoft.Json

--- a/tests/smoke-nuget-compatible-version.yaml
+++ b/tests/smoke-nuget-compatible-version.yaml
@@ -32,6 +32,8 @@ output:
                     - file: /nuget/compatible-version/project/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 6.0.0
                       source: null
                   version: 6.0.0
@@ -66,6 +68,9 @@ output:
                     - file: /nuget/compatible-version/project/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 6.0.0
                       requirement: 6.0.0
                       source: null
                   previous-version: 6.0.0
@@ -73,6 +78,9 @@ output:
                     - file: /nuget/compatible-version/project/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 6.0.0
                       requirement: 6.0.25
                       source:
                         source_url: https://github.com/dotnet/aspnetcore

--- a/tests/smoke-nuget-dirs-proj.yaml
+++ b/tests/smoke-nuget-dirs-proj.yaml
@@ -29,11 +29,15 @@ output:
                     - file: /nuget/dirs-proj/project1/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 6.1.0
                       source: null
                     - file: /nuget/dirs-proj/project2/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 6.1.0
                       source: null
                   version: 6.1.0
@@ -51,11 +55,17 @@ output:
                     - file: /nuget/dirs-proj/project1/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 6.1.0
                       requirement: 6.1.0
                       source: null
                     - file: /nuget/dirs-proj/project2/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 6.1.0
                       requirement: 6.1.0
                       source: null
                   previous-version: 6.1.0
@@ -63,6 +73,9 @@ output:
                     - file: /nuget/dirs-proj/project1/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 6.1.0
                       requirement: 6.8.0
                       source:
                         source_url: https://github.com/NuGet/NuGet.Client
@@ -70,6 +83,9 @@ output:
                     - file: /nuget/dirs-proj/project2/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 6.1.0
                       requirement: 6.8.0
                       source:
                         source_url: https://github.com/NuGet/NuGet.Client

--- a/tests/smoke-nuget-group-multidir.yaml
+++ b/tests/smoke-nuget-group-multidir.yaml
@@ -51,6 +51,8 @@ output:
                     - file: /nuget/multi-dir/foo/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 6.1.0
                       source: null
                   version: 6.1.0
@@ -59,6 +61,8 @@ output:
                     - file: /nuget/multi-dir/bar/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 6.2.2
                       source: null
                   version: 6.2.2
@@ -75,6 +79,9 @@ output:
                     - file: /nuget/multi-dir/foo/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 6.1.0
                       requirement: 6.1.0
                       source: null
                   previous-version: 6.1.0
@@ -82,6 +89,9 @@ output:
                     - file: /nuget/multi-dir/foo/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 6.1.0
                       requirement: 6.2.4
                       source:
                         source_url: https://github.com/NuGet/NuGet.Client
@@ -93,6 +103,9 @@ output:
                     - file: /nuget/multi-dir/bar/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 6.2.2
                       requirement: 6.2.2
                       source: null
                   previous-version: 6.2.2
@@ -100,6 +113,9 @@ output:
                     - file: /nuget/multi-dir/bar/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 6.2.2
                       requirement: 6.2.4
                       source:
                         source_url: https://github.com/NuGet/NuGet.Client

--- a/tests/smoke-nuget-peer-dependencies.yaml
+++ b/tests/smoke-nuget-peer-dependencies.yaml
@@ -47,6 +47,8 @@ output:
                     - file: /nuget/peer-dependencies/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 2.2.0
                       source: null
                   version: 2.2.0
@@ -55,6 +57,8 @@ output:
                     - file: /nuget/peer-dependencies/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 2.2.0
                       source: null
                   version: 2.2.0
@@ -79,6 +83,9 @@ output:
                     - file: /nuget/peer-dependencies/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 2.2.0
                       requirement: 2.2.0
                       source: null
                   previous-version: 2.2.0
@@ -86,6 +93,9 @@ output:
                     - file: /nuget/peer-dependencies/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 2.2.0
                       requirement: 8.0.0
                       source:
                         source_url: https://github.com/dotnet/runtime
@@ -97,6 +107,9 @@ output:
                     - file: /nuget/peer-dependencies/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 2.2.0
                       requirement: 2.2.0
                       source: null
                   previous-version: 2.2.0
@@ -104,6 +117,9 @@ output:
                     - file: /nuget/peer-dependencies/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 2.2.0
                       requirement: 8.0.0
                       source:
                         source_url: https://github.com/dotnet/runtime

--- a/tests/smoke-nuget-potential-downgrade.yaml
+++ b/tests/smoke-nuget-potential-downgrade.yaml
@@ -60,11 +60,15 @@ output:
                     - file: /nuget/potential-downgrade/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 17.6.3
                       source: null
                     - file: /nuget/potential-downgrade/Directory.Packages.props
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 17.6.3
                       source: null
                   version: 17.6.3
@@ -127,11 +131,15 @@ output:
                     - file: /nuget/potential-downgrade/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 17.2.7
                       source: null
                     - file: /nuget/potential-downgrade/Directory.Packages.props
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 17.2.7
                       source: null
                   version: 17.2.7
@@ -140,11 +148,15 @@ output:
                     - file: /nuget/potential-downgrade/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 17.2.7
                       source: null
                     - file: /nuget/potential-downgrade/Directory.Packages.props
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 17.2.7
                       source: null
                   version: 17.2.7
@@ -153,9 +165,11 @@ output:
                     - file: /nuget/potential-downgrade/Directory.Packages.props
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 17.6.36389
                       source: null
-                  version: 17.6.36389
+                  version: 17.2.32505.113
                 - name: Microsoft.VisualStudio.Shell.Framework
                   requirements: []
                   version: 17.2.32505.113
@@ -188,11 +202,15 @@ output:
                     - file: /nuget/potential-downgrade/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 4.18.2
                       source: null
                     - file: /nuget/potential-downgrade/Directory.Packages.props
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 4.18.2
                       source: null
                   version: 4.18.2
@@ -270,11 +288,15 @@ output:
                     - file: /nuget/potential-downgrade/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 2.5.0
                       source: null
                     - file: /nuget/potential-downgrade/Directory.Packages.props
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 2.5.0
                       source: null
                   version: 2.5.0
@@ -298,11 +320,15 @@ output:
                     - file: /nuget/potential-downgrade/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 2.5.0
                       source: null
                     - file: /nuget/potential-downgrade/Directory.Packages.props
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 2.5.0
                       source: null
                   version: 2.5.0
@@ -314,6 +340,8 @@ output:
                     - file: /nuget/potential-downgrade/Directory.Packages.props
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 17.6.268
                       source: null
                   version: 17.6.268
@@ -331,11 +359,17 @@ output:
                     - file: /nuget/potential-downgrade/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 17.2.7
                       requirement: 17.2.7
                       source: null
                     - file: /nuget/potential-downgrade/Directory.Packages.props
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 17.2.7
                       requirement: 17.2.7
                       source: null
                   previous-version: 17.2.7
@@ -343,6 +377,9 @@ output:
                     - file: /nuget/potential-downgrade/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 17.2.7
                       requirement: 17.6.16
                       source:
                         source_url: https://github.com/microsoft/vssdktestfx
@@ -350,6 +387,9 @@ output:
                     - file: /nuget/potential-downgrade/Directory.Packages.props
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 17.2.7
                       requirement: 17.6.16
                       source:
                         source_url: https://github.com/microsoft/vssdktestfx

--- a/tests/smoke-nuget-props-and-targets.yaml
+++ b/tests/smoke-nuget-props-and-targets.yaml
@@ -32,11 +32,15 @@ output:
                     - file: /nuget/props-and-targets/Directory.Build.props
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 6.1.0
                       source: null
                     - file: /nuget/props-and-targets/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 6.1.0
                       source: null
                   version: 6.1.0
@@ -45,11 +49,15 @@ output:
                     - file: /nuget/props-and-targets/Directory.Build.targets
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 3.3.0
                       source: null
                     - file: /nuget/props-and-targets/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 3.3.0
                       source: null
                   version: 3.3.0
@@ -67,11 +75,17 @@ output:
                     - file: /nuget/props-and-targets/Directory.Build.props
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 6.1.0
                       requirement: 6.1.0
                       source: null
                     - file: /nuget/props-and-targets/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 6.1.0
                       requirement: 6.1.0
                       source: null
                   previous-version: 6.1.0
@@ -79,6 +93,9 @@ output:
                     - file: /nuget/props-and-targets/Directory.Build.props
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 6.1.0
                       requirement: 6.8.0
                       source:
                         source_url: https://github.com/NuGet/NuGet.Client
@@ -86,6 +103,9 @@ output:
                     - file: /nuget/props-and-targets/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 6.1.0
                       requirement: 6.8.0
                       source:
                         source_url: https://github.com/NuGet/NuGet.Client
@@ -139,11 +159,17 @@ output:
                     - file: /nuget/props-and-targets/Directory.Build.targets
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 3.3.0
                       requirement: 3.3.0
                       source: null
                     - file: /nuget/props-and-targets/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 3.3.0
                       requirement: 3.3.0
                       source: null
                   previous-version: 3.3.0
@@ -151,6 +177,9 @@ output:
                     - file: /nuget/props-and-targets/Directory.Build.targets
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 3.3.0
                       requirement: 3.3.4
                       source:
                         source_url: https://github.com/dotnet/roslyn-analyzers
@@ -158,6 +187,9 @@ output:
                     - file: /nuget/props-and-targets/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 3.3.0
                       requirement: 3.3.4
                       source:
                         source_url: https://github.com/dotnet/roslyn-analyzers

--- a/tests/smoke-nuget-resolvability.yaml
+++ b/tests/smoke-nuget-resolvability.yaml
@@ -32,16 +32,22 @@ output:
                     - file: /nuget/resolvability/A/A.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 5.0.2
                       source: null
                     - file: /nuget/resolvability/B/B.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 5.0.2
                       source: null
                     - file: /nuget/resolvability/Directory.Packages.props
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 5.0.2
                       source: null
                   version: 5.0.2
@@ -56,14 +62,18 @@ output:
                     - file: /nuget/resolvability/B/B.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 5.0.17
                       source: null
                     - file: /nuget/resolvability/Directory.Packages.props
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 5.0.17
                       source: null
-                  version: 5.0.17
+                  version: 5.0.1
                 - name: Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions
                   requirements: []
                   version: 5.0.1
@@ -99,16 +109,25 @@ output:
                     - file: /nuget/resolvability/A/A.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 5.0.2
                       requirement: 5.0.2
                       source: null
                     - file: /nuget/resolvability/B/B.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 5.0.2
                       requirement: 5.0.2
                       source: null
                     - file: /nuget/resolvability/Directory.Packages.props
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 5.0.2
                       requirement: 5.0.2
                       source: null
                   previous-version: 5.0.2
@@ -116,6 +135,9 @@ output:
                     - file: /nuget/resolvability/A/A.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 5.0.2
                       requirement: 7.0.0
                       source:
                         source_url: https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks
@@ -123,6 +145,9 @@ output:
                     - file: /nuget/resolvability/B/B.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 5.0.2
                       requirement: 7.0.0
                       source:
                         source_url: https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks
@@ -130,6 +155,9 @@ output:
                     - file: /nuget/resolvability/Directory.Packages.props
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 5.0.2
                       requirement: 7.0.0
                       source:
                         source_url: https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks
@@ -141,18 +169,27 @@ output:
                     - file: /nuget/resolvability/B/B.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 5.0.17
                       requirement: 5.0.17
                       source: null
                     - file: /nuget/resolvability/Directory.Packages.props
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 5.0.17
                       requirement: 5.0.17
                       source: null
-                  previous-version: 5.0.17
+                  previous-version: 5.0.1
                   requirements:
                     - file: /nuget/resolvability/B/B.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 5.0.17
                       requirement: 7.0.9
                       source:
                         source_url: https://github.com/dotnet/aspnetcore
@@ -160,6 +197,9 @@ output:
                     - file: /nuget/resolvability/Directory.Packages.props
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 5.0.17
                       requirement: 7.0.9
                       source:
                         source_url: https://github.com/dotnet/aspnetcore
@@ -205,7 +245,7 @@ output:
                 </details>
                 <br />
 
-                Updates `Microsoft.Extensions.Diagnostics.HealthChecks` from 5.0.17 to 7.0.9
+                Updates `Microsoft.Extensions.Diagnostics.HealthChecks` from 5.0.1 to 7.0.9
                 <details>
                 <summary>Release notes</summary>
                 <p><em>Sourced from <a href="https://github.com/dotnet/aspnetcore/releases">Microsoft.Extensions.Diagnostics.HealthChecks's releases</a>.</em></p>
@@ -261,7 +301,7 @@ output:
                 <li><a href="https://github.com/dotnet/aspnetcore/commit/8804a1a835821e811e5532edb3716242f481b5d2"><code>8804a1a</code></a> Update branding to 7.0.9 (<a href="https://redirect.github.com/dotnet/aspnetcore/issues/48901">#48901</a>)</li>
                 <li><a href="https://github.com/dotnet/aspnetcore/commit/db6432162c83e94c0334b403f4a8a2b475a9160b"><code>db64321</code></a> Merged PR 31966: [internal/release/7.0] Merge from public</li>
                 <li><a href="https://github.com/dotnet/aspnetcore/commit/80034989d137b7f61735ce4e9a47a99ee79c2174"><code>8003498</code></a> [internal/release/7.0] Update dependencies from dnceng/internal/dotnet-efcore</li>
-                <li>Additional commits viewable in <a href="https://github.com/dotnet/aspnetcore/compare/v5.0.17...v7.0.9">compare view</a></li>
+                <li>Additional commits viewable in <a href="https://github.com/dotnet/aspnetcore/compare/v5.0.1...v7.0.9">compare view</a></li>
                 </ul>
                 </details>
                 <br />
@@ -275,10 +315,10 @@ output:
                 - [Changelog](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/blob/master/doc/ui-changelog.md)
                 - [Commits](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/commits/preview-all-7.0.0)
 
-                Updates `Microsoft.Extensions.Diagnostics.HealthChecks` from 5.0.17 to 7.0.9
+                Updates `Microsoft.Extensions.Diagnostics.HealthChecks` from 5.0.1 to 7.0.9
                 - [Release notes](https://github.com/dotnet/aspnetcore/releases)
                 - [Changelog](https://github.com/dotnet/aspnetcore/blob/main/docs/ReleasePlanning.md)
-                - [Commits](https://github.com/dotnet/aspnetcore/compare/v5.0.17...v7.0.9)
+                - [Commits](https://github.com/dotnet/aspnetcore/compare/v5.0.1...v7.0.9)
     - type: mark_as_processed
       expect:
         data:

--- a/tests/smoke-nuget-sdk-implicit-deps.yaml
+++ b/tests/smoke-nuget-sdk-implicit-deps.yaml
@@ -45,6 +45,8 @@ output:
                     - file: /nuget/sdk-implicit-deps/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 3.1.3
                       source: null
                   version: 3.1.3

--- a/tests/smoke-nuget-transitive-and-top-level-deps.yaml
+++ b/tests/smoke-nuget-transitive-and-top-level-deps.yaml
@@ -1,0 +1,187 @@
+input:
+    job:
+        package-manager: nuget
+        allowed-updates:
+            - update-type: all
+        experiments:
+            nuget_native_analysis: true
+        ignore-conditions:
+            - dependency-name: Newtonsoft.Json
+              source: tests/smoke-nuget-transitive-and-top-level-deps.yaml
+              version-requirement: '> 13.0.1'
+            - dependency-name: Newtonsoft.Json.Bson
+              source: tests/smoke-nuget-transitive-and-top-level-deps.yaml
+              version-requirement: '> 1.0.2'
+        source:
+            provider: github
+            repo: dependabot/smoke-tests
+            directory: /nuget/top-level-only
+            branch: dev/brettfo/nuget-transitive-and-top-level-deps
+            commit: 90338559e8356f5b588b2e7dff4a5ccdd9766240
+    credentials:
+        - host: github.com
+          password: $LOCAL_GITHUB_ACCESS_TOKEN
+          type: git_source
+          username: x-access-token
+output:
+    - type: update_dependency_list
+      expect:
+        data:
+            dependencies:
+                - name: Newtonsoft.Json
+                  requirements:
+                    - file: /nuget/top-level-only/dep-is-top-level/dep-is-top-level.csproj
+                      groups:
+                        - dependencies
+                      metadata:
+                        is_transitive: false
+                      requirement: 12.0.1
+                      source: null
+                  version: 12.0.1
+                - name: Newtonsoft.Json.Bson
+                  requirements:
+                    - file: /nuget/top-level-only/dep-is-top-level/dep-is-top-level.csproj
+                      groups:
+                        - dependencies
+                      metadata:
+                        is_transitive: false
+                      requirement: 1.0.2
+                      source: null
+                    - file: /nuget/top-level-only/dep-is-transitive/dep-is-transitive.csproj
+                      groups:
+                        - dependencies
+                      metadata:
+                        is_transitive: false
+                      requirement: 1.0.2
+                      source: null
+                  version: 1.0.2
+            dependency_files:
+                - /nuget/top-level-only/dep-is-top-level/dep-is-top-level.csproj
+                - /nuget/top-level-only/dep-is-transitive/dep-is-transitive.csproj
+    - type: create_pull_request
+      expect:
+        data:
+            base-commit-sha: 90338559e8356f5b588b2e7dff4a5ccdd9766240
+            dependencies:
+                - name: Newtonsoft.Json
+                  previous-requirements:
+                    - file: /nuget/top-level-only/dep-is-top-level/dep-is-top-level.csproj
+                      groups:
+                        - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 12.0.1
+                      requirement: 12.0.1
+                      source: null
+                  previous-version: 12.0.1
+                  requirements:
+                    - file: /nuget/top-level-only/dep-is-top-level/dep-is-top-level.csproj
+                      groups:
+                        - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 12.0.1
+                      requirement: 13.0.1
+                      source:
+                        source_url: https://github.com/JamesNK/Newtonsoft.Json
+                        type: nuget_repo
+                  version: 13.0.1
+                  directory: /nuget/top-level-only
+            updated-dependency-files:
+                - content: |-
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <!-- Newtonsoft.Json/12.0.1 is a top-level dependency and will be updated -->
+                        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+                        <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
+                      </ItemGroup>
+                    </Project>
+                  content_encoding: utf-8
+                  deleted: false
+                  directory: /nuget/top-level-only
+                  name: dep-is-top-level/dep-is-top-level.csproj
+                  operation: update
+                  support_file: false
+                  type: file
+            pr-title: Bump Newtonsoft.Json from 12.0.1 to 13.0.1 in /nuget/top-level-only
+            pr-body: |
+                Bumps [Newtonsoft.Json](https://github.com/JamesNK/Newtonsoft.Json) from 12.0.1 to 13.0.1.
+                <details>
+                <summary>Release notes</summary>
+                <p><em>Sourced from <a href="https://github.com/JamesNK/Newtonsoft.Json/releases">Newtonsoft.Json's releases</a>.</em></p>
+                <blockquote>
+                <h2>13.0.1</h2>
+                <ul>
+                <li>New feature - Add JsonSelectSettings with configuration for a regex timeout</li>
+                <li>Change - Remove portable assemblies from NuGet package</li>
+                <li>Change - JsonReader and JsonSerializer MaxDepth defaults to 64</li>
+                <li>Change - Change InvalidCastException to JsonSerializationException on mismatched JToken</li>
+                <li>Fix - Fixed throwing missing member error on ignored fields</li>
+                <li>Fix - Fixed various nullable annotations</li>
+                <li>Fix - Fixed annotations not being copied when tokens are cloned</li>
+                <li>Fix - Fixed naming strategy not being used when deserializing dictionary enum keys</li>
+                <li>Fix - Fixed serializing nullable struct dictionaries</li>
+                <li>Fix - Fixed JsonWriter.WriteToken to allow null with string token</li>
+                <li>Fix - Fixed missing error when deserializing JToken with a contract type mismatch</li>
+                <li>Fix - Fixed JTokenWriter when writing comment to an object</li>
+                </ul>
+                <h2>12.0.3</h2>
+                <ul>
+                <li>New feature - Added support for nullable reference types</li>
+                <li>New feature - Added KebabCaseNamingStrategy</li>
+                <li>Change - Package now uses embedded package icon</li>
+                <li>Fix - Fixed bug when merging JToken with itself</li>
+                <li>Fix - Fixed performance of calling ICustomTypeDescriptor.GetProperties</li>
+                <li>Fix - Fixed serializing Enumerable.Empty and empty arrays on .NET Core 3.0</li>
+                <li>Fix - Fixed deserializing some collection types with constructor</li>
+                <li>Fix - Fixed deserializing IImmutableSet to ImmutableHashSet instead of ImmutableSortedSet</li>
+                <li>Fix - Fixed deserializing IImmutableDictionary to ImmutableDictionary instead of ImmutableSortedDictionary</li>
+                <li>Fix - Fixed deserializing into constructors with more than 256 parameters</li>
+                <li>Fix - Fixed hang when deserializing JTokenReader with preceding comment</li>
+                <li>Fix - Fixed JSONPath scanning with nested indexer</li>
+                <li>Fix - Fixed deserializing incomplete JSON object to JObject</li>
+                <li>Fix - Fixed using StringEnumConverter with naming strategy and specified values</li>
+                </ul>
+                <h2>12.0.2</h2>
+                <ul>
+                <li>New feature - Added MissingMemberHandling to JsonObjectAttribute and JsonObjectContract</li>
+                <li>New feature - Added constructor to JTokenReader to specify initial path</li>
+                <li>New feature - Added JsonProperty.IsRequiredSpecified</li>
+                <li>New feature - Added JsonContract.InternalConverter</li>
+                <li>Change - Moved embedded debug symbols in NuGet package to a symbol package on NuGet.org</li>
+                <li>Fix - Fixed deserializing nullable struct collections</li>
+                <li>Fix - Fixed memory link when serializing enums to named values</li>
+                <li>Fix - Fixed error when setting JsonLoadSettings.DuplicatePropertyNameHandling to Replace</li>
+                </ul>
+                </blockquote>
+                </details>
+                <details>
+                <summary>Commits</summary>
+                <ul>
+                <li><a href="https://github.com/JamesNK/Newtonsoft.Json/commit/ae9fe44e1323e91bcbd185ca1a14099fba7c021f"><code>ae9fe44</code></a> Remove compiler package and update sourcelink (<a href="https://redirect.github.com/JamesNK/Newtonsoft.Json/issues/2498">#2498</a>)</li>
+                <li><a href="https://github.com/JamesNK/Newtonsoft.Json/commit/8ef662189dd7fc890c8fcd832d3e283edb90ef31"><code>8ef6621</code></a> Remove prerelease for 13.0.1</li>
+                <li><a href="https://github.com/JamesNK/Newtonsoft.Json/commit/11331f50fd1c09dc1f44fe17ef26aba7c460b42c"><code>11331f5</code></a> Update SDK to 5.0.200 (<a href="https://redirect.github.com/JamesNK/Newtonsoft.Json/issues/2495">#2495</a>)</li>
+                <li><a href="https://github.com/JamesNK/Newtonsoft.Json/commit/c7e8abc09de751785355e3f972150f8a72379b02"><code>c7e8abc</code></a> Update to 13.0.1-beta2</li>
+                <li><a href="https://github.com/JamesNK/Newtonsoft.Json/commit/1745d7c14ec7e4244a5ca1c7ddf5d955cf7d1f43"><code>1745d7c</code></a> Fix JTokenWriter when writing comment to an object (<a href="https://redirect.github.com/JamesNK/Newtonsoft.Json/issues/2493">#2493</a>)</li>
+                <li><a href="https://github.com/JamesNK/Newtonsoft.Json/commit/583eb120152f8b6332df2fe3d4b9f4c947c944d0"><code>583eb12</code></a> Fix missing error when deserializing JToken with a contract type mismatch (<a href="https://redirect.github.com/JamesNK/Newtonsoft.Json/issues/2">#2</a>...</li>
+                <li><a href="https://github.com/JamesNK/Newtonsoft.Json/commit/b6dc05be5a0f4808f06ec430f3bb59b24d3fbc3e"><code>b6dc05b</code></a> Change MaxDepth default to 64 (<a href="https://redirect.github.com/JamesNK/Newtonsoft.Json/issues/2473">#2473</a>)</li>
+                <li><a href="https://github.com/JamesNK/Newtonsoft.Json/commit/15525f1c44e0d99ef8fdee73430853e22239181d"><code>15525f1</code></a> Fix JsonWriter.WriteToken to allow null with string token (<a href="https://redirect.github.com/JamesNK/Newtonsoft.Json/issues/2472">#2472</a>)</li>
+                <li><a href="https://github.com/JamesNK/Newtonsoft.Json/commit/926d2f0f42292cfcdf07cdadeb501b73fd5b1d52"><code>926d2f0</code></a> Enable embed untracked sources (<a href="https://redirect.github.com/JamesNK/Newtonsoft.Json/issues/2471">#2471</a>)</li>
+                <li><a href="https://github.com/JamesNK/Newtonsoft.Json/commit/0a56633b6cd4fccc860a8486260ee67636f3fe90"><code>0a56633</code></a> Fixes <a href="https://redirect.github.com/JamesNK/Newtonsoft.Json/issues/2372">#2372</a> - variable typos (<a href="https://redirect.github.com/JamesNK/Newtonsoft.Json/issues/2465">#2465</a>)</li>
+                <li>Additional commits viewable in <a href="https://github.com/JamesNK/Newtonsoft.Json/compare/12.0.1...13.0.1">compare view</a></li>
+                </ul>
+                </details>
+                <br />
+            commit-message: |-
+                Bump Newtonsoft.Json from 12.0.1 to 13.0.1 in /nuget/top-level-only
+
+                Bumps [Newtonsoft.Json](https://github.com/JamesNK/Newtonsoft.Json) from 12.0.1 to 13.0.1.
+                - [Release notes](https://github.com/JamesNK/Newtonsoft.Json/releases)
+                - [Commits](https://github.com/JamesNK/Newtonsoft.Json/compare/12.0.1...13.0.1)
+    - type: mark_as_processed
+      expect:
+        data:
+            base-commit-sha: 90338559e8356f5b588b2e7dff4a5ccdd9766240

--- a/tests/smoke-nuget-transitive-pinning.yaml
+++ b/tests/smoke-nuget-transitive-pinning.yaml
@@ -45,11 +45,15 @@ output:
                     - file: /nuget/transitive-pinning/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 3.1.3
                       source: null
                     - file: /nuget/transitive-pinning/Directory.Packages.props
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 3.1.3
                       source: null
                   version: 3.1.3

--- a/tests/smoke-nuget-version-multidir.yaml
+++ b/tests/smoke-nuget-version-multidir.yaml
@@ -52,6 +52,8 @@ output:
                     - file: /nuget/multi-dir/foo/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 2.2.0
                       source: null
                   version: 2.2.0
@@ -69,6 +71,8 @@ output:
                     - file: /nuget/multi-dir/foo/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 6.1.0
                       source: null
                   version: 6.1.0
@@ -89,6 +93,8 @@ output:
                     - file: /nuget/multi-dir/bar/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 2.2.0
                       source: null
                   version: 2.2.0
@@ -109,6 +115,8 @@ output:
                     - file: /nuget/multi-dir/bar/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 6.2.2
                       source: null
                   version: 6.2.2
@@ -125,6 +133,9 @@ output:
                     - file: /nuget/multi-dir/foo/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 2.2.0
                       requirement: 2.2.0
                       source: null
                   previous-version: 2.2.0
@@ -132,6 +143,9 @@ output:
                     - file: /nuget/multi-dir/foo/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 2.2.0
                       requirement: 8.0.0
                       source:
                         source_url: https://github.com/dotnet/runtime
@@ -143,6 +157,9 @@ output:
                     - file: /nuget/multi-dir/foo/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 6.1.0
                       requirement: 6.1.0
                       source: null
                   previous-version: 6.1.0
@@ -150,6 +167,9 @@ output:
                     - file: /nuget/multi-dir/foo/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 6.1.0
                       requirement: 6.8.0
                       source:
                         source_url: https://github.com/NuGet/NuGet.Client
@@ -161,6 +181,9 @@ output:
                     - file: /nuget/multi-dir/bar/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 6.2.2
                       requirement: 6.2.2
                       source: null
                   previous-version: 6.2.2
@@ -168,6 +191,9 @@ output:
                     - file: /nuget/multi-dir/bar/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 6.2.2
                       requirement: 6.8.0
                       source:
                         source_url: https://github.com/NuGet/NuGet.Client
@@ -179,6 +205,9 @@ output:
                     - file: /nuget/multi-dir/bar/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 2.2.0
                       requirement: 2.2.0
                       source: null
                   previous-version: 2.2.0
@@ -186,6 +215,9 @@ output:
                     - file: /nuget/multi-dir/bar/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 2.2.0
                       requirement: 8.0.0
                       source:
                         source_url: https://github.com/dotnet/runtime

--- a/tests/smoke-nuget-version-property.yaml
+++ b/tests/smoke-nuget-version-property.yaml
@@ -33,6 +33,7 @@ output:
                       groups:
                         - dependencies
                       metadata:
+                        is_transitive: false
                         property_name: NewtonsoftJsonPackageVersion
                       requirement: 13.0.1
                       source: null
@@ -51,6 +52,8 @@ output:
                       groups:
                         - dependencies
                       metadata:
+                        is_transitive: false
+                        previous_requirement: 13.0.1
                         property_name: NewtonsoftJsonPackageVersion
                       requirement: 13.0.1
                       source: null
@@ -60,6 +63,8 @@ output:
                       groups:
                         - dependencies
                       metadata:
+                        is_transitive: false
+                        previous_requirement: 13.0.1
                         property_name: NewtonsoftJsonPackageVersion
                       requirement: 13.0.3
                       source:

--- a/tests/smoke-nuget.yaml
+++ b/tests/smoke-nuget.yaml
@@ -29,6 +29,8 @@ output:
                     - file: /nuget/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
                       requirement: 6.1.0
                       source: null
                   version: 6.1.0
@@ -44,6 +46,9 @@ output:
                     - file: /nuget/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 6.1.0
                       requirement: 6.1.0
                       source: null
                   previous-version: 6.1.0
@@ -51,6 +56,9 @@ output:
                     - file: /nuget/project.csproj
                       groups:
                         - dependencies
+                      metadata:
+                        is_transitive: false
+                        previous_requirement: 6.1.0
                       requirement: 6.2.2
                       source:
                         source_url: https://github.com/NuGet/NuGet.Client


### PR DESCRIPTION
This PR is in support of dependabot/dependabot-core#10449 and both will need to be merged at the same time.