### PR TITLE
Revert "Revert "Bump version in maven security advisory""

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -4,7 +4,7 @@ name: Smoke
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
   pull_request:
-    branches: ["main"]
+    branches: ["revert-10647-revert-10558-amazimbe/use-new-maven-version"]
   schedule:
     - cron: "0 * * * *"
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -4,7 +4,7 @@ name: Smoke
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
   pull_request:
-    branches: ["revert-10647-revert-10558-amazimbe/use-new-maven-version"]
+    branches: ["main"]
   schedule:
     - cron: "0 * * * *"
 

--- a/tests/smoke-maven-group-multidir.yaml
+++ b/tests/smoke-maven-group-multidir.yaml
@@ -23,7 +23,7 @@ input:
         security-advisories:
             - dependency-name: org.springframework.boot:spring-boot-starter-parent
               affected-versions:
-                - < 1.5.11
+                - < 1.5.12
               patched-versions: []
               unaffected-versions: []
         security-updates-only: true


### PR DESCRIPTION
Reverts dependabot/smoke-tests#229

Link to issue: https://github.com/dependabot/smoke-tests/issues/226

I've made a change to how maven orders versions in this PR: https://github.com/dependabot/dependabot-core/pull/10558 . As a result, version 1.5.11 == 1.5.11.RELEASE . Before this change, this test passed because it erroneously concluded that 1.5.11.RELEASE < 1.5.11.