### PR TITLE
Update maven test output

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -4,7 +4,7 @@ name: Smoke
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
   pull_request:
-    branches: ["main"]
+    branches: ["amazimbe/use-new-maven-version"]
   schedule:
     - cron: "0 * * * *"
 

--- a/tests/smoke-maven-group-multidir.yaml
+++ b/tests/smoke-maven-group-multidir.yaml
@@ -212,11 +212,11 @@ output:
                       groups: []
                       metadata:
                         packaging_type: pom
-                      requirement: 1.5.12.RELEASE
+                      requirement: 1.5.11.RELEASE
                       source:
                         type: maven_repo
                         url: https://repo.maven.apache.org/maven2
-                  version: 1.5.12.RELEASE
+                  version: 1.5.11.RELEASE
                   directory: /maven/multi-dir/foo
                 - name: org.springframework.boot:spring-boot-starter-parent
                   previous-requirements:
@@ -232,11 +232,11 @@ output:
                       groups: []
                       metadata:
                         packaging_type: pom
-                      requirement: 1.5.12.RELEASE
+                      requirement: 1.5.11.RELEASE
                       source:
                         type: maven_repo
                         url: https://repo.maven.apache.org/maven2
-                  version: 1.5.12.RELEASE
+                  version: 1.5.11.RELEASE
                   directory: /maven/multi-dir/bar
             updated-dependency-files:
                 - content: |
@@ -254,7 +254,7 @@ output:
                       <parent>
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-starter-parent</artifactId>
-                        <version>1.5.12.RELEASE</version>
+                        <version>1.5.11.RELEASE</version>
                         <relativePath /> <!-- lookup parent from repository -->
                       </parent>
 
@@ -327,7 +327,7 @@ output:
                       <parent>
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-starter-parent</artifactId>
-                        <version>1.5.12.RELEASE</version>
+                        <version>1.5.11.RELEASE</version>
                         <relativePath /> <!-- lookup parent from repository -->
                       </parent>
 
@@ -390,9 +390,9 @@ output:
                 Bumps the maven group with 1 update in the /maven/multi-dir/foo directory: org.springframework.boot:spring-boot-starter-parent.
                 Bumps the maven group with 1 update in the /maven/multi-dir/bar directory: org.springframework.boot:spring-boot-starter-parent.
 
-                Updates `org.springframework.boot:spring-boot-starter-parent` from 1.5.10.RELEASE to 1.5.12.RELEASE
+                Updates `org.springframework.boot:spring-boot-starter-parent` from 1.5.10.RELEASE to 1.5.11.RELEASE
 
-                Updates `org.springframework.boot:spring-boot-starter-parent` from 1.5.9.RELEASE to 1.5.12.RELEASE
+                Updates `org.springframework.boot:spring-boot-starter-parent` from 1.5.9.RELEASE to 1.5.11.RELEASE
             commit-message: |-
                 Bump the maven group across 2 directories with 1 update
 
@@ -400,9 +400,9 @@ output:
                 Bumps the maven group with 1 update in the /maven/multi-dir/bar directory: org.springframework.boot:spring-boot-starter-parent.
 
 
-                Updates `org.springframework.boot:spring-boot-starter-parent` from 1.5.10.RELEASE to 1.5.12.RELEASE
+                Updates `org.springframework.boot:spring-boot-starter-parent` from 1.5.10.RELEASE to 1.5.11.RELEASE
 
-                Updates `org.springframework.boot:spring-boot-starter-parent` from 1.5.9.RELEASE to 1.5.12.RELEASE
+                Updates `org.springframework.boot:spring-boot-starter-parent` from 1.5.9.RELEASE to 1.5.11.RELEASE
             dependency-group:
                 name: maven
     - type: mark_as_processed


### PR DESCRIPTION
Link to issue: https://github.com/dependabot/smoke-tests/issues/226

The updated test started failing after this change: https://github.com/dependabot/dependabot-core/pull/10558 and this PR updates the contents of the output section so that the tests pass again.