### PR TITLE
Update Smoke Tests for NPM 8 Fallback and Lockfile Version 3 with NPM 9

### DIFF
--- a/tests/smoke-npm-group-multidir.yaml
+++ b/tests/smoke-npm-group-multidir.yaml
@@ -14,6 +14,8 @@ input:
             - '@dependabot/dummy-pkg-a'
             - '@dependabot/dummy-pkg-b'
             - left-pad
+        experiments:
+            npm_fallback_version_above_v6: true
         ignore-conditions:
             - dependency-name: '@dependabot/dummy-pkg-b'
               source: tests/smoke-npm-group-multidir.yaml
@@ -67,9 +69,7 @@ output:
                       groups:
                         - dependencies
                       requirement: ^1.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   version: 1.0.0
                 - name: left-pad
                   requirements:
@@ -77,9 +77,7 @@ output:
                       groups:
                         - dependencies
                       requirement: ^1.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   version: 1.0.0
                 - name: '@dependabot/dummy-pkg-a'
                   requirements: []
@@ -90,9 +88,7 @@ output:
                       groups:
                         - dependencies
                       requirement: ^1.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   version: 1.0.0
                 - name: left-pad
                   requirements:
@@ -100,9 +96,7 @@ output:
                       groups:
                         - dependencies
                       requirement: ^1.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   version: 1.0.0
             dependency_files:
                 - /npm/multi-dir/foo/package.json
@@ -120,18 +114,14 @@ output:
                       groups:
                         - dependencies
                       requirement: ^1.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   previous-version: 1.0.0
                   requirements:
                     - file: package.json
                       groups:
                         - dependencies
                       requirement: ^1.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   version: 1.1.0
                   directory: /npm/multi-dir/foo
                 - name: left-pad
@@ -140,18 +130,14 @@ output:
                       groups:
                         - dependencies
                       requirement: ^1.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   previous-version: 1.0.0
                   requirements:
                     - file: package.json
                       groups:
                         - dependencies
                       requirement: ^1.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   version: 1.3.0
                   directory: /npm/multi-dir/foo
                 - name: '@dependabot/dummy-pkg-a'
@@ -166,18 +152,14 @@ output:
                       groups:
                         - dependencies
                       requirement: ^1.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   previous-version: 1.0.0
                   requirements:
                     - file: package.json
                       groups:
                         - dependencies
                       requirement: ^1.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   version: 1.3.0
                   directory: /npm/multi-dir/bar
                 - name: '@dependabot/dummy-pkg-a'
@@ -186,18 +168,14 @@ output:
                       groups:
                         - dependencies
                       requirement: ^1.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   previous-version: 1.0.0
                   requirements:
                     - file: package.json
                       groups:
                         - dependencies
                       requirement: ^1.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   version: 1.1.0
                   directory: /npm/multi-dir/bar
             updated-dependency-files:
@@ -205,36 +183,26 @@ output:
                     {
                       "name": "foo",
                       "version": "1.0.0",
-                      "lockfileVersion": 3,
+                      "lockfileVersion": 1,
                       "requires": true,
-                      "packages": {
-                        "": {
-                          "name": "foo",
-                          "version": "1.0.0",
-                          "license": "ISC",
-                          "dependencies": {
-                            "@dependabot/dummy-pkg-b": "^1.0.0",
-                            "left-pad": "^1.0.0"
-                          }
-                        },
-                        "node_modules/@dependabot/dummy-pkg-a": {
+                      "dependencies": {
+                        "@dependabot/dummy-pkg-a": {
                           "version": "2.0.0",
                           "resolved": "https://registry.npmjs.org/@dependabot/dummy-pkg-a/-/dummy-pkg-a-2.0.0.tgz",
                           "integrity": "sha512-kUkqhjyK+9PgJMiwoBrkfX7NTkZiw2s94gGnSRSP1ZFaoBqpwTuvQbZhDCa+mKPgpP5719qsW2YzuSK4RXhGAg=="
                         },
-                        "node_modules/@dependabot/dummy-pkg-b": {
+                        "@dependabot/dummy-pkg-b": {
                           "version": "1.1.0",
                           "resolved": "https://registry.npmjs.org/@dependabot/dummy-pkg-b/-/dummy-pkg-b-1.1.0.tgz",
                           "integrity": "sha512-6r/5iuUs49Hln9Dl05waRoyzgkY9gwt8Yaa5SlhDmM5c2LwJ8tIG23+690FlXSUZ9c6xmOeuhHbcXGBMXsawbw==",
-                          "dependencies": {
+                          "requires": {
                             "@dependabot/dummy-pkg-a": "^2.0.0"
                           }
                         },
-                        "node_modules/left-pad": {
+                        "left-pad": {
                           "version": "1.3.0",
                           "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-                          "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
-                          "deprecated": "use String.prototype.padStart()"
+                          "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
                         }
                       }
                     }
@@ -249,28 +217,18 @@ output:
                     {
                       "name": "bar",
                       "version": "1.0.0",
-                      "lockfileVersion": 3,
+                      "lockfileVersion": 1,
                       "requires": true,
-                      "packages": {
-                        "": {
-                          "name": "bar",
-                          "version": "1.0.0",
-                          "license": "ISC",
-                          "dependencies": {
-                            "@dependabot/dummy-pkg-a": "^1.0.0",
-                            "left-pad": "^1.0.0"
-                          }
-                        },
-                        "node_modules/@dependabot/dummy-pkg-a": {
+                      "dependencies": {
+                        "@dependabot/dummy-pkg-a": {
                           "version": "1.1.0",
                           "resolved": "https://registry.npmjs.org/@dependabot/dummy-pkg-a/-/dummy-pkg-a-1.1.0.tgz",
                           "integrity": "sha512-mjJzV5MdCP389oz3J0j3CiOZjF6h0R+36HqhG0Rl4Y0uCj0xdX+r0QboLZBugPwb7yBxrRHs6ZIe8J182r9Ssw=="
                         },
-                        "node_modules/left-pad": {
+                        "left-pad": {
                           "version": "1.3.0",
                           "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-                          "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
-                          "deprecated": "use String.prototype.padStart()"
+                          "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
                         }
                       }
                     }
@@ -283,8 +241,8 @@ output:
                   type: file
             pr-title: Bump the npm_and_yarn group across 2 directories with 3 updates
             pr-body: |
-                Bumps the npm_and_yarn group with 2 updates in the /npm/multi-dir/foo directory: @dependabot/dummy-pkg-b and [left-pad](https://github.com/stevemao/left-pad).
-                Bumps the npm_and_yarn group with 2 updates in the /npm/multi-dir/bar directory: [left-pad](https://github.com/stevemao/left-pad) and @dependabot/dummy-pkg-a.
+                Bumps the npm_and_yarn group with 1 update in the /npm/multi-dir/foo directory: @dependabot/dummy-pkg-b.
+                Bumps the npm_and_yarn group with 1 update in the /npm/multi-dir/bar directory: [left-pad](https://github.com/stevemao/left-pad).
 
                 Updates `@dependabot/dummy-pkg-b` from 1.0.0 to 1.1.0
 
@@ -312,8 +270,8 @@ output:
             commit-message: |-
                 Bump the npm_and_yarn group across 2 directories with 3 updates
 
-                Bumps the npm_and_yarn group with 2 updates in the /npm/multi-dir/foo directory: @dependabot/dummy-pkg-b and [left-pad](https://github.com/stevemao/left-pad).
-                Bumps the npm_and_yarn group with 2 updates in the /npm/multi-dir/bar directory: [left-pad](https://github.com/stevemao/left-pad) and @dependabot/dummy-pkg-a.
+                Bumps the npm_and_yarn group with 1 update in the /npm/multi-dir/foo directory: @dependabot/dummy-pkg-b.
+                Bumps the npm_and_yarn group with 1 update in the /npm/multi-dir/bar directory: [left-pad](https://github.com/stevemao/left-pad).
 
 
                 Updates `@dependabot/dummy-pkg-b` from 1.0.0 to 1.1.0

--- a/tests/smoke-npm-group-multiple.yaml
+++ b/tests/smoke-npm-group-multiple.yaml
@@ -23,6 +23,7 @@ input:
                 update-types:
                     - major
         experiments:
+            npm_fallback_version_above_v6: true
             record-ecosystem-versions: true
         ignore-conditions:
             - dependency-name: none
@@ -42,7 +43,7 @@ output:
         data:
             ecosystem_versions:
                 package_managers:
-                    npm: 8
+                    npm: 9
     - type: update_dependency_list
       expect:
         data:
@@ -53,9 +54,7 @@ output:
                       groups:
                         - dependencies
                       requirement: ^15.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   version: 15.0.0
                 - name: '@angular/common'
                   requirements:
@@ -63,9 +62,7 @@ output:
                       groups:
                         - dependencies
                       requirement: ^15.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   version: 15.0.0
                 - name: '@angular/compiler'
                   requirements:
@@ -73,9 +70,7 @@ output:
                       groups:
                         - dependencies
                       requirement: ^15.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   version: 15.0.0
                 - name: '@angular/core'
                   requirements:
@@ -83,9 +78,7 @@ output:
                       groups:
                         - dependencies
                       requirement: ^15.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   version: 15.0.0
                 - name: '@angular/forms'
                   requirements:
@@ -93,9 +86,7 @@ output:
                       groups:
                         - dependencies
                       requirement: ^15.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   version: 15.0.0
                 - name: '@angular/platform-browser'
                   requirements:
@@ -103,9 +94,7 @@ output:
                       groups:
                         - dependencies
                       requirement: ^15.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   version: 15.0.0
                 - name: '@angular/platform-browser-dynamic'
                   requirements:
@@ -113,9 +102,7 @@ output:
                       groups:
                         - dependencies
                       requirement: ^15.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   version: 15.0.0
                 - name: '@angular/router'
                   requirements:
@@ -123,9 +110,7 @@ output:
                       groups:
                         - dependencies
                       requirement: ^15.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   version: 15.0.0
                 - name: rxjs
                   requirements: []
@@ -150,19 +135,15 @@ output:
                       groups:
                         - dependencies
                       requirement: ^15.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   previous-version: 15.0.0
                   requirements:
                     - file: package.json
                       groups:
                         - dependencies
-                      requirement: ^16.2.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
-                  version: 16.2.0
+                      requirement: ^18.2.7
+                      source: null
+                  version: 18.2.7
                   directory: /npm/angular
                 - name: '@angular/common'
                   previous-requirements:
@@ -170,19 +151,15 @@ output:
                       groups:
                         - dependencies
                       requirement: ^15.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   previous-version: 15.0.0
                   requirements:
                     - file: package.json
                       groups:
                         - dependencies
-                      requirement: ^16.2.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
-                  version: 16.2.0
+                      requirement: ^15.0.0
+                      source: null
+                  version: 15.2.10
                   directory: /npm/angular
                 - name: '@angular/compiler'
                   previous-requirements:
@@ -190,19 +167,15 @@ output:
                       groups:
                         - dependencies
                       requirement: ^15.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   previous-version: 15.0.0
                   requirements:
                     - file: package.json
                       groups:
                         - dependencies
-                      requirement: ^16.2.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
-                  version: 16.2.0
+                      requirement: ^15.0.0
+                      source: null
+                  version: 15.2.10
                   directory: /npm/angular
                 - name: '@angular/core'
                   previous-requirements:
@@ -210,19 +183,15 @@ output:
                       groups:
                         - dependencies
                       requirement: ^15.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   previous-version: 15.0.0
                   requirements:
                     - file: package.json
                       groups:
                         - dependencies
-                      requirement: ^16.2.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
-                  version: 16.2.0
+                      requirement: ^15.0.0
+                      source: null
+                  version: 15.2.10
                   directory: /npm/angular
                 - name: '@angular/forms'
                   previous-requirements:
@@ -230,19 +199,15 @@ output:
                       groups:
                         - dependencies
                       requirement: ^15.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   previous-version: 15.0.0
                   requirements:
                     - file: package.json
                       groups:
                         - dependencies
-                      requirement: ^16.2.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
-                  version: 16.2.0
+                      requirement: ^15.0.0
+                      source: null
+                  version: 15.2.10
                   directory: /npm/angular
                 - name: '@angular/platform-browser'
                   previous-requirements:
@@ -250,19 +215,15 @@ output:
                       groups:
                         - dependencies
                       requirement: ^15.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   previous-version: 15.0.0
                   requirements:
                     - file: package.json
                       groups:
                         - dependencies
-                      requirement: ^16.2.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
-                  version: 16.2.0
+                      requirement: ^15.0.0
+                      source: null
+                  version: 15.2.10
                   directory: /npm/angular
                 - name: '@angular/platform-browser-dynamic'
                   previous-requirements:
@@ -270,19 +231,15 @@ output:
                       groups:
                         - dependencies
                       requirement: ^15.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   previous-version: 15.0.0
                   requirements:
                     - file: package.json
                       groups:
                         - dependencies
-                      requirement: ^16.2.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
-                  version: 16.2.0
+                      requirement: ^15.0.0
+                      source: null
+                  version: 15.2.10
                   directory: /npm/angular
                 - name: '@angular/router'
                   previous-requirements:
@@ -290,19 +247,15 @@ output:
                       groups:
                         - dependencies
                       requirement: ^15.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   previous-version: 15.0.0
                   requirements:
                     - file: package.json
                       groups:
                         - dependencies
-                      requirement: ^16.2.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
-                  version: 16.2.0
+                      requirement: ^15.0.0
+                      source: null
+                  version: 15.2.10
                   directory: /npm/angular
             updated-dependency-files:
                 - content: |
@@ -318,14 +271,14 @@ output:
                       },
                       "private": true,
                       "dependencies": {
-                        "@angular/animations": "^16.2.0",
-                        "@angular/common": "^16.2.0",
-                        "@angular/compiler": "^16.2.0",
-                        "@angular/core": "^16.2.0",
-                        "@angular/forms": "^16.2.0",
-                        "@angular/platform-browser": "^16.2.0",
-                        "@angular/platform-browser-dynamic": "^16.2.0",
-                        "@angular/router": "^16.2.0"
+                        "@angular/animations": "^18.2.7",
+                        "@angular/common": "^15.0.0",
+                        "@angular/compiler": "^15.0.0",
+                        "@angular/core": "^15.0.0",
+                        "@angular/forms": "^15.0.0",
+                        "@angular/platform-browser": "^15.0.0",
+                        "@angular/platform-browser-dynamic": "^15.0.0",
+                        "@angular/router": "^15.0.0"
                       }
                     }
                   content_encoding: utf-8
@@ -339,180 +292,77 @@ output:
                     {
                       "name": "my-angular",
                       "version": "0.0.0",
-                      "lockfileVersion": 3,
+                      "lockfileVersion": 1,
                       "requires": true,
-                      "packages": {
-                        "": {
-                          "name": "my-angular",
-                          "version": "0.0.0",
-                          "dependencies": {
-                            "@angular/animations": "^16.2.0",
-                            "@angular/common": "^16.2.0",
-                            "@angular/compiler": "^16.2.0",
-                            "@angular/core": "^16.2.0",
-                            "@angular/forms": "^16.2.0",
-                            "@angular/platform-browser": "^16.2.0",
-                            "@angular/platform-browser-dynamic": "^16.2.0",
-                            "@angular/router": "^16.2.0"
-                          }
-                        },
-                        "node_modules/@angular/animations": {
-                          "version": "16.2.0",
-                          "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-16.2.0.tgz",
-                          "integrity": "sha512-SgOjldgRlU6XL1f6OUmFa+1iiy1OCWXH8i7q7g0yGCeQ4XAlvNRjDj++xxvUwDhE2pLKJLPYDJmCH98mvjKZcA==",
-                          "dependencies": {
-                            "tslib": "^2.3.0"
-                          },
-                          "engines": {
-                            "node": "^16.14.0 || >=18.10.0"
-                          },
-                          "peerDependencies": {
-                            "@angular/core": "16.2.0"
-                          }
-                        },
-                        "node_modules/@angular/common": {
-                          "version": "16.2.0",
-                          "resolved": "https://registry.npmjs.org/@angular/common/-/common-16.2.0.tgz",
-                          "integrity": "sha512-ByrDLsTBarzqRmq4GS841Ku0lvB4L2wfOCfGEIw2ZuiNbZlDA5O/qohQgJnHR5d9meVJnu9NgdbeyMzk90xZNg==",
-                          "dependencies": {
-                            "tslib": "^2.3.0"
-                          },
-                          "engines": {
-                            "node": "^16.14.0 || >=18.10.0"
-                          },
-                          "peerDependencies": {
-                            "@angular/core": "16.2.0",
-                            "rxjs": "^6.5.3 || ^7.4.0"
-                          }
-                        },
-                        "node_modules/@angular/compiler": {
-                          "version": "16.2.0",
-                          "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.2.0.tgz",
-                          "integrity": "sha512-Ai0CKRUDlMY6iFCeoRsC+soVFTU7eyMDmNzeakdmNvGYMdLdjH8WvgaNukesi6WX7YBIQIKTPJVral8fXBQroQ==",
-                          "dependencies": {
-                            "tslib": "^2.3.0"
-                          },
-                          "engines": {
-                            "node": "^16.14.0 || >=18.10.0"
-                          },
-                          "peerDependencies": {
-                            "@angular/core": "16.2.0"
-                          },
-                          "peerDependenciesMeta": {
-                            "@angular/core": {
-                              "optional": true
-                            }
-                          }
-                        },
-                        "node_modules/@angular/core": {
-                          "version": "16.2.0",
-                          "resolved": "https://registry.npmjs.org/@angular/core/-/core-16.2.0.tgz",
-                          "integrity": "sha512-iwUWFw+JmRxw0chcNoqhXVR8XUTE+Rszhy22iSCkK0Jo8IJqEad1d2dQoFu1QfqOVdPMZtpJDmC/ppQ/f5c5aA==",
-                          "dependencies": {
-                            "tslib": "^2.3.0"
-                          },
-                          "engines": {
-                            "node": "^16.14.0 || >=18.10.0"
-                          },
-                          "peerDependencies": {
-                            "rxjs": "^6.5.3 || ^7.4.0",
-                            "zone.js": "~0.13.0"
-                          }
-                        },
-                        "node_modules/@angular/forms": {
-                          "version": "16.2.0",
-                          "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-16.2.0.tgz",
-                          "integrity": "sha512-Z/IFw319ZSgGbJFkR5Ba0sRIIqDxQDVH4I+vnVoOYqq2NxuHYfLJDHAB9uHln9GWj86b1SrJBZe8qiS7Sxb7yQ==",
-                          "dependencies": {
-                            "tslib": "^2.3.0"
-                          },
-                          "engines": {
-                            "node": "^16.14.0 || >=18.10.0"
-                          },
-                          "peerDependencies": {
-                            "@angular/common": "16.2.0",
-                            "@angular/core": "16.2.0",
-                            "@angular/platform-browser": "16.2.0",
-                            "rxjs": "^6.5.3 || ^7.4.0"
-                          }
-                        },
-                        "node_modules/@angular/platform-browser": {
-                          "version": "16.2.0",
-                          "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-16.2.0.tgz",
-                          "integrity": "sha512-6xjZFnSD0C8ylDbzKpsxCJ4pLJDRvippr9Wj9RCeDQvAzMibsqIjpbesyOccw3hO+jheJQRhM/rZeO1ubZU94w==",
-                          "dependencies": {
-                            "tslib": "^2.3.0"
-                          },
-                          "engines": {
-                            "node": "^16.14.0 || >=18.10.0"
-                          },
-                          "peerDependencies": {
-                            "@angular/animations": "16.2.0",
-                            "@angular/common": "16.2.0",
-                            "@angular/core": "16.2.0"
-                          },
-                          "peerDependenciesMeta": {
-                            "@angular/animations": {
-                              "optional": true
-                            }
-                          }
-                        },
-                        "node_modules/@angular/platform-browser-dynamic": {
-                          "version": "16.2.0",
-                          "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-16.2.0.tgz",
-                          "integrity": "sha512-kLxgR+ichWb6dNA1JUAh0JB+iSrObkomd10porGQWVxAGmHqg1eiB3bBaSAgcaLftsrmEguIH8O9AEfq+HLfrA==",
-                          "dependencies": {
-                            "tslib": "^2.3.0"
-                          },
-                          "engines": {
-                            "node": "^16.14.0 || >=18.10.0"
-                          },
-                          "peerDependencies": {
-                            "@angular/common": "16.2.0",
-                            "@angular/compiler": "16.2.0",
-                            "@angular/core": "16.2.0",
-                            "@angular/platform-browser": "16.2.0"
-                          }
-                        },
-                        "node_modules/@angular/router": {
-                          "version": "16.2.0",
-                          "resolved": "https://registry.npmjs.org/@angular/router/-/router-16.2.0.tgz",
-                          "integrity": "sha512-bFOaE7PNF0UHgVhl8BvyHiZHizTRZO7w3V29VqsdXUMMugBR4kr1/FXGzXTaz+9/eK7LokUwN9pjKKENNmhdyg==",
-                          "dependencies": {
-                            "tslib": "^2.3.0"
-                          },
-                          "engines": {
-                            "node": "^16.14.0 || >=18.10.0"
-                          },
-                          "peerDependencies": {
-                            "@angular/common": "16.2.0",
-                            "@angular/core": "16.2.0",
-                            "@angular/platform-browser": "16.2.0",
-                            "rxjs": "^6.5.3 || ^7.4.0"
-                          }
-                        },
-                        "node_modules/rxjs": {
-                          "version": "7.8.1",
-                          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-                          "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-                          "peer": true,
-                          "dependencies": {
-                            "tslib": "^2.1.0"
-                          }
-                        },
-                        "node_modules/tslib": {
-                          "version": "2.6.1",
-                          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-                          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-                        },
-                        "node_modules/zone.js": {
-                          "version": "0.13.1",
-                          "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.13.1.tgz",
-                          "integrity": "sha512-+bIeDAFEBYuXRuU3qGQvzdPap+N1zjM4KkBAiiQuVVCrHrhjDuY6VkUhNa5+U27+9w0q3fbKiMCbpJ0XzMmSWA==",
-                          "peer": true,
-                          "dependencies": {
+                      "dependencies": {
+                        "@angular/animations": {
+                          "version": "18.2.7",
+                          "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-18.2.7.tgz",
+                          "integrity": "sha512-5B7qD1K+kKOf9lgJT4VNMft3IK2BnRHjN1S6l38ywzQ/nxpmCG7f+qKAAU6CpCywhNUBeXW0hVXTMuMNPVOcQQ==",
+                          "requires": {
                             "tslib": "^2.3.0"
                           }
+                        },
+                        "@angular/common": {
+                          "version": "15.2.10",
+                          "resolved": "https://registry.npmjs.org/@angular/common/-/common-15.2.10.tgz",
+                          "integrity": "sha512-jdBn3fctkqoNrJn9VLsUHpcCEhCxWSczdsR+BBbD6T0oLl6vMrAVNjPwfBejnlgfWN1KoRU9kgOYsMxa5apIWQ==",
+                          "requires": {
+                            "tslib": "^2.3.0"
+                          }
+                        },
+                        "@angular/compiler": {
+                          "version": "15.2.10",
+                          "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-15.2.10.tgz",
+                          "integrity": "sha512-M0XkeU0O73UlJZwDvOyp8/apetz9UKj78eTFDseMYJDLcxe6MpkbkxqpsGZnKYDj7LIep8PmCAKEkhtenE82zw==",
+                          "requires": {
+                            "tslib": "^2.3.0"
+                          }
+                        },
+                        "@angular/core": {
+                          "version": "15.2.10",
+                          "resolved": "https://registry.npmjs.org/@angular/core/-/core-15.2.10.tgz",
+                          "integrity": "sha512-meGGidnitQJGDxYd9/LrqYiVlId+vGaLoiLgJdKBz+o2ZO6OmXQGuNw2VBqf17/Cc0/UjzrOY7+kILNFKkk/WQ==",
+                          "requires": {
+                            "tslib": "^2.3.0"
+                          }
+                        },
+                        "@angular/forms": {
+                          "version": "15.2.10",
+                          "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-15.2.10.tgz",
+                          "integrity": "sha512-NIntGsNcN6o8L1txsbWXOf6f3K/CUBizdKsxsYVYGJIXEW5qU6UnWmfAZffNNXsT/XvbgUCjgDwT0cAwcqZPuQ==",
+                          "requires": {
+                            "tslib": "^2.3.0"
+                          }
+                        },
+                        "@angular/platform-browser": {
+                          "version": "15.2.10",
+                          "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-15.2.10.tgz",
+                          "integrity": "sha512-9tbgVGSJqwfrOzT8aA/kWBLNhJSQ9gUg0CJxwFBSJm8VkBUJrszoBlDsnSvlxx8/W2ejNULKHFTXeUzq0O/+RQ==",
+                          "requires": {
+                            "tslib": "^2.3.0"
+                          }
+                        },
+                        "@angular/platform-browser-dynamic": {
+                          "version": "15.2.10",
+                          "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-15.2.10.tgz",
+                          "integrity": "sha512-JHP6W+FX715Qv7DhqvfZLuBZXSDJrboiQsR06gUAgDSjAUyhbqmpVg/2YOtgeWpPkzNDtXdPU2PhcRdIv5J3Yg==",
+                          "requires": {
+                            "tslib": "^2.3.0"
+                          }
+                        },
+                        "@angular/router": {
+                          "version": "15.2.10",
+                          "resolved": "https://registry.npmjs.org/@angular/router/-/router-15.2.10.tgz",
+                          "integrity": "sha512-LmuqEg0iIXSw7bli6HKJ19cbxP91v37GtRwbGKswyLihqzTgvjBYpvcfMnB5FRQ5LWkTwq5JclkX03dZw290Yg==",
+                          "requires": {
+                            "tslib": "^2.3.0"
+                          }
+                        },
+                        "tslib": {
+                          "version": "2.7.0",
+                          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+                          "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
                         }
                       }
                     }
@@ -524,43 +374,28 @@ output:
                   support_file: false
                   type: file
             pr-title: Bump the major group in /npm/angular with 8 updates
-            pr-body: |-
+            pr-body: |
                 Bumps the major group in /npm/angular with 8 updates:
 
                 | Package | From | To |
                 | --- | --- | --- |
-                | [@angular/animations](https://github.com/angular/angular/tree/HEAD/packages/animations) | `15.0.0` | `16.2.0` |
-                | [@angular/common](https://github.com/angular/angular/tree/HEAD/packages/common) | `15.0.0` | `16.2.0` |
-                | [@angular/compiler](https://github.com/angular/angular/tree/HEAD/packages/compiler) | `15.0.0` | `16.2.0` |
-                | [@angular/core](https://github.com/angular/angular/tree/HEAD/packages/core) | `15.0.0` | `16.2.0` |
-                | [@angular/forms](https://github.com/angular/angular/tree/HEAD/packages/forms) | `15.0.0` | `16.2.0` |
-                | [@angular/platform-browser](https://github.com/angular/angular/tree/HEAD/packages/platform-browser) | `15.0.0` | `16.2.0` |
-                | [@angular/platform-browser-dynamic](https://github.com/angular/angular/tree/HEAD/packages/platform-browser-dynamic) | `15.0.0` | `16.2.0` |
-                | [@angular/router](https://github.com/angular/angular/tree/HEAD/packages/router) | `15.0.0` | `16.2.0` |
+                | [@angular/animations](https://github.com/angular/angular/tree/HEAD/packages/animations) | `15.0.0` | `18.2.7` |
+                | [@angular/common](https://github.com/angular/angular/tree/HEAD/packages/common) | `15.0.0` | `15.2.10` |
+                | [@angular/compiler](https://github.com/angular/angular/tree/HEAD/packages/compiler) | `15.0.0` | `15.2.10` |
+                | [@angular/core](https://github.com/angular/angular/tree/HEAD/packages/core) | `15.0.0` | `15.2.10` |
+                | [@angular/forms](https://github.com/angular/angular/tree/HEAD/packages/forms) | `15.0.0` | `15.2.10` |
+                | [@angular/platform-browser](https://github.com/angular/angular/tree/HEAD/packages/platform-browser) | `15.0.0` | `15.2.10` |
+                | [@angular/platform-browser-dynamic](https://github.com/angular/angular/tree/HEAD/packages/platform-browser-dynamic) | `15.0.0` | `15.2.10` |
+                | [@angular/router](https://github.com/angular/angular/tree/HEAD/packages/router) | `15.0.0` | `15.2.10` |
 
-                Updates `@angular/animations` from 15.0.0 to 16.2.0
+                Updates `@angular/animations` from 15.0.0 to 18.2.7
                 <details>
                 <summary>Release notes</summary>
                 <p><em>Sourced from <a href="https://github.com/angular/angular/releases"><code>@​angular/animations</code>'s releases</a>.</em></p>
                 <blockquote>
-                <h2>v16.2.0</h2>
+                <h2>v18.2.7</h2>
                 <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
-                <h1>16.2.0 (2023-08-09)</h1>
-                <h3>benchpress</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/dd850b2ab781f24065550f8a948ced498e0f1e99"><img src="https://img.shields.io/badge/dd850b2ab7-fix-green" alt="fix - dd850b2ab7" /></a></td>
-                <td>correctly report GC memory amounts (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/50760">#50760</a>)</td>
-                </tr>
-                </tbody>
-                </table>
+                <h1>18.2.7 (2024-10-02)</h1>
                 <h3>common</h3>
                 <table>
                 <thead>
@@ -571,27 +406,16 @@ output:
                 </thead>
                 <tbody>
                 <tr>
-                <td><a href="https://github.com/angular/angular/commit/29d358170b046f4a6773dfdfbbd1050f54deb301"><img src="https://img.shields.io/badge/29d358170b-feat-blue" alt="feat - 29d358170b" /></a></td>
-                <td>add component input binding support for NgComponentOutlet (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/51148">#51148</a>)</td>
+                <td><a href="https://github.com/angular/angular/commit/249d0260f97a2fec8e4daef0b1565ba40b27d370"><img src="https://img.shields.io/badge/249d0260f9-fix-green" alt="fix - 249d0260f9" /></a></td>
+                <td>execute checks and remove placeholder when image is already loaded (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/55444">#55444</a>)</td>
                 </tr>
                 <tr>
-                <td><a href="https://github.com/angular/angular/commit/1837efb9daf5c8e86a99a06ecc77bb42bc60dbb0"><img src="https://img.shields.io/badge/1837efb9da-feat-blue" alt="feat - 1837efb9da" /></a></td>
-                <td>Allow ngSrc to be changed post-init (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/50683">#50683</a>)</td>
+                <td><a href="https://github.com/angular/angular/commit/46a2ad39f53f6e3b224dfe4b25087c08830713b6"><img src="https://img.shields.io/badge/46a2ad39f5-fix-green" alt="fix - 46a2ad39f5" /></a></td>
+                <td>prevent warning about oversize image twice (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/58021">#58021</a>)</td>
                 </tr>
-                </tbody>
-                </table>
-                <h3>compiler</h3>
-                <table>
-                <thead>
                 <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/c27a1e61d64a67aa169086f7db11bcfd5bb7d2fc"><img src="https://img.shields.io/badge/c27a1e61d6-feat-blue" alt="feat - c27a1e61d6" /></a></td>
-                <td>scope selectors in <a href="https://github.com/scope"><code>@​scope</code></a> queries (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/50747">#50747</a>)</td>
+                <td><a href="https://github.com/angular/angular/commit/8f2b0ede5962ad30171843cd7af80c8878b35b53"><img src="https://img.shields.io/badge/8f2b0ede59-fix-green" alt="fix - 8f2b0ede59" /></a></td>
+                <td>skip checking whether SVGs are oversized (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/57966">#57966</a>)</td>
                 </tr>
                 </tbody>
                 </table>
@@ -605,8 +429,8 @@ output:
                 </thead>
                 <tbody>
                 <tr>
-                <td><a href="https://github.com/angular/angular/commit/12bad6576d2ffe4667118b214d9c7598ed3d8edb"><img src="https://img.shields.io/badge/12bad6576d-fix-green" alt="fix - 12bad6576d" /></a></td>
-                <td>libraries compiled with v16.1+ breaking with Angular framework v16.0.x (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/50714">#50714</a>)</td>
+                <td><a href="https://github.com/angular/angular/commit/901c1e1a7faadee73af4f9e6c37efa778f406ab8"><img src="https://img.shields.io/badge/901c1e1a7f-fix-green" alt="fix - 901c1e1a7f" /></a></td>
+                <td>correctly get the type of nested function call expressions (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/57010">#57010</a>)</td>
                 </tr>
                 </tbody>
                 </table>
@@ -620,24 +444,12 @@ output:
                 </thead>
                 <tbody>
                 <tr>
-                <td><a href="https://github.com/angular/angular/commit/e53d4ecf4cfd9e64d6ba8c8b19adbb7df9cfc047"><img src="https://img.shields.io/badge/e53d4ecf4c-feat-blue" alt="feat - e53d4ecf4c" /></a></td>
-                <td>add afterRender and afterNextRender (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/50607">#50607</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/98d262fd27795014ee3988b08d3c48a0dfb63c40"><img src="https://img.shields.io/badge/98d262fd27-feat-blue" alt="feat - 98d262fd27" /></a></td>
-                <td>create injector debugging APIs (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/48639">#48639</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/cdaa2a8a9eab490b55bbb841ede4f54a2656df30"><img src="https://img.shields.io/badge/cdaa2a8a9e-feat-blue" alt="feat - cdaa2a8a9e" /></a></td>
-                <td>support Provider type in Injector.create (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/49587">#49587</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/9f490da7e27e495cb45d2064af9091731422a6b1"><img src="https://img.shields.io/badge/9f490da7e2-fix-green" alt="fix - 9f490da7e2" /></a></td>
-                <td>handle hydration of view containers for root components (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/51247">#51247</a>)</td>
+                <td><a href="https://github.com/angular/angular/commit/2f347ef8fcef8645d86047d7a339405c0156aa43"><img src="https://img.shields.io/badge/2f347ef8fc-fix-green" alt="fix - 2f347ef8fc" /></a></td>
+                <td>provide flag to opt into manual cleanup for after render hooks (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/57917">#57917</a>)</td>
                 </tr>
                 </tbody>
                 </table>
-                <h3>router</h3>
+                <h3>http</h3>
                 <table>
                 <thead>
                 <tr>
@@ -647,15 +459,48 @@ output:
                 </thead>
                 <tbody>
                 <tr>
-                <td><a href="https://github.com/angular/angular/commit/0b14e4ef742b1c0f73d873e2c337683b60f46845"><img src="https://img.shields.io/badge/0b14e4ef74-feat-blue" alt="feat - 0b14e4ef74" /></a></td>
-                <td>exposes the <code>fixture</code> of the <code>RouterTestingHarness</code> (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/50280">#50280</a>)</td>
+                <td><a href="https://github.com/angular/angular/commit/ca637fe6a95bd020221d71cd0581a3394070cf2c"><img src="https://img.shields.io/badge/ca637fe6a9-fix-green" alt="fix - ca637fe6a9" /></a></td>
+                <td>cleanup JSONP script listeners once loading completed (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/57877">#57877</a>)</td>
                 </tr>
                 </tbody>
                 </table>
-                <h2>v16.2.0-rc.0</h2>
+                <h3>migrations</h3>
+                <table>
+                <thead>
+                <tr>
+                <th>Commit</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/b9d846dad77832dff44b112ac22951e0f31733ba"><img src="https://img.shields.io/badge/b9d846dad7-fix-green" alt="fix - b9d846dad7" /></a></td>
+                <td>delete constructor if it only has super call (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/58013">#58013</a>)</td>
+                </tr>
+                </tbody>
+                </table>
+                <h3>upgrade</h3>
+                <table>
+                <thead>
+                <tr>
+                <th>Commit</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/e40a4fa3c71c9ad76c1546b38ca2e9f74eff7dc0"><img src="https://img.shields.io/badge/e40a4fa3c7-fix-green" alt="fix - e40a4fa3c7" /></a></td>
+                <td>support input signal bindings (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/57020">#57020</a>)</td>
+                </tr>
+                </tbody>
+                </table>
+                <h2>v18.2.6</h2>
                 <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
-                <h1>16.2.0-rc.0 (2023-08-02)</h1>
-                <h3>compiler</h3>
+                <h1>18.2.6 (2024-09-25)</h1>
+                <h2>v18.2.5</h2>
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>18.2.5 (2024-09-18)</h1>
+                <h3>compiler-cli</h3>
                 <table>
                 <thead>
                 <tr>
@@ -665,8 +510,8 @@ output:
                 </thead>
                 <tbody>
                 <tr>
-                <td><a href="https://github.com/angular/angular/commit/6755f5354c7657ecb6f2643450dd2572b114a895"><img src="https://img.shields.io/badge/6755f5354c-fix-green" alt="fix - 6755f5354c" /></a></td>
-                <td>return full spans for Comment nodes (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/50855">#50855</a>)</td>
+                <td><a href="https://github.com/angular/angular/commit/e685ed883a09628c2b87a11a17ffb6d858d51c54"><img src="https://img.shields.io/badge/e685ed883a-fix-green" alt="fix - e685ed883a" /></a></td>
+                <td>extended diagnostics not validating ICUs (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/57845">#57845</a>)</td>
                 </tr>
                 </tbody>
                 </table>
@@ -680,23 +525,26 @@ output:
                 </thead>
                 <tbody>
                 <tr>
-                <td><a href="https://github.com/angular/angular/commit/e53d4ecf4cfd9e64d6ba8c8b19adbb7df9cfc047"><img src="https://img.shields.io/badge/e53d4ecf4c-feat-blue" alt="feat - e53d4ecf4c" /></a></td>
-                <td>add afterRender and afterNextRender (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/50607">#50607</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/98d262fd27795014ee3988b08d3c48a0dfb63c40"><img src="https://img.shields.io/badge/98d262fd27-feat-blue" alt="feat - 98d262fd27" /></a></td>
-                <td>create injector debugging APIs (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/48639">#48639</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/cdaa2a8a9eab490b55bbb841ede4f54a2656df30"><img src="https://img.shields.io/badge/cdaa2a8a9e-feat-blue" alt="feat - cdaa2a8a9e" /></a></td>
-                <td>support Provider type in Injector.create (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/49587">#49587</a>)</td>
+                <td><a href="https://github.com/angular/angular/commit/76709d5d6ec1f83e3f44641704b540636f91b5f4"><img src="https://img.shields.io/badge/76709d5d6e-fix-green" alt="fix - 76709d5d6e" /></a></td>
+                <td>Handle <code>@let</code> declaration with array when <code>preparingForHydration</code> (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/57816">#57816</a>)</td>
                 </tr>
                 </tbody>
                 </table>
-                <h2>v16.2.0-next.4</h2>
-                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
-                <h1>16.2.0-next.4 (2023-07-26)</h1>
-                <h3>common</h3>
+                <h3>migrations</h3>
+                <table>
+                <thead>
+                <tr>
+                <th>Commit</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/5c866942a1b8a60e3a024385048bbb2f52f84513"><img src="https://img.shields.io/badge/5c866942a1-fix-green" alt="fix - 5c866942a1" /></a></td>
+                <td>account for explicit standalone: false in migration (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/57803">#57803</a>)</td>
+                </tr>
+                </tbody>
+                </table>
                 <!-- raw HTML omitted -->
                 </blockquote>
                 <p>... (truncated)</p>
@@ -705,24 +553,7 @@ output:
                 <summary>Changelog</summary>
                 <p><em>Sourced from <a href="https://github.com/angular/angular/blob/main/CHANGELOG.md"><code>@​angular/animations</code>'s changelog</a>.</em></p>
                 <blockquote>
-                <h1>16.2.0 (2023-08-09)</h1>
-                <h3>benchpress</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Type</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/dd850b2ab781f24065550f8a948ced498e0f1e99">dd850b2ab7</a></td>
-                <td>fix</td>
-                <td>correctly report GC memory amounts (<a href="https://redirect.github.com/angular/angular/pull/50760">#50760</a>)</td>
-                </tr>
-                </tbody>
-                </table>
+                <h1>18.2.7 (2024-10-02)</h1>
                 <h3>common</h3>
                 <table>
                 <thead>
@@ -734,31 +565,19 @@ output:
                 </thead>
                 <tbody>
                 <tr>
-                <td><a href="https://github.com/angular/angular/commit/29d358170b046f4a6773dfdfbbd1050f54deb301">29d358170b</a></td>
-                <td>feat</td>
-                <td>add component input binding support for NgComponentOutlet (<a href="https://redirect.github.com/angular/angular/pull/51148">#51148</a>)</td>
+                <td><a href="https://github.com/angular/angular/commit/249d0260f97a2fec8e4daef0b1565ba40b27d370">249d0260f9</a></td>
+                <td>fix</td>
+                <td>execute checks and remove placeholder when image is already loaded (<a href="https://redirect.github.com/angular/angular/pull/55444">#55444</a>)</td>
                 </tr>
                 <tr>
-                <td><a href="https://github.com/angular/angular/commit/1837efb9daf5c8e86a99a06ecc77bb42bc60dbb0">1837efb9da</a></td>
-                <td>feat</td>
-                <td>Allow ngSrc to be changed post-init (<a href="https://redirect.github.com/angular/angular/pull/50683">#50683</a>)</td>
+                <td><a href="https://github.com/angular/angular/commit/46a2ad39f53f6e3b224dfe4b25087c08830713b6">46a2ad39f5</a></td>
+                <td>fix</td>
+                <td>prevent warning about oversize image twice (<a href="https://redirect.github.com/angular/angular/pull/58021">#58021</a>)</td>
                 </tr>
-                </tbody>
-                </table>
-                <h3>compiler</h3>
-                <table>
-                <thead>
                 <tr>
-                <th>Commit</th>
-                <th>Type</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/c27a1e61d64a67aa169086f7db11bcfd5bb7d2fc">c27a1e61d6</a></td>
-                <td>feat</td>
-                <td>scope selectors in <a href="https://github.com/scope"><code>@​scope</code></a> queries (<a href="https://redirect.github.com/angular/angular/pull/50747">#50747</a>)</td>
+                <td><a href="https://github.com/angular/angular/commit/8f2b0ede5962ad30171843cd7af80c8878b35b53">8f2b0ede59</a></td>
+                <td>fix</td>
+                <td>skip checking whether SVGs are oversized (<a href="https://redirect.github.com/angular/angular/pull/57966">#57966</a>)</td>
                 </tr>
                 </tbody>
                 </table>
@@ -773,9 +592,9 @@ output:
                 </thead>
                 <tbody>
                 <tr>
-                <td><a href="https://github.com/angular/angular/commit/12bad6576d2ffe4667118b214d9c7598ed3d8edb">12bad6576d</a></td>
+                <td><a href="https://github.com/angular/angular/commit/901c1e1a7faadee73af4f9e6c37efa778f406ab8">901c1e1a7f</a></td>
                 <td>fix</td>
-                <td>libraries compiled with v16.1+ breaking with Angular framework v16.0.x (<a href="https://redirect.github.com/angular/angular/pull/50714">#50714</a>)</td>
+                <td>correctly get the type of nested function call expressions (<a href="https://redirect.github.com/angular/angular/pull/57010">#57010</a>)</td>
                 </tr>
                 </tbody>
                 </table>
@@ -790,72 +609,92 @@ output:
                 </thead>
                 <tbody>
                 <tr>
-                <td><a href="https://github.com/angular/angular/commit/e53d4ecf4cfd9e64d6ba8c8b19adbb7df9cfc047">e53d4ecf4c</a></td>
-                <td>feat</td>
-                <td>add afterRender and afterNextRender (<a href="https://redirect.github.com/angular/angular/pull/50607">#50607</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/98d262fd27795014ee3988b08d3c48a0dfb63c40">98d262fd27</a></td>
-                <td>feat</td>
-                <td>create injector debugging APIs (<a href="https://redirect.github.com/angular/angular/pull/48639">#48639</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/cdaa2a8a9eab490b55bbb841ede4f54a2656df30">cdaa2a8a9e</a></td>
-                <td>feat</td>
-                <td>support Provider type in Injector.create (<a href="https://redirect.github.com/angular/angular/pull/49587">#49587</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/9f490da7e27e495cb45d2064af9091731422a6b1">9f490da7e2</a></td>
+                <td><a href="https://github.com/angular/angular/commit/2f347ef8fcef8645d86047d7a339405c0156aa43">2f347ef8fc</a></td>
                 <td>fix</td>
-                <td>handle hydration of view containers for root components (<a href="https://redirect.github.com/angular/angular/pull/51247">#51247</a>)</td>
+                <td>provide flag to opt into manual cleanup for after render hooks (<a href="https://redirect.github.com/angular/angular/pull/57917">#57917</a>)</td>
                 </tr>
                 </tbody>
                 </table>
-                <h3>router</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Type</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/0b14e4ef742b1c0f73d873e2c337683b60f46845">0b14e4ef74</a></td>
-                <td>feat</td>
-                <td>exposes the <code>fixture</code> of the <code>RouterTestingHarness</code> (<a href="https://redirect.github.com/angular/angular/pull/50280">#50280</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <!-- raw HTML omitted -->
-                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
-                <h1>16.1.9 (2023-08-09)</h1>
-                <!-- raw HTML omitted -->
-                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
-                <h1>16.1.8 (2023-08-02)</h1>
-                <h3>compiler</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Type</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/cc722ea1f5b16f5a4fddc1ecd91b21b3005242ae">cc722ea1f5</a></td>
-                <td>fix</td>
-                <td>return full spans for Comment nodes (<a href="https://redirect.github.com/angular/angular/pull/50855">#50855</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <!-- raw HTML omitted -->
-                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
-                <h1>16.1.7 (2023-07-26)</h1>
                 <h3>http</h3>
-                <p>| Commit | Type | Description |</p>
+                <table>
+                <thead>
+                <tr>
+                <th>Commit</th>
+                <th>Type</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/ca637fe6a95bd020221d71cd0581a3394070cf2c">ca637fe6a9</a></td>
+                <td>fix</td>
+                <td>cleanup JSONP script listeners once loading completed (<a href="https://redirect.github.com/angular/angular/pull/57877">#57877</a>)</td>
+                </tr>
+                </tbody>
+                </table>
+                <h3>migrations</h3>
+                <table>
+                <thead>
+                <tr>
+                <th>Commit</th>
+                <th>Type</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/b9d846dad77832dff44b112ac22951e0f31733ba">b9d846dad7</a></td>
+                <td>fix</td>
+                <td>delete constructor if it only has super call (<a href="https://redirect.github.com/angular/angular/pull/58013">#58013</a>)</td>
+                </tr>
+                </tbody>
+                </table>
+                <h3>upgrade</h3>
+                <table>
+                <thead>
+                <tr>
+                <th>Commit</th>
+                <th>Type</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/e40a4fa3c71c9ad76c1546b38ca2e9f74eff7dc0">e40a4fa3c7</a></td>
+                <td>fix</td>
+                <td>support input signal bindings (<a href="https://redirect.github.com/angular/angular/pull/57020">#57020</a>)</td>
+                </tr>
+                </tbody>
+                </table>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>19.0.0-next.7 (2024-09-25)</h1>
+                <h2>Breaking Changes</h2>
+                <h3>core</h3>
+                <ul>
+                <li>
+                <p>Changes to effect timing which generally has two implications:</p>
+                <ul>
+                <li>
+                <p>effects which are triggered outside of change detection run as part of
+                the change detection process instead of as a microtask. Depending on the
+                specifics of application/test setup, this can result in them executing
+                earlier or later (or requiring additional test steps to trigger; see below
+                examples).</p>
+                </li>
+                <li>
+                <p>effects which are triggered during change detection (e.g. by input
+                signals) run <em>earlier</em>, before the component's template.</p>
+                </li>
+                </ul>
+                <p>We've seen a few common failure cases:</p>
+                <ul>
+                <li>Tests which used to rely on the <code>Promise</code> timing of effects now need to
+                <code>await whenStable()</code> or call <code>.detectChanges()</code> in order for effects to
+                run.</li>
+                </ul>
+                </li>
+                </ul>
                 <!-- raw HTML omitted -->
                 </blockquote>
                 <p>... (truncated)</p>
@@ -863,190 +702,28 @@ output:
                 <details>
                 <summary>Commits</summary>
                 <ul>
-                <li><a href="https://github.com/angular/angular/commit/0ba2b5e5c340c24435c6c6b43cae4759d0a2b94b"><code>0ba2b5e</code></a> refactor(animations): remove unecessary interface (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/50662">#50662</a>)</li>
-                <li><a href="https://github.com/angular/angular/commit/a14bdfe8591a33d359bf4940f4efa828499a6373"><code>a14bdfe</code></a> fix(animations): Ensure elements are removed from the cache after leave anima...</li>
-                <li><a href="https://github.com/angular/angular/commit/01e2bde0c08b9a5e52d2dd64f83fbcc1557879e1"><code>01e2bde</code></a> refactor(animations): Fix JSDoc comment (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/50893">#50893</a>)</li>
-                <li><a href="https://github.com/angular/angular/commit/29f6912e95f7e901d02578357879b80b99157c39"><code>29f6912</code></a> refactor(animations): remove redundant castings (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/50860">#50860</a>)</li>
-                <li><a href="https://github.com/angular/angular/commit/0380564f8562f5971cff671319439ad0f2b40a7e"><code>0380564</code></a> fix(platform-browser): wait until animation completion before destroying rend...</li>
-                <li><a href="https://github.com/angular/angular/commit/452a3e9ca0a5fd61ada564d57c414b315310672c"><code>452a3e9</code></a> Revert &quot;fix(platform-browser): wait until animation completion before destroy...</li>
-                <li><a href="https://github.com/angular/angular/commit/ed8b088de261405ed55d20f7feda06769db27ec0"><code>ed8b088</code></a> Revert &quot;refactor(animations): remove redundant castings (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/50677">#50677</a>)&quot; (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/50857">#50857</a>)</li>
-                <li><a href="https://github.com/angular/angular/commit/d22734766bc1b1bd18cf41c049de2b397abadc2e"><code>d227347</code></a> refactor(animations): remove redundant castings (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/50677">#50677</a>)</li>
-                <li><a href="https://github.com/angular/angular/commit/2b55103e94578ab1cb765147077e82e1228b0dbb"><code>2b55103</code></a> fix(platform-browser): wait until animation completion before destroying rend...</li>
-                <li><a href="https://github.com/angular/angular/commit/4550fe42f704b18f48bd0c490b0c6a283ea912c5"><code>4550fe4</code></a> refactor: use <code>queueMicrotask</code> to schedule micro tasks instead of various hel...</li>
-                <li>Additional commits viewable in <a href="https://github.com/angular/angular/commits/16.2.0/packages/animations">compare view</a></li>
+                <li><a href="https://github.com/angular/angular/commit/03ac3c299d7ce2de01b9edee98b85810ae2254b6"><code>03ac3c2</code></a> refactor: update license text to point to angular.dev (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/57902">#57902</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/513a4fe05e26a99935f31d2f99a13dc373b612f0"><code>513a4fe</code></a> refactor(core): replace usages of removeChild (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/57203">#57203</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/a7b973eac57bbe4d7590dc84ca81900e97f4b704"><code>a7b973e</code></a> docs(docs-infra): Use shiki for code highlighting (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/57059">#57059</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/176b26fd7b28906b16eaf0740d63de9254450c34"><code>176b26f</code></a> docs: remove private symbol from docs (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/56851">#56851</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/0bd55a684f7adf83ceb7d6c0b1d510252209388c"><code>0bd55a6</code></a> refactor(docs-infra): complete removal of aio directory (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/56496">#56496</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/01172b84d9e8ab37ea989783a480add80c442421"><code>01172b8</code></a> build: update Node.js to match Angular CLI engines (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/56187">#56187</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/fb351300c30dc4670f8c92e4e4d7dea76517d04d"><code>fb35130</code></a> build: update to latest dev infra code (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/56128">#56128</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/024e9bf54d7dcab2637dd6f653b0ebdba61014a2"><code>024e9bf</code></a> refactor(core): Ensure animations are flushed before running render hooks (<a href="https://github.com/angular/angular/tree/HEAD/packages/animations/issues/5">#5</a>...</li>
+                <li><a href="https://github.com/angular/angular/commit/bf8814c6c3718622cbf4b44be9d8ca73772525ee"><code>bf8814c</code></a> refactor(core): Omit listeners from out-of-zone scheduling when using ZoneJS ...</li>
+                <li><a href="https://github.com/angular/angular/commit/e3d5607caf1c500ea85ea1a922fce6015d04ecd0"><code>e3d5607</code></a> Revert &quot;refactor(core): Ensure DOM removal happens when no app views need ref...</li>
+                <li>Additional commits viewable in <a href="https://github.com/angular/angular/commits/18.2.7/packages/animations">compare view</a></li>
                 </ul>
                 </details>
                 <br />
 
-                Updates `@angular/common` from 15.0.0 to 16.2.0
-                <details>
-                <summary>Release notes</summary>
-                <p><em>Sourced from <a href="https://github.com/angular/angular/releases"><code>@​angular/common</code>'s releases</a>.</em></p>
-                <blockquote>
-                <h2>v16.2.0</h2>
-                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
-                <h1>16.2.0 (2023-08-09)</h1>
-                <h3>benchpress</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/dd850b2ab781f24065550f8a948ced498e0f1e99"><img src="https://img.shields.io/badge/dd850b2ab7-fix-green" alt="fix - dd850b2ab7" /></a></td>
-                <td>correctly report GC memory amounts (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/50760">#50760</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h3>common</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/29d358170b046f4a6773dfdfbbd1050f54deb301"><img src="https://img.shields.io/badge/29d358170b-feat-blue" alt="feat - 29d358170b" /></a></td>
-                <td>add component input binding support for NgComponentOutlet (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/51148">#51148</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/1837efb9daf5c8e86a99a06ecc77bb42bc60dbb0"><img src="https://img.shields.io/badge/1837efb9da-feat-blue" alt="feat - 1837efb9da" /></a></td>
-                <td>Allow ngSrc to be changed post-init (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/50683">#50683</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h3>compiler</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/c27a1e61d64a67aa169086f7db11bcfd5bb7d2fc"><img src="https://img.shields.io/badge/c27a1e61d6-feat-blue" alt="feat - c27a1e61d6" /></a></td>
-                <td>scope selectors in <a href="https://github.com/scope"><code>@​scope</code></a> queries (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/50747">#50747</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h3>compiler-cli</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/12bad6576d2ffe4667118b214d9c7598ed3d8edb"><img src="https://img.shields.io/badge/12bad6576d-fix-green" alt="fix - 12bad6576d" /></a></td>
-                <td>libraries compiled with v16.1+ breaking with Angular framework v16.0.x (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/50714">#50714</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h3>core</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/e53d4ecf4cfd9e64d6ba8c8b19adbb7df9cfc047"><img src="https://img.shields.io/badge/e53d4ecf4c-feat-blue" alt="feat - e53d4ecf4c" /></a></td>
-                <td>add afterRender and afterNextRender (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/50607">#50607</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/98d262fd27795014ee3988b08d3c48a0dfb63c40"><img src="https://img.shields.io/badge/98d262fd27-feat-blue" alt="feat - 98d262fd27" /></a></td>
-                <td>create injector debugging APIs (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/48639">#48639</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/cdaa2a8a9eab490b55bbb841ede4f54a2656df30"><img src="https://img.shields.io/badge/cdaa2a8a9e-feat-blue" alt="feat - cdaa2a8a9e" /></a></td>
-                <td>support Provider type in Injector.create (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/49587">#49587</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/9f490da7e27e495cb45d2064af9091731422a6b1"><img src="https://img.shields.io/badge/9f490da7e2-fix-green" alt="fix - 9f490da7e2" /></a></td>
-                <td>handle hydration of view containers for root components (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/51247">#51247</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h3>router</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/0b14e4ef742b1c0f73d873e2c337683b60f46845"><img src="https://img.shields.io/badge/0b14e4ef74-feat-blue" alt="feat - 0b14e4ef74" /></a></td>
-                <td>exposes the <code>fixture</code> of the <code>RouterTestingHarness</code> (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/50280">#50280</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h2>v16.2.0-rc.0</h2>
-                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
-                <h1>16.2.0-rc.0 (2023-08-02)</h1>
-                <h3>compiler</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/6755f5354c7657ecb6f2643450dd2572b114a895"><img src="https://img.shields.io/badge/6755f5354c-fix-green" alt="fix - 6755f5354c" /></a></td>
-                <td>return full spans for Comment nodes (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/50855">#50855</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h3>core</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/e53d4ecf4cfd9e64d6ba8c8b19adbb7df9cfc047"><img src="https://img.shields.io/badge/e53d4ecf4c-feat-blue" alt="feat - e53d4ecf4c" /></a></td>
-                <td>add afterRender and afterNextRender (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/50607">#50607</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/98d262fd27795014ee3988b08d3c48a0dfb63c40"><img src="https://img.shields.io/badge/98d262fd27-feat-blue" alt="feat - 98d262fd27" /></a></td>
-                <td>create injector debugging APIs (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/48639">#48639</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/cdaa2a8a9eab490b55bbb841ede4f54a2656df30"><img src="https://img.shields.io/badge/cdaa2a8a9e-feat-blue" alt="feat - cdaa2a8a9e" /></a></td>
-                <td>support Provider type in Injector.create (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/49587">#49587</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h2>v16.2.0-next.4</h2>
-                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
-                <h1>16.2.0-next.4 (2023-07-26)</h1>
-                <h3>common</h3>
-                <!-- raw HTML omitted -->
-                </blockquote>
-                <p>... (truncated)</p>
-                </details>
+                Updates `@angular/common` from 15.0.0 to 15.2.10
                 <details>
                 <summary>Changelog</summary>
                 <p><em>Sourced from <a href="https://github.com/angular/angular/blob/main/CHANGELOG.md"><code>@​angular/common</code>'s changelog</a>.</em></p>
                 <blockquote>
-                <h1>16.2.0 (2023-08-09)</h1>
-                <h3>benchpress</h3>
+                <h1>15.2.10 (2023-10-04)</h1>
+                <h3>service-worker</h3>
                 <table>
                 <thead>
                 <tr>
@@ -1057,13 +734,16 @@ output:
                 </thead>
                 <tbody>
                 <tr>
-                <td><a href="https://github.com/angular/angular/commit/dd850b2ab781f24065550f8a948ced498e0f1e99">dd850b2ab7</a></td>
+                <td><a href="https://github.com/angular/angular/commit/9fe08968b84b92da47ce91f5d2860b3aa23d2d2b">9fe08968b8</a></td>
                 <td>fix</td>
-                <td>correctly report GC memory amounts (<a href="https://redirect.github.com/angular/angular/pull/50760">#50760</a>)</td>
+                <td>throw a critical error when handleFetch fail (<a href="https://redirect.github.com/angular/angular/pull/51989">#51989</a>)</td>
                 </tr>
                 </tbody>
                 </table>
-                <h3>common</h3>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.7 (2023-09-27)</h1>
+                <h3>core</h3>
                 <table>
                 <thead>
                 <tr>
@@ -1074,18 +754,13 @@ output:
                 </thead>
                 <tbody>
                 <tr>
-                <td><a href="https://github.com/angular/angular/commit/29d358170b046f4a6773dfdfbbd1050f54deb301">29d358170b</a></td>
-                <td>feat</td>
-                <td>add component input binding support for NgComponentOutlet (<a href="https://redirect.github.com/angular/angular/pull/51148">#51148</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/1837efb9daf5c8e86a99a06ecc77bb42bc60dbb0">1837efb9da</a></td>
-                <td>feat</td>
-                <td>Allow ngSrc to be changed post-init (<a href="https://redirect.github.com/angular/angular/pull/50683">#50683</a>)</td>
+                <td><a href="https://github.com/angular/angular/commit/39a3e34e035b324bfa1f1a11cf452272c91011c6">39a3e34e03</a></td>
+                <td>fix</td>
+                <td>allow toSignal calls in reactive context (<a href="https://redirect.github.com/angular/angular/pull/51831">#51831</a>) (<a href="https://redirect.github.com/angular/angular/pull/51892">#51892</a>)</td>
                 </tr>
                 </tbody>
                 </table>
-                <h3>compiler</h3>
+                <h3>service-worker</h3>
                 <table>
                 <thead>
                 <tr>
@@ -1096,9 +771,55 @@ output:
                 </thead>
                 <tbody>
                 <tr>
-                <td><a href="https://github.com/angular/angular/commit/c27a1e61d64a67aa169086f7db11bcfd5bb7d2fc">c27a1e61d6</a></td>
-                <td>feat</td>
-                <td>scope selectors in <a href="https://github.com/scope"><code>@​scope</code></a> queries (<a href="https://redirect.github.com/angular/angular/pull/50747">#50747</a>)</td>
+                <td><a href="https://github.com/angular/angular/commit/c3d901eacfe8d035441e5c990f6e6b2630d592f5">c3d901eacf</a></td>
+                <td>fix</td>
+                <td>throw a critical error when <code>handleFetch</code> fails (<a href="https://redirect.github.com/angular/angular/pull/51885">#51885</a>)</td>
+                </tr>
+                </tbody>
+                </table>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.6 (2023-09-20)</h1>
+                <h3>core</h3>
+                <table>
+                <thead>
+                <tr>
+                <th>Commit</th>
+                <th>Type</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/82712f80dfc6aed2baf8d8f80c3552a6707c88ff">82712f80df</a></td>
+                <td>fix</td>
+                <td>ensure a consumer drops all its stale producers (<a href="https://redirect.github.com/angular/angular/pull/51722">#51722</a>) (<a href="https://redirect.github.com/angular/angular/pull/51772">#51772</a>)</td>
+                </tr>
+                </tbody>
+                </table>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.5 (2023-09-13)</h1>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.4 (2023-09-06)</h1>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.3 (2023-08-30)</h1>
+                <h3>animations</h3>
+                <table>
+                <thead>
+                <tr>
+                <th>Commit</th>
+                <th>Type</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/04c65742802537c8bd725f9a7a931955a67684d9">04c6574280</a></td>
+                <td>fix</td>
+                <td>remove unnecessary escaping in regex expressions (<a href="https://redirect.github.com/angular/angular/pull/51554">#51554</a>)</td>
                 </tr>
                 </tbody>
                 </table>
@@ -1113,89 +834,12 @@ output:
                 </thead>
                 <tbody>
                 <tr>
-                <td><a href="https://github.com/angular/angular/commit/12bad6576d2ffe4667118b214d9c7598ed3d8edb">12bad6576d</a></td>
+                <td><a href="https://github.com/angular/angular/commit/dbd761f528a08cba0fbdd476b115e1445683cf36">dbd761f528</a></td>
                 <td>fix</td>
-                <td>libraries compiled with v16.1+ breaking with Angular framework v16.0.x (<a href="https://redirect.github.com/angular/angular/pull/50714">#50714</a>)</td>
+                <td>correct incomplete escaping (<a href="https://redirect.github.com/angular/angular/pull/51557">#51557</a>)</td>
                 </tr>
                 </tbody>
                 </table>
-                <h3>core</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Type</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/e53d4ecf4cfd9e64d6ba8c8b19adbb7df9cfc047">e53d4ecf4c</a></td>
-                <td>feat</td>
-                <td>add afterRender and afterNextRender (<a href="https://redirect.github.com/angular/angular/pull/50607">#50607</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/98d262fd27795014ee3988b08d3c48a0dfb63c40">98d262fd27</a></td>
-                <td>feat</td>
-                <td>create injector debugging APIs (<a href="https://redirect.github.com/angular/angular/pull/48639">#48639</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/cdaa2a8a9eab490b55bbb841ede4f54a2656df30">cdaa2a8a9e</a></td>
-                <td>feat</td>
-                <td>support Provider type in Injector.create (<a href="https://redirect.github.com/angular/angular/pull/49587">#49587</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/9f490da7e27e495cb45d2064af9091731422a6b1">9f490da7e2</a></td>
-                <td>fix</td>
-                <td>handle hydration of view containers for root components (<a href="https://redirect.github.com/angular/angular/pull/51247">#51247</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h3>router</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Type</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/0b14e4ef742b1c0f73d873e2c337683b60f46845">0b14e4ef74</a></td>
-                <td>feat</td>
-                <td>exposes the <code>fixture</code> of the <code>RouterTestingHarness</code> (<a href="https://redirect.github.com/angular/angular/pull/50280">#50280</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <!-- raw HTML omitted -->
-                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
-                <h1>16.1.9 (2023-08-09)</h1>
-                <!-- raw HTML omitted -->
-                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
-                <h1>16.1.8 (2023-08-02)</h1>
-                <h3>compiler</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Type</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/cc722ea1f5b16f5a4fddc1ecd91b21b3005242ae">cc722ea1f5</a></td>
-                <td>fix</td>
-                <td>return full spans for Comment nodes (<a href="https://redirect.github.com/angular/angular/pull/50855">#50855</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <!-- raw HTML omitted -->
-                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
-                <h1>16.1.7 (2023-07-26)</h1>
-                <h3>http</h3>
-                <p>| Commit | Type | Description |</p>
                 <!-- raw HTML omitted -->
                 </blockquote>
                 <p>... (truncated)</p>
@@ -1203,190 +847,28 @@ output:
                 <details>
                 <summary>Commits</summary>
                 <ul>
-                <li><a href="https://github.com/angular/angular/commit/29d358170b046f4a6773dfdfbbd1050f54deb301"><code>29d3581</code></a> feat(common): add component input binding support for NgComponentOutlet (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/51148">#51148</a>)</li>
-                <li><a href="https://github.com/angular/angular/commit/daaa0a449bd9f05eb1cb85e3e8223eb1b743dc10"><code>daaa0a4</code></a> docs: remove trailing periods after <code>@see</code> (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/51144">#51144</a>)</li>
-                <li><a href="https://github.com/angular/angular/commit/57e8412e53229b0671df02c55be52e88b66a6865"><code>57e8412</code></a> fix(http): check whether <code>Zone</code> is defined (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/51119">#51119</a>)</li>
-                <li><a href="https://github.com/angular/angular/commit/109737b598a7242522f7f5a1c1945e1e43e5a874"><code>109737b</code></a> docs(common): Add NgOptimizedImage FAQ (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/51036">#51036</a>)</li>
-                <li><a href="https://github.com/angular/angular/commit/c5608e5ca99805af1a3a7caf4ce28a35f3a13ebf"><code>c5608e5</code></a> fix(http): Run fetch request out the angular zone (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/50981">#50981</a>)</li>
-                <li><a href="https://github.com/angular/angular/commit/b8107b19149a51cbe9ae04bd9e5b829782c7c0f6"><code>b8107b1</code></a> refactor(common): remove <code>supportScrollRestoration</code> (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/50056">#50056</a>)</li>
-                <li><a href="https://github.com/angular/angular/commit/1837efb9daf5c8e86a99a06ecc77bb42bc60dbb0"><code>1837efb</code></a> feat(common): Allow ngSrc to be changed post-init (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/50683">#50683</a>)</li>
-                <li><a href="https://github.com/angular/angular/commit/d6b1fedb90cfdddfa107429f432db4c07acee106"><code>d6b1fed</code></a> docs(common): remove <code>@developerPreview</code> from <code>NgOptimizedImage</code> related item...</li>
-                <li><a href="https://github.com/angular/angular/commit/232a78630eeeead1e033be65e0ce115f6ec4d0b9"><code>232a786</code></a> ci: re-enable RBE for http tests (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/50741">#50741</a>)</li>
-                <li><a href="https://github.com/angular/angular/commit/9f2fb7c6dcebc0437b0e3ce97565a86502f0266c"><code>9f2fb7c</code></a> docs: update invalid links to the new http guides (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/49456">#49456</a>)</li>
-                <li>Additional commits viewable in <a href="https://github.com/angular/angular/commits/16.2.0/packages/common">compare view</a></li>
+                <li><a href="https://github.com/angular/angular/commit/8b34482e3d4405e48397cd1f120dee811c0a3dd9"><code>8b34482</code></a> docs: Make links out of <a href="https://github.com/see"><code>@​see</code></a> tags (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/50098">#50098</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/9107e931cad6c7543f717796a75648cefee2fd12"><code>9107e93</code></a> fix(common): fix incorrectly reported distortion for padded images (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/49889">#49889</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/245a23e1ec153aae2fecaec9bb8814cf3484f7fb"><code>245a23e</code></a> docs: remove mention of the webworker platform issues (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/49947">#49947</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/05a0225deb126849f3798e828f6dbef7c221ec57"><code>05a0225</code></a> fix(http): prevent headers from throwing an error when initializing numerical...</li>
+                <li><a href="https://github.com/angular/angular/commit/4c89a2497aef1f4c8b8ee2786414145596c1e3f3"><code>4c89a24</code></a> refactor(common): add missing <code>override</code> to satisfy the linter (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/49599">#49599</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/ca5acadb78c33bf896001a5810cb4be15ff7bc86"><code>ca5acad</code></a> fix(common): invalid ImageKit transformation (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/49201">#49201</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/589e76b7eff86a04c2a8159a2182a9c2b92d2672"><code>589e76b</code></a> test(common): update async pipe tests to fix test errors (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/49433">#49433</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/32e98f7937fa48269067b6da9e184344febfe774"><code>32e98f7</code></a> docs(common): mark lifecycle methods as nodoc (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/49416">#49416</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/f321e65c467ff0781af343035f8059945eefff3d"><code>f321e65</code></a> refactor(common): remove <code>BrowserPlatformLocation</code> from private exports. (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/49">#49</a>...</li>
+                <li><a href="https://github.com/angular/angular/commit/af31adb8dd5501463f8d9bc59976559a4ee0aa05"><code>af31adb</code></a> refactor(common): Use isPromise from <code>@​angular/core</code> (<a href="https://github.com/angular/angular/tree/HEAD/packages/common/issues/49210">#49210</a>)</li>
+                <li>Additional commits viewable in <a href="https://github.com/angular/angular/commits/15.2.10/packages/common">compare view</a></li>
                 </ul>
                 </details>
                 <br />
 
-                Updates `@angular/compiler` from 15.0.0 to 16.2.0
-                <details>
-                <summary>Release notes</summary>
-                <p><em>Sourced from <a href="https://github.com/angular/angular/releases"><code>@​angular/compiler</code>'s releases</a>.</em></p>
-                <blockquote>
-                <h2>v16.2.0</h2>
-                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
-                <h1>16.2.0 (2023-08-09)</h1>
-                <h3>benchpress</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/dd850b2ab781f24065550f8a948ced498e0f1e99"><img src="https://img.shields.io/badge/dd850b2ab7-fix-green" alt="fix - dd850b2ab7" /></a></td>
-                <td>correctly report GC memory amounts (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/50760">#50760</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h3>common</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/29d358170b046f4a6773dfdfbbd1050f54deb301"><img src="https://img.shields.io/badge/29d358170b-feat-blue" alt="feat - 29d358170b" /></a></td>
-                <td>add component input binding support for NgComponentOutlet (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/51148">#51148</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/1837efb9daf5c8e86a99a06ecc77bb42bc60dbb0"><img src="https://img.shields.io/badge/1837efb9da-feat-blue" alt="feat - 1837efb9da" /></a></td>
-                <td>Allow ngSrc to be changed post-init (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/50683">#50683</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h3>compiler</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/c27a1e61d64a67aa169086f7db11bcfd5bb7d2fc"><img src="https://img.shields.io/badge/c27a1e61d6-feat-blue" alt="feat - c27a1e61d6" /></a></td>
-                <td>scope selectors in <a href="https://github.com/scope"><code>@​scope</code></a> queries (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/50747">#50747</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h3>compiler-cli</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/12bad6576d2ffe4667118b214d9c7598ed3d8edb"><img src="https://img.shields.io/badge/12bad6576d-fix-green" alt="fix - 12bad6576d" /></a></td>
-                <td>libraries compiled with v16.1+ breaking with Angular framework v16.0.x (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/50714">#50714</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h3>core</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/e53d4ecf4cfd9e64d6ba8c8b19adbb7df9cfc047"><img src="https://img.shields.io/badge/e53d4ecf4c-feat-blue" alt="feat - e53d4ecf4c" /></a></td>
-                <td>add afterRender and afterNextRender (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/50607">#50607</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/98d262fd27795014ee3988b08d3c48a0dfb63c40"><img src="https://img.shields.io/badge/98d262fd27-feat-blue" alt="feat - 98d262fd27" /></a></td>
-                <td>create injector debugging APIs (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/48639">#48639</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/cdaa2a8a9eab490b55bbb841ede4f54a2656df30"><img src="https://img.shields.io/badge/cdaa2a8a9e-feat-blue" alt="feat - cdaa2a8a9e" /></a></td>
-                <td>support Provider type in Injector.create (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/49587">#49587</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/9f490da7e27e495cb45d2064af9091731422a6b1"><img src="https://img.shields.io/badge/9f490da7e2-fix-green" alt="fix - 9f490da7e2" /></a></td>
-                <td>handle hydration of view containers for root components (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/51247">#51247</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h3>router</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/0b14e4ef742b1c0f73d873e2c337683b60f46845"><img src="https://img.shields.io/badge/0b14e4ef74-feat-blue" alt="feat - 0b14e4ef74" /></a></td>
-                <td>exposes the <code>fixture</code> of the <code>RouterTestingHarness</code> (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/50280">#50280</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h2>v16.2.0-rc.0</h2>
-                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
-                <h1>16.2.0-rc.0 (2023-08-02)</h1>
-                <h3>compiler</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/6755f5354c7657ecb6f2643450dd2572b114a895"><img src="https://img.shields.io/badge/6755f5354c-fix-green" alt="fix - 6755f5354c" /></a></td>
-                <td>return full spans for Comment nodes (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/50855">#50855</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h3>core</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/e53d4ecf4cfd9e64d6ba8c8b19adbb7df9cfc047"><img src="https://img.shields.io/badge/e53d4ecf4c-feat-blue" alt="feat - e53d4ecf4c" /></a></td>
-                <td>add afterRender and afterNextRender (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/50607">#50607</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/98d262fd27795014ee3988b08d3c48a0dfb63c40"><img src="https://img.shields.io/badge/98d262fd27-feat-blue" alt="feat - 98d262fd27" /></a></td>
-                <td>create injector debugging APIs (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/48639">#48639</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/cdaa2a8a9eab490b55bbb841ede4f54a2656df30"><img src="https://img.shields.io/badge/cdaa2a8a9e-feat-blue" alt="feat - cdaa2a8a9e" /></a></td>
-                <td>support Provider type in Injector.create (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/49587">#49587</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h2>v16.2.0-next.4</h2>
-                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
-                <h1>16.2.0-next.4 (2023-07-26)</h1>
-                <h3>common</h3>
-                <!-- raw HTML omitted -->
-                </blockquote>
-                <p>... (truncated)</p>
-                </details>
+                Updates `@angular/compiler` from 15.0.0 to 15.2.10
                 <details>
                 <summary>Changelog</summary>
                 <p><em>Sourced from <a href="https://github.com/angular/angular/blob/main/CHANGELOG.md"><code>@​angular/compiler</code>'s changelog</a>.</em></p>
                 <blockquote>
-                <h1>16.2.0 (2023-08-09)</h1>
-                <h3>benchpress</h3>
+                <h1>15.2.10 (2023-10-04)</h1>
+                <h3>service-worker</h3>
                 <table>
                 <thead>
                 <tr>
@@ -1397,13 +879,16 @@ output:
                 </thead>
                 <tbody>
                 <tr>
-                <td><a href="https://github.com/angular/angular/commit/dd850b2ab781f24065550f8a948ced498e0f1e99">dd850b2ab7</a></td>
+                <td><a href="https://github.com/angular/angular/commit/9fe08968b84b92da47ce91f5d2860b3aa23d2d2b">9fe08968b8</a></td>
                 <td>fix</td>
-                <td>correctly report GC memory amounts (<a href="https://redirect.github.com/angular/angular/pull/50760">#50760</a>)</td>
+                <td>throw a critical error when handleFetch fail (<a href="https://redirect.github.com/angular/angular/pull/51989">#51989</a>)</td>
                 </tr>
                 </tbody>
                 </table>
-                <h3>common</h3>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.7 (2023-09-27)</h1>
+                <h3>core</h3>
                 <table>
                 <thead>
                 <tr>
@@ -1414,18 +899,13 @@ output:
                 </thead>
                 <tbody>
                 <tr>
-                <td><a href="https://github.com/angular/angular/commit/29d358170b046f4a6773dfdfbbd1050f54deb301">29d358170b</a></td>
-                <td>feat</td>
-                <td>add component input binding support for NgComponentOutlet (<a href="https://redirect.github.com/angular/angular/pull/51148">#51148</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/1837efb9daf5c8e86a99a06ecc77bb42bc60dbb0">1837efb9da</a></td>
-                <td>feat</td>
-                <td>Allow ngSrc to be changed post-init (<a href="https://redirect.github.com/angular/angular/pull/50683">#50683</a>)</td>
+                <td><a href="https://github.com/angular/angular/commit/39a3e34e035b324bfa1f1a11cf452272c91011c6">39a3e34e03</a></td>
+                <td>fix</td>
+                <td>allow toSignal calls in reactive context (<a href="https://redirect.github.com/angular/angular/pull/51831">#51831</a>) (<a href="https://redirect.github.com/angular/angular/pull/51892">#51892</a>)</td>
                 </tr>
                 </tbody>
                 </table>
-                <h3>compiler</h3>
+                <h3>service-worker</h3>
                 <table>
                 <thead>
                 <tr>
@@ -1436,9 +916,55 @@ output:
                 </thead>
                 <tbody>
                 <tr>
-                <td><a href="https://github.com/angular/angular/commit/c27a1e61d64a67aa169086f7db11bcfd5bb7d2fc">c27a1e61d6</a></td>
-                <td>feat</td>
-                <td>scope selectors in <a href="https://github.com/scope"><code>@​scope</code></a> queries (<a href="https://redirect.github.com/angular/angular/pull/50747">#50747</a>)</td>
+                <td><a href="https://github.com/angular/angular/commit/c3d901eacfe8d035441e5c990f6e6b2630d592f5">c3d901eacf</a></td>
+                <td>fix</td>
+                <td>throw a critical error when <code>handleFetch</code> fails (<a href="https://redirect.github.com/angular/angular/pull/51885">#51885</a>)</td>
+                </tr>
+                </tbody>
+                </table>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.6 (2023-09-20)</h1>
+                <h3>core</h3>
+                <table>
+                <thead>
+                <tr>
+                <th>Commit</th>
+                <th>Type</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/82712f80dfc6aed2baf8d8f80c3552a6707c88ff">82712f80df</a></td>
+                <td>fix</td>
+                <td>ensure a consumer drops all its stale producers (<a href="https://redirect.github.com/angular/angular/pull/51722">#51722</a>) (<a href="https://redirect.github.com/angular/angular/pull/51772">#51772</a>)</td>
+                </tr>
+                </tbody>
+                </table>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.5 (2023-09-13)</h1>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.4 (2023-09-06)</h1>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.3 (2023-08-30)</h1>
+                <h3>animations</h3>
+                <table>
+                <thead>
+                <tr>
+                <th>Commit</th>
+                <th>Type</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/04c65742802537c8bd725f9a7a931955a67684d9">04c6574280</a></td>
+                <td>fix</td>
+                <td>remove unnecessary escaping in regex expressions (<a href="https://redirect.github.com/angular/angular/pull/51554">#51554</a>)</td>
                 </tr>
                 </tbody>
                 </table>
@@ -1453,89 +979,12 @@ output:
                 </thead>
                 <tbody>
                 <tr>
-                <td><a href="https://github.com/angular/angular/commit/12bad6576d2ffe4667118b214d9c7598ed3d8edb">12bad6576d</a></td>
+                <td><a href="https://github.com/angular/angular/commit/dbd761f528a08cba0fbdd476b115e1445683cf36">dbd761f528</a></td>
                 <td>fix</td>
-                <td>libraries compiled with v16.1+ breaking with Angular framework v16.0.x (<a href="https://redirect.github.com/angular/angular/pull/50714">#50714</a>)</td>
+                <td>correct incomplete escaping (<a href="https://redirect.github.com/angular/angular/pull/51557">#51557</a>)</td>
                 </tr>
                 </tbody>
                 </table>
-                <h3>core</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Type</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/e53d4ecf4cfd9e64d6ba8c8b19adbb7df9cfc047">e53d4ecf4c</a></td>
-                <td>feat</td>
-                <td>add afterRender and afterNextRender (<a href="https://redirect.github.com/angular/angular/pull/50607">#50607</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/98d262fd27795014ee3988b08d3c48a0dfb63c40">98d262fd27</a></td>
-                <td>feat</td>
-                <td>create injector debugging APIs (<a href="https://redirect.github.com/angular/angular/pull/48639">#48639</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/cdaa2a8a9eab490b55bbb841ede4f54a2656df30">cdaa2a8a9e</a></td>
-                <td>feat</td>
-                <td>support Provider type in Injector.create (<a href="https://redirect.github.com/angular/angular/pull/49587">#49587</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/9f490da7e27e495cb45d2064af9091731422a6b1">9f490da7e2</a></td>
-                <td>fix</td>
-                <td>handle hydration of view containers for root components (<a href="https://redirect.github.com/angular/angular/pull/51247">#51247</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h3>router</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Type</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/0b14e4ef742b1c0f73d873e2c337683b60f46845">0b14e4ef74</a></td>
-                <td>feat</td>
-                <td>exposes the <code>fixture</code> of the <code>RouterTestingHarness</code> (<a href="https://redirect.github.com/angular/angular/pull/50280">#50280</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <!-- raw HTML omitted -->
-                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
-                <h1>16.1.9 (2023-08-09)</h1>
-                <!-- raw HTML omitted -->
-                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
-                <h1>16.1.8 (2023-08-02)</h1>
-                <h3>compiler</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Type</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/cc722ea1f5b16f5a4fddc1ecd91b21b3005242ae">cc722ea1f5</a></td>
-                <td>fix</td>
-                <td>return full spans for Comment nodes (<a href="https://redirect.github.com/angular/angular/pull/50855">#50855</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <!-- raw HTML omitted -->
-                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
-                <h1>16.1.7 (2023-07-26)</h1>
-                <h3>http</h3>
-                <p>| Commit | Type | Description |</p>
                 <!-- raw HTML omitted -->
                 </blockquote>
                 <p>... (truncated)</p>
@@ -1543,190 +992,28 @@ output:
                 <details>
                 <summary>Commits</summary>
                 <ul>
-                <li><a href="https://github.com/angular/angular/commit/2d52d5e62c4364808c4e3c62d1fb98e3203c5d61"><code>2d52d5e</code></a> refactor(compiler): support safe function calls (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/51100">#51100</a>)</li>
-                <li><a href="https://github.com/angular/angular/commit/42caeeef219214a6af7c9ed91b4ff874b7c2cccd"><code>42caeee</code></a> refactor(compiler): reuse temp vars when possible (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/51100">#51100</a>)</li>
-                <li><a href="https://github.com/angular/angular/commit/efb486e8bc8712a961a73180fed324bbaac93348"><code>efb486e</code></a> refactor(compiler): handle defer blocks in TemplateDefinitionBuilder (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/51162">#51162</a>)</li>
-                <li><a href="https://github.com/angular/angular/commit/08992a5f2f91b9791312d8c0bc75bb6d702c75e5"><code>08992a5</code></a> refactor(compiler): compute the list of dependencies for defer blocks (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/51162">#51162</a>)</li>
-                <li><a href="https://github.com/angular/angular/commit/553cbaed8472d8b2d12a4c3597a8838314c3019d"><code>553cbae</code></a> refactor(compiler): update TemplateBinder and DirectiveBinder to work with de...</li>
-                <li><a href="https://github.com/angular/angular/commit/c1052cf7a77e0bf2a4ec14f9dd5abc92034cfd2e"><code>c1052cf</code></a> refactor(compiler): add support for sanitizing properties and attributes (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/51">#51</a>...</li>
-                <li><a href="https://github.com/angular/angular/commit/72255288bf6d2f7bcd58d5970e9f4ec572e6c013"><code>7225528</code></a> refactor(compiler): add utility to enable deferred blocks for testing (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/51183">#51183</a>)</li>
-                <li><a href="https://github.com/angular/angular/commit/09bf32724f3977a6e8eb536a9ae53513ef2c9166"><code>09bf327</code></a> refactor(compiler): add support for animation listeners (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/50975">#50975</a>)</li>
-                <li><a href="https://github.com/angular/angular/commit/570bd67eaee76b79a5b902745f7786bcf419cd75"><code>570bd67</code></a> refactor(compiler): make listener instruction chainable (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/50975">#50975</a>)</li>
-                <li><a href="https://github.com/angular/angular/commit/7dd99cd84302a2d196243957c6e3543813b54a1c"><code>7dd99cd</code></a> refactor(compiler): add support for animation properties (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/50975">#50975</a>)</li>
-                <li>Additional commits viewable in <a href="https://github.com/angular/angular/commits/16.2.0/packages/compiler">compare view</a></li>
+                <li><a href="https://github.com/angular/angular/commit/077f6b4674c01bfed083e73a17d848e226e543b4"><code>077f6b4</code></a> fix(compiler): do not unquote CSS values (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/49460">#49460</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/4c89a2497aef1f4c8b8ee2786414145596c1e3f3"><code>4c89a24</code></a> refactor(common): add missing <code>override</code> to satisfy the linter (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/49599">#49599</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/c3cff35869648fdf70c9707c3d87bcfdcc84d903"><code>c3cff35</code></a> fix(compiler): handle trailing comma in object literal (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/49535">#49535</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/c2bcf0b47540510a24931da7cd24f58b60788881"><code>c2bcf0b</code></a> refactor(compiler): Remove strictStyling option for ShadowCss (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/48824">#48824</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/06e161f2dd78b42ad1938578f4d730a41404a24f"><code>06e161f</code></a> fix(compiler): incorrect code when non-null assertion is used after a safe ac...</li>
+                <li><a href="https://github.com/angular/angular/commit/bc8cfa25520c3b8b0a506c69a269e42a63f097d6"><code>bc8cfa2</code></a> fix(compiler): handle css selectors with space after an escaped character. (#...</li>
+                <li><a href="https://github.com/angular/angular/commit/6beff5e8d708b575c38320fc8f997bd304a738f3"><code>6beff5e</code></a> refactor(compiler): rework and expose APIs to be used in schematics (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/48730">#48730</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/61023b563d5545f5d9066b959c3ebc0464d29113"><code>61023b5</code></a> refactor(compiler): refactor the shadow css specs (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/48443">#48443</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/fc1c03e16efcfb31e72f674a95e6189f060a7594"><code>fc1c03e</code></a> refactor(compiler): Remove unnecessary assignment (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/48478">#48478</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/a532d71975bef463223fd5d8322e3140760c9134"><code>a532d71</code></a> feat(compiler): allow self-closing tags on custom elements (<a href="https://github.com/angular/angular/tree/HEAD/packages/compiler/issues/48535">#48535</a>)</li>
+                <li>Additional commits viewable in <a href="https://github.com/angular/angular/commits/15.2.10/packages/compiler">compare view</a></li>
                 </ul>
                 </details>
                 <br />
 
-                Updates `@angular/core` from 15.0.0 to 16.2.0
-                <details>
-                <summary>Release notes</summary>
-                <p><em>Sourced from <a href="https://github.com/angular/angular/releases"><code>@​angular/core</code>'s releases</a>.</em></p>
-                <blockquote>
-                <h2>v16.2.0</h2>
-                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
-                <h1>16.2.0 (2023-08-09)</h1>
-                <h3>benchpress</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/dd850b2ab781f24065550f8a948ced498e0f1e99"><img src="https://img.shields.io/badge/dd850b2ab7-fix-green" alt="fix - dd850b2ab7" /></a></td>
-                <td>correctly report GC memory amounts (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/50760">#50760</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h3>common</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/29d358170b046f4a6773dfdfbbd1050f54deb301"><img src="https://img.shields.io/badge/29d358170b-feat-blue" alt="feat - 29d358170b" /></a></td>
-                <td>add component input binding support for NgComponentOutlet (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/51148">#51148</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/1837efb9daf5c8e86a99a06ecc77bb42bc60dbb0"><img src="https://img.shields.io/badge/1837efb9da-feat-blue" alt="feat - 1837efb9da" /></a></td>
-                <td>Allow ngSrc to be changed post-init (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/50683">#50683</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h3>compiler</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/c27a1e61d64a67aa169086f7db11bcfd5bb7d2fc"><img src="https://img.shields.io/badge/c27a1e61d6-feat-blue" alt="feat - c27a1e61d6" /></a></td>
-                <td>scope selectors in <a href="https://github.com/scope"><code>@​scope</code></a> queries (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/50747">#50747</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h3>compiler-cli</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/12bad6576d2ffe4667118b214d9c7598ed3d8edb"><img src="https://img.shields.io/badge/12bad6576d-fix-green" alt="fix - 12bad6576d" /></a></td>
-                <td>libraries compiled with v16.1+ breaking with Angular framework v16.0.x (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/50714">#50714</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h3>core</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/e53d4ecf4cfd9e64d6ba8c8b19adbb7df9cfc047"><img src="https://img.shields.io/badge/e53d4ecf4c-feat-blue" alt="feat - e53d4ecf4c" /></a></td>
-                <td>add afterRender and afterNextRender (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/50607">#50607</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/98d262fd27795014ee3988b08d3c48a0dfb63c40"><img src="https://img.shields.io/badge/98d262fd27-feat-blue" alt="feat - 98d262fd27" /></a></td>
-                <td>create injector debugging APIs (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/48639">#48639</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/cdaa2a8a9eab490b55bbb841ede4f54a2656df30"><img src="https://img.shields.io/badge/cdaa2a8a9e-feat-blue" alt="feat - cdaa2a8a9e" /></a></td>
-                <td>support Provider type in Injector.create (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/49587">#49587</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/9f490da7e27e495cb45d2064af9091731422a6b1"><img src="https://img.shields.io/badge/9f490da7e2-fix-green" alt="fix - 9f490da7e2" /></a></td>
-                <td>handle hydration of view containers for root components (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/51247">#51247</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h3>router</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/0b14e4ef742b1c0f73d873e2c337683b60f46845"><img src="https://img.shields.io/badge/0b14e4ef74-feat-blue" alt="feat - 0b14e4ef74" /></a></td>
-                <td>exposes the <code>fixture</code> of the <code>RouterTestingHarness</code> (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/50280">#50280</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h2>v16.2.0-rc.0</h2>
-                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
-                <h1>16.2.0-rc.0 (2023-08-02)</h1>
-                <h3>compiler</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/6755f5354c7657ecb6f2643450dd2572b114a895"><img src="https://img.shields.io/badge/6755f5354c-fix-green" alt="fix - 6755f5354c" /></a></td>
-                <td>return full spans for Comment nodes (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/50855">#50855</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h3>core</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/e53d4ecf4cfd9e64d6ba8c8b19adbb7df9cfc047"><img src="https://img.shields.io/badge/e53d4ecf4c-feat-blue" alt="feat - e53d4ecf4c" /></a></td>
-                <td>add afterRender and afterNextRender (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/50607">#50607</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/98d262fd27795014ee3988b08d3c48a0dfb63c40"><img src="https://img.shields.io/badge/98d262fd27-feat-blue" alt="feat - 98d262fd27" /></a></td>
-                <td>create injector debugging APIs (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/48639">#48639</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/cdaa2a8a9eab490b55bbb841ede4f54a2656df30"><img src="https://img.shields.io/badge/cdaa2a8a9e-feat-blue" alt="feat - cdaa2a8a9e" /></a></td>
-                <td>support Provider type in Injector.create (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/49587">#49587</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h2>v16.2.0-next.4</h2>
-                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
-                <h1>16.2.0-next.4 (2023-07-26)</h1>
-                <h3>common</h3>
-                <!-- raw HTML omitted -->
-                </blockquote>
-                <p>... (truncated)</p>
-                </details>
+                Updates `@angular/core` from 15.0.0 to 15.2.10
                 <details>
                 <summary>Changelog</summary>
                 <p><em>Sourced from <a href="https://github.com/angular/angular/blob/main/CHANGELOG.md"><code>@​angular/core</code>'s changelog</a>.</em></p>
                 <blockquote>
-                <h1>16.2.0 (2023-08-09)</h1>
-                <h3>benchpress</h3>
+                <h1>15.2.10 (2023-10-04)</h1>
+                <h3>service-worker</h3>
                 <table>
                 <thead>
                 <tr>
@@ -1737,13 +1024,16 @@ output:
                 </thead>
                 <tbody>
                 <tr>
-                <td><a href="https://github.com/angular/angular/commit/dd850b2ab781f24065550f8a948ced498e0f1e99">dd850b2ab7</a></td>
+                <td><a href="https://github.com/angular/angular/commit/9fe08968b84b92da47ce91f5d2860b3aa23d2d2b">9fe08968b8</a></td>
                 <td>fix</td>
-                <td>correctly report GC memory amounts (<a href="https://redirect.github.com/angular/angular/pull/50760">#50760</a>)</td>
+                <td>throw a critical error when handleFetch fail (<a href="https://redirect.github.com/angular/angular/pull/51989">#51989</a>)</td>
                 </tr>
                 </tbody>
                 </table>
-                <h3>common</h3>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.7 (2023-09-27)</h1>
+                <h3>core</h3>
                 <table>
                 <thead>
                 <tr>
@@ -1754,18 +1044,13 @@ output:
                 </thead>
                 <tbody>
                 <tr>
-                <td><a href="https://github.com/angular/angular/commit/29d358170b046f4a6773dfdfbbd1050f54deb301">29d358170b</a></td>
-                <td>feat</td>
-                <td>add component input binding support for NgComponentOutlet (<a href="https://redirect.github.com/angular/angular/pull/51148">#51148</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/1837efb9daf5c8e86a99a06ecc77bb42bc60dbb0">1837efb9da</a></td>
-                <td>feat</td>
-                <td>Allow ngSrc to be changed post-init (<a href="https://redirect.github.com/angular/angular/pull/50683">#50683</a>)</td>
+                <td><a href="https://github.com/angular/angular/commit/39a3e34e035b324bfa1f1a11cf452272c91011c6">39a3e34e03</a></td>
+                <td>fix</td>
+                <td>allow toSignal calls in reactive context (<a href="https://redirect.github.com/angular/angular/pull/51831">#51831</a>) (<a href="https://redirect.github.com/angular/angular/pull/51892">#51892</a>)</td>
                 </tr>
                 </tbody>
                 </table>
-                <h3>compiler</h3>
+                <h3>service-worker</h3>
                 <table>
                 <thead>
                 <tr>
@@ -1776,9 +1061,55 @@ output:
                 </thead>
                 <tbody>
                 <tr>
-                <td><a href="https://github.com/angular/angular/commit/c27a1e61d64a67aa169086f7db11bcfd5bb7d2fc">c27a1e61d6</a></td>
-                <td>feat</td>
-                <td>scope selectors in <a href="https://github.com/scope"><code>@​scope</code></a> queries (<a href="https://redirect.github.com/angular/angular/pull/50747">#50747</a>)</td>
+                <td><a href="https://github.com/angular/angular/commit/c3d901eacfe8d035441e5c990f6e6b2630d592f5">c3d901eacf</a></td>
+                <td>fix</td>
+                <td>throw a critical error when <code>handleFetch</code> fails (<a href="https://redirect.github.com/angular/angular/pull/51885">#51885</a>)</td>
+                </tr>
+                </tbody>
+                </table>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.6 (2023-09-20)</h1>
+                <h3>core</h3>
+                <table>
+                <thead>
+                <tr>
+                <th>Commit</th>
+                <th>Type</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/82712f80dfc6aed2baf8d8f80c3552a6707c88ff">82712f80df</a></td>
+                <td>fix</td>
+                <td>ensure a consumer drops all its stale producers (<a href="https://redirect.github.com/angular/angular/pull/51722">#51722</a>) (<a href="https://redirect.github.com/angular/angular/pull/51772">#51772</a>)</td>
+                </tr>
+                </tbody>
+                </table>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.5 (2023-09-13)</h1>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.4 (2023-09-06)</h1>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.3 (2023-08-30)</h1>
+                <h3>animations</h3>
+                <table>
+                <thead>
+                <tr>
+                <th>Commit</th>
+                <th>Type</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/04c65742802537c8bd725f9a7a931955a67684d9">04c6574280</a></td>
+                <td>fix</td>
+                <td>remove unnecessary escaping in regex expressions (<a href="https://redirect.github.com/angular/angular/pull/51554">#51554</a>)</td>
                 </tr>
                 </tbody>
                 </table>
@@ -1793,89 +1124,12 @@ output:
                 </thead>
                 <tbody>
                 <tr>
-                <td><a href="https://github.com/angular/angular/commit/12bad6576d2ffe4667118b214d9c7598ed3d8edb">12bad6576d</a></td>
+                <td><a href="https://github.com/angular/angular/commit/dbd761f528a08cba0fbdd476b115e1445683cf36">dbd761f528</a></td>
                 <td>fix</td>
-                <td>libraries compiled with v16.1+ breaking with Angular framework v16.0.x (<a href="https://redirect.github.com/angular/angular/pull/50714">#50714</a>)</td>
+                <td>correct incomplete escaping (<a href="https://redirect.github.com/angular/angular/pull/51557">#51557</a>)</td>
                 </tr>
                 </tbody>
                 </table>
-                <h3>core</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Type</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/e53d4ecf4cfd9e64d6ba8c8b19adbb7df9cfc047">e53d4ecf4c</a></td>
-                <td>feat</td>
-                <td>add afterRender and afterNextRender (<a href="https://redirect.github.com/angular/angular/pull/50607">#50607</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/98d262fd27795014ee3988b08d3c48a0dfb63c40">98d262fd27</a></td>
-                <td>feat</td>
-                <td>create injector debugging APIs (<a href="https://redirect.github.com/angular/angular/pull/48639">#48639</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/cdaa2a8a9eab490b55bbb841ede4f54a2656df30">cdaa2a8a9e</a></td>
-                <td>feat</td>
-                <td>support Provider type in Injector.create (<a href="https://redirect.github.com/angular/angular/pull/49587">#49587</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/9f490da7e27e495cb45d2064af9091731422a6b1">9f490da7e2</a></td>
-                <td>fix</td>
-                <td>handle hydration of view containers for root components (<a href="https://redirect.github.com/angular/angular/pull/51247">#51247</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h3>router</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Type</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/0b14e4ef742b1c0f73d873e2c337683b60f46845">0b14e4ef74</a></td>
-                <td>feat</td>
-                <td>exposes the <code>fixture</code> of the <code>RouterTestingHarness</code> (<a href="https://redirect.github.com/angular/angular/pull/50280">#50280</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <!-- raw HTML omitted -->
-                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
-                <h1>16.1.9 (2023-08-09)</h1>
-                <!-- raw HTML omitted -->
-                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
-                <h1>16.1.8 (2023-08-02)</h1>
-                <h3>compiler</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Type</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/cc722ea1f5b16f5a4fddc1ecd91b21b3005242ae">cc722ea1f5</a></td>
-                <td>fix</td>
-                <td>return full spans for Comment nodes (<a href="https://redirect.github.com/angular/angular/pull/50855">#50855</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <!-- raw HTML omitted -->
-                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
-                <h1>16.1.7 (2023-07-26)</h1>
-                <h3>http</h3>
-                <p>| Commit | Type | Description |</p>
                 <!-- raw HTML omitted -->
                 </blockquote>
                 <p>... (truncated)</p>
@@ -1883,75 +1137,124 @@ output:
                 <details>
                 <summary>Commits</summary>
                 <ul>
-                <li><a href="https://github.com/angular/angular/commit/9f490da7e27e495cb45d2064af9091731422a6b1"><code>9f490da</code></a> fix(core): handle hydration of view containers for root components (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/51247">#51247</a>)</li>
-                <li><a href="https://github.com/angular/angular/commit/b95b5b55d8dfbd9cbb9c319e34d329de1bccf8f2"><code>b95b5b5</code></a> refactor(core): throw an error when hydration marker is missing from DOM (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/51">#51</a>...</li>
-                <li><a href="https://github.com/angular/angular/commit/26781fd0fe5c26c7e1915eb1668817b4f14c50c3"><code>26781fd</code></a> refactor(core): remove unnecessary import for custom expect. (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/51216">#51216</a>)</li>
-                <li><a href="https://github.com/angular/angular/commit/c7c0723c7ff63988481db7c50ce9c65d2dfa5b86"><code>c7c0723</code></a> refactor(core): deprecate <code>PACKAGE_ROOT_URL</code> token (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/51222">#51222</a>)</li>
-                <li><a href="https://github.com/angular/angular/commit/e01549b26b7ed04f18285395a7d3336ada354865"><code>e01549b</code></a> refactor(core): introduce LView and LContainer utility functions (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/51191">#51191</a>)</li>
-                <li><a href="https://github.com/angular/angular/commit/e53d4ecf4cfd9e64d6ba8c8b19adbb7df9cfc047"><code>e53d4ec</code></a> feat(core): add afterRender and afterNextRender (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/50607">#50607</a>)</li>
-                <li><a href="https://github.com/angular/angular/commit/8913d3e4075e82a04a175f2ae2cee6ad045aa0f2"><code>8913d3e</code></a> docs: fix warning about an unknown decorator (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/51237">#51237</a>)</li>
-                <li><a href="https://github.com/angular/angular/commit/4602545fe6d6a5cd13929a966ca14c4bdca526a7"><code>4602545</code></a> refactor(core): remove useless hack (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/51224">#51224</a>)</li>
-                <li><a href="https://github.com/angular/angular/commit/d81d12581452d8cfbdeccd971f1400e2cac073c5"><code>d81d125</code></a> refactor(core): Remove dead unit test code (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/51223">#51223</a>)</li>
-                <li><a href="https://github.com/angular/angular/commit/9d59764ffced7d8260282e0445860e7e0279d2dc"><code>9d59764</code></a> refactor(core): createInjector is a private function (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/51221">#51221</a>)</li>
-                <li>Additional commits viewable in <a href="https://github.com/angular/angular/commits/16.2.0/packages/core">compare view</a></li>
+                <li><a href="https://github.com/angular/angular/commit/9d6654896f4a328b2f1fc16cbe16eddd232f5bf9"><code>9d66548</code></a> test(common): test rounding problems in image distortion detection (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/49889">#49889</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/6764fb63ff0b69f00238dc6597a5dc272537edd6"><code>6764fb6</code></a> test(common): show ngOptimizedImage distortion detection failure on padded im...</li>
+                <li><a href="https://github.com/angular/angular/commit/2fff8fadbeff9df3bc09b8847dbf08febbe3b5f8"><code>2fff8fa</code></a> fix(core): handle invalid classes in class array bindings (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/49924">#49924</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/bce7f6bfd9829c308f6ebee0ffc8c9a9d75a8b5a"><code>bce7f6b</code></a> refactor(core): Remove ununsed Zone mock from testing internals. (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/49873">#49873</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/08ba49296ab0427f74dfe1a34b4ceaeee2291608"><code>08ba492</code></a> refactor(core): improve styling coverage (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/49868">#49868</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/f266a05d2f26d62e1e0787cbdd0c121159d59566"><code>f266a05</code></a> refactor(core): drop IE workarounds (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/49763">#49763</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/702ec901100b2d84efdf0b16d8347f8b28b94d5d"><code>702ec90</code></a> fix(core): When using setInput, mark view dirty in same way as <code>markForCheck</code>...</li>
+                <li><a href="https://github.com/angular/angular/commit/ffdfdc238f6dee00fc0c7c1f57484d4e186d99a2"><code>ffdfdc2</code></a> refactor(migrations): log a link to the standalone migration (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/49752">#49752</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/da5f316ebf19ec932e0c7e99d29eb0bbd38b57b2"><code>da5f316</code></a> refactor(core): Use the nullish coalescing assignment in render3 functions (#...</li>
+                <li><a href="https://github.com/angular/angular/commit/d9efa1b0d742217de1164f7904c202b2697348d9"><code>d9efa1b</code></a> feat(core): change the URL sanitization to only block javascript: URLs (<a href="https://github.com/angular/angular/tree/HEAD/packages/core/issues/49659">#49659</a>)</li>
+                <li>Additional commits viewable in <a href="https://github.com/angular/angular/commits/15.2.10/packages/core">compare view</a></li>
                 </ul>
                 </details>
                 <br />
 
-                Updates `@angular/forms` from 15.0.0 to 16.2.0
+                Updates `@angular/forms` from 15.0.0 to 15.2.10
                 <details>
-                <summary>Release notes</summary>
-                <p><em>Sourced from <a href="https://github.com/angular/angular/releases"><code>@​angular/forms</code>'s releases</a>.</em></p>
+                <summary>Changelog</summary>
+                <p><em>Sourced from <a href="https://github.com/angular/angular/blob/main/CHANGELOG.md"><code>@​angular/forms</code>'s changelog</a>.</em></p>
                 <blockquote>
-                <h2>v16.2.0</h2>
+                <h1>15.2.10 (2023-10-04)</h1>
+                <h3>service-worker</h3>
+                <table>
+                <thead>
+                <tr>
+                <th>Commit</th>
+                <th>Type</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/9fe08968b84b92da47ce91f5d2860b3aa23d2d2b">9fe08968b8</a></td>
+                <td>fix</td>
+                <td>throw a critical error when handleFetch fail (<a href="https://redirect.github.com/angular/angular/pull/51989">#51989</a>)</td>
+                </tr>
+                </tbody>
+                </table>
+                <!-- raw HTML omitted -->
                 <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
-                <h1>16.2.0 (2023-08-09)</h1>
-                <h3>benchpress</h3>
+                <h1>16.2.7 (2023-09-27)</h1>
+                <h3>core</h3>
                 <table>
                 <thead>
                 <tr>
                 <th>Commit</th>
+                <th>Type</th>
                 <th>Description</th>
                 </tr>
                 </thead>
                 <tbody>
                 <tr>
-                <td><a href="https://github.com/angular/angular/commit/dd850b2ab781f24065550f8a948ced498e0f1e99"><img src="https://img.shields.io/badge/dd850b2ab7-fix-green" alt="fix - dd850b2ab7" /></a></td>
-                <td>correctly report GC memory amounts (<a href="https://github.com/angular/angular/tree/HEAD/packages/forms/issues/50760">#50760</a>)</td>
+                <td><a href="https://github.com/angular/angular/commit/39a3e34e035b324bfa1f1a11cf452272c91011c6">39a3e34e03</a></td>
+                <td>fix</td>
+                <td>allow toSignal calls in reactive context (<a href="https://redirect.github.com/angular/angular/pull/51831">#51831</a>) (<a href="https://redirect.github.com/angular/angular/pull/51892">#51892</a>)</td>
                 </tr>
                 </tbody>
                 </table>
-                <h3>common</h3>
+                <h3>service-worker</h3>
                 <table>
                 <thead>
                 <tr>
                 <th>Commit</th>
+                <th>Type</th>
                 <th>Description</th>
                 </tr>
                 </thead>
                 <tbody>
                 <tr>
-                <td><a href="https://github.com/angular/angular/commit/29d358170b046f4a6773dfdfbbd1050f54deb301"><img src="https://img.shields.io/badge/29d358170b-feat-blue" alt="feat - 29d358170b" /></a></td>
-                <td>add component input binding support for NgComponentOutlet (<a href="https://github.com/angular/angular/tree/HEAD/packages/forms/issues/51148">#51148</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/1837efb9daf5c8e86a99a06ecc77bb42bc60dbb0"><img src="https://img.shields.io/badge/1837efb9da-feat-blue" alt="feat - 1837efb9da" /></a></td>
-                <td>Allow ngSrc to be changed post-init (<a href="https://github.com/angular/angular/tree/HEAD/packages/forms/issues/50683">#50683</a>)</td>
+                <td><a href="https://github.com/angular/angular/commit/c3d901eacfe8d035441e5c990f6e6b2630d592f5">c3d901eacf</a></td>
+                <td>fix</td>
+                <td>throw a critical error when <code>handleFetch</code> fails (<a href="https://redirect.github.com/angular/angular/pull/51885">#51885</a>)</td>
                 </tr>
                 </tbody>
                 </table>
-                <h3>compiler</h3>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.6 (2023-09-20)</h1>
+                <h3>core</h3>
                 <table>
                 <thead>
                 <tr>
                 <th>Commit</th>
+                <th>Type</th>
                 <th>Description</th>
                 </tr>
                 </thead>
                 <tbody>
                 <tr>
-                <td><a href="https://github.com/angular/angular/commit/c27a1e61d64a67aa169086f7db11bcfd5bb7d2fc"><img src="https://img.shields.io/badge/c27a1e61d6-feat-blue" alt="feat - c27a1e61d6" /></a></td>
-                <td>scope selectors in <a href="https://github.com/scope"><code>@​scope</code></a> queries (<a href="https://github.com/angular/angular/tree/HEAD/packages/forms/issues/50747">#50747</a>)</td>
+                <td><a href="https://github.com/angular/angular/commit/82712f80dfc6aed2baf8d8f80c3552a6707c88ff">82712f80df</a></td>
+                <td>fix</td>
+                <td>ensure a consumer drops all its stale producers (<a href="https://redirect.github.com/angular/angular/pull/51722">#51722</a>) (<a href="https://redirect.github.com/angular/angular/pull/51772">#51772</a>)</td>
+                </tr>
+                </tbody>
+                </table>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.5 (2023-09-13)</h1>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.4 (2023-09-06)</h1>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.3 (2023-08-30)</h1>
+                <h3>animations</h3>
+                <table>
+                <thead>
+                <tr>
+                <th>Commit</th>
+                <th>Type</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/04c65742802537c8bd725f9a7a931955a67684d9">04c6574280</a></td>
+                <td>fix</td>
+                <td>remove unnecessary escaping in regex expressions (<a href="https://redirect.github.com/angular/angular/pull/51554">#51554</a>)</td>
                 </tr>
                 </tbody>
                 </table>
@@ -1960,113 +1263,47 @@ output:
                 <thead>
                 <tr>
                 <th>Commit</th>
+                <th>Type</th>
                 <th>Description</th>
                 </tr>
                 </thead>
                 <tbody>
                 <tr>
-                <td><a href="https://github.com/angular/angular/commit/12bad6576d2ffe4667118b214d9c7598ed3d8edb"><img src="https://img.shields.io/badge/12bad6576d-fix-green" alt="fix - 12bad6576d" /></a></td>
-                <td>libraries compiled with v16.1+ breaking with Angular framework v16.0.x (<a href="https://github.com/angular/angular/tree/HEAD/packages/forms/issues/50714">#50714</a>)</td>
+                <td><a href="https://github.com/angular/angular/commit/dbd761f528a08cba0fbdd476b115e1445683cf36">dbd761f528</a></td>
+                <td>fix</td>
+                <td>correct incomplete escaping (<a href="https://redirect.github.com/angular/angular/pull/51557">#51557</a>)</td>
                 </tr>
                 </tbody>
                 </table>
-                <h3>core</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/e53d4ecf4cfd9e64d6ba8c8b19adbb7df9cfc047"><img src="https://img.shields.io/badge/e53d4ecf4c-feat-blue" alt="feat - e53d4ecf4c" /></a></td>
-                <td>add afterRender and afterNextRender (<a href="https://github.com/angular/angular/tree/HEAD/packages/forms/issues/50607">#50607</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/98d262fd27795014ee3988b08d3c48a0dfb63c40"><img src="https://img.shields.io/badge/98d262fd27-feat-blue" alt="feat - 98d262fd27" /></a></td>
-                <td>create injector debugging APIs (<a href="https://github.com/angular/angular/tree/HEAD/packages/forms/issues/48639">#48639</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/cdaa2a8a9eab490b55bbb841ede4f54a2656df30"><img src="https://img.shields.io/badge/cdaa2a8a9e-feat-blue" alt="feat - cdaa2a8a9e" /></a></td>
-                <td>support Provider type in Injector.create (<a href="https://github.com/angular/angular/tree/HEAD/packages/forms/issues/49587">#49587</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/9f490da7e27e495cb45d2064af9091731422a6b1"><img src="https://img.shields.io/badge/9f490da7e2-fix-green" alt="fix - 9f490da7e2" /></a></td>
-                <td>handle hydration of view containers for root components (<a href="https://github.com/angular/angular/tree/HEAD/packages/forms/issues/51247">#51247</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h3>router</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/0b14e4ef742b1c0f73d873e2c337683b60f46845"><img src="https://img.shields.io/badge/0b14e4ef74-feat-blue" alt="feat - 0b14e4ef74" /></a></td>
-                <td>exposes the <code>fixture</code> of the <code>RouterTestingHarness</code> (<a href="https://github.com/angular/angular/tree/HEAD/packages/forms/issues/50280">#50280</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h2>v16.2.0-rc.0</h2>
-                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
-                <h1>16.2.0-rc.0 (2023-08-02)</h1>
-                <h3>compiler</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/6755f5354c7657ecb6f2643450dd2572b114a895"><img src="https://img.shields.io/badge/6755f5354c-fix-green" alt="fix - 6755f5354c" /></a></td>
-                <td>return full spans for Comment nodes (<a href="https://github.com/angular/angular/tree/HEAD/packages/forms/issues/50855">#50855</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h3>core</h3>
-                <table>
-                <thead>
-                <tr>
-                <th>Commit</th>
-                <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/e53d4ecf4cfd9e64d6ba8c8b19adbb7df9cfc047"><img src="https://img.shields.io/badge/e53d4ecf4c-feat-blue" alt="feat - e53d4ecf4c" /></a></td>
-                <td>add afterRender and afterNextRender (<a href="https://github.com/angular/angular/tree/HEAD/packages/forms/issues/50607">#50607</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/98d262fd27795014ee3988b08d3c48a0dfb63c40"><img src="https://img.shields.io/badge/98d262fd27-feat-blue" alt="feat - 98d262fd27" /></a></td>
-                <td>create injector debugging APIs (<a href="https://github.com/angular/angular/tree/HEAD/packages/forms/issues/48639">#48639</a>)</td>
-                </tr>
-                <tr>
-                <td><a href="https://github.com/angular/angular/commit/cdaa2a8a9eab490b55bbb841ede4f54a2656df30"><img src="https://img.shields.io/badge/cdaa2a8a9e-feat-blue" alt="feat - cdaa2a8a9e" /></a></td>
-                <td>support Provider type in Injector.create (<a href="https://github.com/angular/angular/tree/HEAD/packages/forms/issues/49587">#49587</a>)</td>
-                </tr>
-                </tbody>
-                </table>
-                <h2>v16.2.0-next.4</h2>
-                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
-                <h1>16.2.0-next.4 (2023-07-26)</h1>
-                <h3>common</h3>
                 <!-- raw HTML omitted -->
                 </blockquote>
                 <p>... (truncated)</p>
                 </details>
                 <details>
+                <summary>Commits</summary>
+                <ul>
+                <li><a href="https://github.com/angular/angular/commit/b0a9e674199e0222b571cb92c1d784794dfec853"><code>b0a9e67</code></a> docs: fix links on untyped forms (<a href="https://github.com/angular/angular/tree/HEAD/packages/forms/issues/49306">#49306</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/59685614f82bee3f001b42398db88516407b34b1"><code>5968561</code></a> fix(forms): Make radio buttons respect <code>[attr.disabled]</code> (<a href="https://github.com/angular/angular/tree/HEAD/packages/forms/issues/48864">#48864</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/431ec6c8be87313ed2f724021b85526502a52a29"><code>431ec6c</code></a> refactor(forms): removing a workaround comment (<a href="https://github.com/angular/angular/tree/HEAD/packages/forms/issues/48904">#48904</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/33b9cb8693288f0c240259da461b0cf3f1412214"><code>33b9cb8</code></a> refactor: remove todos on forms tests (<a href="https://github.com/angular/angular/tree/HEAD/packages/forms/issues/48894">#48894</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/6edf35c8d60acca8cfd2ab72613d2290e4e0fb38"><code>6edf35c</code></a> refactor(forms): remove deprecated uses from the unit tests (<a href="https://github.com/angular/angular/tree/HEAD/packages/forms/issues/48894">#48894</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/4dcbb6aef9ec6d1f1fe9a926d0b40c72139a013b"><code>4dcbb6a</code></a> refactor(forms): replace type any for the providers (<a href="https://github.com/angular/angular/tree/HEAD/packages/forms/issues/48647">#48647</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/bdf288dcbfd1d680f17c04111926ff49e5e450dd"><code>bdf288d</code></a> fix(forms): Form provider FormsModule.withConfig return a FormsModule (<a href="https://github.com/angular/angular/tree/HEAD/packages/forms/issues/48526">#48526</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/b9577adeb274e61a6b5c3611d882da41589ec2da"><code>b9577ad</code></a> refactor(forms): cleanup type any in forms tests (<a href="https://github.com/angular/angular/tree/HEAD/packages/forms/issues/48624">#48624</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/a8f92554d0fd360c83b3a354c0ed46efc45904f9"><code>a8f9255</code></a> refactor: update <code>forms</code> package tests to work with ES2020 ESM (<a href="https://github.com/angular/angular/tree/HEAD/packages/forms/issues/48521">#48521</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/c9415e4d75a2567fe344e1fbc0b1713c2bd912ff"><code>c9415e4</code></a> build: ensure bootstrap transitive runfiles are made available (<a href="https://github.com/angular/angular/tree/HEAD/packages/forms/issues/48521">#48521</a>)</li>
+                <li>Additional commits viewable in <a href="https://github.com/angular/angular/commits/15.2.10/packages/forms">compare view</a></li>
+                </ul>
+                </details>
+                <br />
+
+                Updates `@angular/platform-browser` from 15.0.0 to 15.2.10
+                <details>
                 <summary>Changelog</summary>
-                <p><em>Sourced from <a href="https://github.com/angular/angular/blob/main/CHANGELOG.md"><code>@​angular/forms</code>'s changelog</a>.</em></p>
+                <p><em>Sourced from <a href="https://github.com/angular/angular/blob/main/CHANGELOG.md"><code>@​angular/platform-browser</code>'s changelog</a>.</em></p>
                 <blockquote>
-                <h1>16.2.0 (2023-08-09)</h1>
-                <h3>benchpress</h3>
+                <h1>15.2.10 (2023-10-04)</h1>
+                <h3>service-worker</h3>
                 <table>
                 <thead>
                 <tr>
@@ -2077,13 +1314,16 @@ output:
                 </thead>
                 <tbody>
                 <tr>
-                <td><a href="https://github.com/angular/angular/commit/dd850b2ab781f24065550f8a948ced498e0f1e99">dd850b2ab7</a></td>
+                <td><a href="https://github.com/angular/angular/commit/9fe08968b84b92da47ce91f5d2860b3aa23d2d2b">9fe08968b8</a></td>
                 <td>fix</td>
-                <td>correctly report GC memory amounts (<a href="https://redirect.github.com/angular/angular/pull/50760">#50760</a>)</td>
+                <td>throw a critical error when handleFetch fail (<a href="https://redirect.github.com/angular/angular/pull/51989">#51989</a>)</td>
                 </tr>
                 </tbody>
                 </table>
-                <h3>common</h3>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.7 (2023-09-27)</h1>
+                <h3>core</h3>
                 <table>
                 <thead>
                 <tr>
@@ -2094,14 +1334,403 @@ output:
                 </thead>
                 <tbody>
                 <tr>
-                <td><a href="https://github.com/angular/angular/commit/29d358170b046f4a6773dfdfbbd1050f54deb301">29d358170b</a></td>
-                <td>feat</td>
-                <td>add component input binding support for NgComponentOutlet (<a href="https://redirect.github.com/angular/angular/pull/51148">#51148</a>)</td>
+                <td><a href="https://github.com/angular/angular/commit/39a3e34e035b324bfa1f1a11cf452272c91011c6">39a3e34e03</a></td>
+                <td>fix</td>
+                <td>allow toSignal calls in reactive context (<a href="https://redirect.github.com/angular/angular/pull/51831">#51831</a>) (<a href="https://redirect.github.com/angular/angular/pull/51892">#51892</a>)</td>
                 </tr>
+                </tbody>
+                </table>
+                <h3>service-worker</h3>
+                <table>
+                <thead>
                 <tr>
-                <td><a href="https://gith...
+                <th>Commit</th>
+                <th>Type</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/c3d901eacfe8d035441e5c990f6e6b2630d592f5">c3d901eacf</a></td>
+                <td>fix</td>
+                <td>throw a critical error when <code>handleFetch</code> fails (<a href="https://redirect.github.com/angular/angular/pull/51885">#51885</a>)</td>
+                </tr>
+                </tbody>
+                </table>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.6 (2023-09-20)</h1>
+                <h3>core</h3>
+                <table>
+                <thead>
+                <tr>
+                <th>Commit</th>
+                <th>Type</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/82712f80dfc6aed2baf8d8f80c3552a6707c88ff">82712f80df</a></td>
+                <td>fix</td>
+                <td>ensure a consumer drops all its stale producers (<a href="https://redirect.github.com/angular/angular/pull/51722">#51722</a>) (<a href="https://redirect.github.com/angular/angular/pull/51772">#51772</a>)</td>
+                </tr>
+                </tbody>
+                </table>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.5 (2023-09-13)</h1>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.4 (2023-09-06)</h1>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.3 (2023-08-30)</h1>
+                <h3>animations</h3>
+                <table>
+                <thead>
+                <tr>
+                <th>Commit</th>
+                <th>Type</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/04c65742802537c8bd725f9a7a931955a67684d9">04c6574280</a></td>
+                <td>fix</td>
+                <td>remove unnecessary escaping in regex expressions (<a href="https://redirect.github.com/angular/angular/pull/51554">#51554</a>)</td>
+                </tr>
+                </tbody>
+                </table>
+                <h3>compiler-cli</h3>
+                <table>
+                <thead>
+                <tr>
+                <th>Commit</th>
+                <th>Type</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/dbd761f528a08cba0fbdd476b115e1445683cf36">dbd761f528</a></td>
+                <td>fix</td>
+                <td>correct incomplete escaping (<a href="https://redirect.github.com/angular/angular/pull/51557">#51557</a>)</td>
+                </tr>
+                </tbody>
+                </table>
+                <!-- raw HTML omitted -->
+                </blockquote>
+                <p>... (truncated)</p>
+                </details>
+                <details>
+                <summary>Commits</summary>
+                <ul>
+                <li><a href="https://github.com/angular/angular/commit/f266a05d2f26d62e1e0787cbdd0c121159d59566"><code>f266a05</code></a> refactor(core): drop IE workarounds (<a href="https://github.com/angular/angular/tree/HEAD/packages/platform-browser/issues/49763">#49763</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/6d6fc12c88e371673f9bf440e127487d29185855"><code>6d6fc12</code></a> refactor(core): Remove usage of deprecated <code>Injector.create()</code> (<a href="https://github.com/angular/angular/tree/HEAD/packages/platform-browser/issues/49606">#49606</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/4c89a2497aef1f4c8b8ee2786414145596c1e3f3"><code>4c89a24</code></a> refactor(common): add missing <code>override</code> to satisfy the linter (<a href="https://github.com/angular/angular/tree/HEAD/packages/platform-browser/issues/49599">#49599</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/84f45363eb3cf0bc48173b3f963cb509db3d5a08"><code>84f4536</code></a> refactor(platform-browser): remove ununsed functions. (<a href="https://github.com/angular/angular/tree/HEAD/packages/platform-browser/issues/49302">#49302</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/182258520dfac2d97a4b88dc16b973a5e9b81f65"><code>1822585</code></a> refactor(platform-browser): handle <a href="https://github.com/angular/angular/tree/HEAD/packages/platform-browser/issues/24571">#24571</a> todos (<a href="https://github.com/angular/angular/tree/HEAD/packages/platform-browser/issues/49232">#49232</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/8542593c8061fcff3062d030d262c7e9b9716bd1"><code>8542593</code></a> refactor(platform-browser): move TransferState init logic into its constructo...</li>
+                <li><a href="https://github.com/angular/angular/commit/bf4ad3811762d9ba43d18c3360d014a9ceb06b4d"><code>bf4ad38</code></a> fix(platform-browser): remove styles from DOM of destroyed components (<a href="https://github.com/angular/angular/tree/HEAD/packages/platform-browser/issues/48298">#48298</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/0331473e3ac33892577747229a91139942cf7d0d"><code>0331473</code></a> docs(platform-browser): Sanitize method has more explicit documentation (<a href="https://github.com/angular/angular/tree/HEAD/packages/platform-browser/issues/48765">#48765</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/87fe3161d49172deb9c8c84da570fd550cf86e08"><code>87fe316</code></a> refactor: remove unnecessary test support check utilities (<a href="https://github.com/angular/angular/tree/HEAD/packages/platform-browser/issues/47543">#47543</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/61023b563d5545f5d9066b959c3ebc0464d29113"><code>61023b5</code></a> refactor(compiler): refactor the shadow css specs (<a href="https://github.com/angular/angular/tree/HEAD/packages/platform-browser/issues/48443">#48443</a>)</li>
+                <li>Additional commits viewable in <a href="https://github.com/angular/angular/commits/15.2.10/packages/platform-browser">compare view</a></li>
+                </ul>
+                </details>
+                <br />
 
-                _Description has been truncated_
+                Updates `@angular/platform-browser-dynamic` from 15.0.0 to 15.2.10
+                <details>
+                <summary>Changelog</summary>
+                <p><em>Sourced from <a href="https://github.com/angular/angular/blob/main/CHANGELOG.md"><code>@​angular/platform-browser-dynamic</code>'s changelog</a>.</em></p>
+                <blockquote>
+                <h1>15.2.10 (2023-10-04)</h1>
+                <h3>service-worker</h3>
+                <table>
+                <thead>
+                <tr>
+                <th>Commit</th>
+                <th>Type</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/9fe08968b84b92da47ce91f5d2860b3aa23d2d2b">9fe08968b8</a></td>
+                <td>fix</td>
+                <td>throw a critical error when handleFetch fail (<a href="https://redirect.github.com/angular/angular/pull/51989">#51989</a>)</td>
+                </tr>
+                </tbody>
+                </table>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.7 (2023-09-27)</h1>
+                <h3>core</h3>
+                <table>
+                <thead>
+                <tr>
+                <th>Commit</th>
+                <th>Type</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/39a3e34e035b324bfa1f1a11cf452272c91011c6">39a3e34e03</a></td>
+                <td>fix</td>
+                <td>allow toSignal calls in reactive context (<a href="https://redirect.github.com/angular/angular/pull/51831">#51831</a>) (<a href="https://redirect.github.com/angular/angular/pull/51892">#51892</a>)</td>
+                </tr>
+                </tbody>
+                </table>
+                <h3>service-worker</h3>
+                <table>
+                <thead>
+                <tr>
+                <th>Commit</th>
+                <th>Type</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/c3d901eacfe8d035441e5c990f6e6b2630d592f5">c3d901eacf</a></td>
+                <td>fix</td>
+                <td>throw a critical error when <code>handleFetch</code> fails (<a href="https://redirect.github.com/angular/angular/pull/51885">#51885</a>)</td>
+                </tr>
+                </tbody>
+                </table>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.6 (2023-09-20)</h1>
+                <h3>core</h3>
+                <table>
+                <thead>
+                <tr>
+                <th>Commit</th>
+                <th>Type</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/82712f80dfc6aed2baf8d8f80c3552a6707c88ff">82712f80df</a></td>
+                <td>fix</td>
+                <td>ensure a consumer drops all its stale producers (<a href="https://redirect.github.com/angular/angular/pull/51722">#51722</a>) (<a href="https://redirect.github.com/angular/angular/pull/51772">#51772</a>)</td>
+                </tr>
+                </tbody>
+                </table>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.5 (2023-09-13)</h1>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.4 (2023-09-06)</h1>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.3 (2023-08-30)</h1>
+                <h3>animations</h3>
+                <table>
+                <thead>
+                <tr>
+                <th>Commit</th>
+                <th>Type</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/04c65742802537c8bd725f9a7a931955a67684d9">04c6574280</a></td>
+                <td>fix</td>
+                <td>remove unnecessary escaping in regex expressions (<a href="https://redirect.github.com/angular/angular/pull/51554">#51554</a>)</td>
+                </tr>
+                </tbody>
+                </table>
+                <h3>compiler-cli</h3>
+                <table>
+                <thead>
+                <tr>
+                <th>Commit</th>
+                <th>Type</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/dbd761f528a08cba0fbdd476b115e1445683cf36">dbd761f528</a></td>
+                <td>fix</td>
+                <td>correct incomplete escaping (<a href="https://redirect.github.com/angular/angular/pull/51557">#51557</a>)</td>
+                </tr>
+                </tbody>
+                </table>
+                <!-- raw HTML omitted -->
+                </blockquote>
+                <p>... (truncated)</p>
+                </details>
+                <details>
+                <summary>Commits</summary>
+                <ul>
+                <li><a href="https://github.com/angular/angular/commit/6d6fc12c88e371673f9bf440e127487d29185855"><code>6d6fc12</code></a> refactor(core): Remove usage of deprecated <code>Injector.create()</code> (<a href="https://github.com/angular/angular/tree/HEAD/packages/platform-browser-dynamic/issues/49606">#49606</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/63bfe19f23a3bba3ca0835f11fc1382aa6aecee8"><code>63bfe19</code></a> refactor: update <code>platform-browser-dynamic</code> to work with ESM output (<a href="https://github.com/angular/angular/tree/HEAD/packages/platform-browser-dynamic/issues/48521">#48521</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/c9415e4d75a2567fe344e1fbc0b1713c2bd912ff"><code>c9415e4</code></a> build: ensure bootstrap transitive runfiles are made available (<a href="https://github.com/angular/angular/tree/HEAD/packages/platform-browser-dynamic/issues/48521">#48521</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/20551503fa8914a40b6a2fcaebc4dc1858561530"><code>2055150</code></a> build: replace <code>_es2015</code> shorthand with more flexible <code>_files</code> suffix (<a href="https://github.com/angular/angular/tree/HEAD/packages/platform-browser-dynamic/issues/48521">#48521</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/303bb4d27c2422515d293289c518702f612606de"><code>303bb4d</code></a> build: reformat BUILD files (<a href="https://github.com/angular/angular/tree/HEAD/packages/platform-browser-dynamic/issues/48181">#48181</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/f37dd0fc96a21be5dd12904662c281de70477ff1"><code>f37dd0f</code></a> build(bazel): create AIO example playgrounds for manual testing</li>
+                <li><a href="https://github.com/angular/angular/commit/bc1e93d63939cacce0f4d0f08d48a16770ce3162"><code>bc1e93d</code></a> build(bazel): refactor aio example e2es to fix windows performance</li>
+                <li><a href="https://github.com/angular/angular/commit/22a317de3d4080fb70d9dd3733c650baf0b4c14a"><code>22a317d</code></a> build(bazel): stamp targets to build, test, and serve aio against</li>
+                <li><a href="https://github.com/angular/angular/commit/7a134cf41ac9442de4f45e1375a7fe0b3bf67441"><code>7a134cf</code></a> build(bazel): incrementally run aio example e2e tests</li>
+                <li><a href="https://github.com/angular/angular/commit/431c5628155c1fddac900cd420e04a3f2a2e1d94"><code>431c562</code></a> build(bazel): add bazel targets for aio doc generation</li>
+                <li>See full diff in <a href="https://github.com/angular/angular/commits/15.2.10/packages/platform-browser-dynamic">compare view</a></li>
+                </ul>
+                </details>
+                <br />
+
+                Updates `@angular/router` from 15.0.0 to 15.2.10
+                <details>
+                <summary>Changelog</summary>
+                <p><em>Sourced from <a href="https://github.com/angular/angular/blob/main/CHANGELOG.md"><code>@​angular/router</code>'s changelog</a>.</em></p>
+                <blockquote>
+                <h1>15.2.10 (2023-10-04)</h1>
+                <h3>service-worker</h3>
+                <table>
+                <thead>
+                <tr>
+                <th>Commit</th>
+                <th>Type</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/9fe08968b84b92da47ce91f5d2860b3aa23d2d2b">9fe08968b8</a></td>
+                <td>fix</td>
+                <td>throw a critical error when handleFetch fail (<a href="https://redirect.github.com/angular/angular/pull/51989">#51989</a>)</td>
+                </tr>
+                </tbody>
+                </table>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.7 (2023-09-27)</h1>
+                <h3>core</h3>
+                <table>
+                <thead>
+                <tr>
+                <th>Commit</th>
+                <th>Type</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/39a3e34e035b324bfa1f1a11cf452272c91011c6">39a3e34e03</a></td>
+                <td>fix</td>
+                <td>allow toSignal calls in reactive context (<a href="https://redirect.github.com/angular/angular/pull/51831">#51831</a>) (<a href="https://redirect.github.com/angular/angular/pull/51892">#51892</a>)</td>
+                </tr>
+                </tbody>
+                </table>
+                <h3>service-worker</h3>
+                <table>
+                <thead>
+                <tr>
+                <th>Commit</th>
+                <th>Type</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/c3d901eacfe8d035441e5c990f6e6b2630d592f5">c3d901eacf</a></td>
+                <td>fix</td>
+                <td>throw a critical error when <code>handleFetch</code> fails (<a href="https://redirect.github.com/angular/angular/pull/51885">#51885</a>)</td>
+                </tr>
+                </tbody>
+                </table>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.6 (2023-09-20)</h1>
+                <h3>core</h3>
+                <table>
+                <thead>
+                <tr>
+                <th>Commit</th>
+                <th>Type</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/82712f80dfc6aed2baf8d8f80c3552a6707c88ff">82712f80df</a></td>
+                <td>fix</td>
+                <td>ensure a consumer drops all its stale producers (<a href="https://redirect.github.com/angular/angular/pull/51722">#51722</a>) (<a href="https://redirect.github.com/angular/angular/pull/51772">#51772</a>)</td>
+                </tr>
+                </tbody>
+                </table>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.5 (2023-09-13)</h1>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.4 (2023-09-06)</h1>
+                <!-- raw HTML omitted -->
+                <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
+                <h1>16.2.3 (2023-08-30)</h1>
+                <h3>animations</h3>
+                <table>
+                <thead>
+                <tr>
+                <th>Commit</th>
+                <th>Type</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/04c65742802537c8bd725f9a7a931955a67684d9">04c6574280</a></td>
+                <td>fix</td>
+                <td>remove unnecessary escaping in regex expressions (<a href="https://redirect.github.com/angular/angular/pull/51554">#51554</a>)</td>
+                </tr>
+                </tbody>
+                </table>
+                <h3>compiler-cli</h3>
+                <table>
+                <thead>
+                <tr>
+                <th>Commit</th>
+                <th>Type</th>
+                <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                <td><a href="https://github.com/angular/angular/commit/dbd761f528a08cba0fbdd476b115e1445683cf36">dbd761f528</a></td>
+                <td>fix</td>
+                <td>correct incomplete escaping (<a href="https://redirect.github.com/angular/angular/pull/51557">#51557</a>)</td>
+                </tr>
+                </tbody>
+                </table>
+                <!-- raw HTML omitted -->
+                </blockquote>
+                <p>... (truncated)</p>
+                </details>
+                <details>
+                <summary>Commits</summary>
+                <ul>
+                <li><a href="https://github.com/angular/angular/commit/0a9d1060b90b43cd9cd3a8f549e208beef0fdaf1"><code>0a9d106</code></a> refactor(router): Do not access browserPageId if not computed resolution (<a href="https://github.com/angular/angular/tree/HEAD/packages/router/issues/49">#49</a>...</li>
+                <li><a href="https://github.com/angular/angular/commit/09a42d988e654825648205c8df90f7ca4d034c74"><code>09a42d9</code></a> fix(router): canceledNavigationResolution: 'computed' with redirects to the c...</li>
+                <li><a href="https://github.com/angular/angular/commit/cad7274ef90914f0c24d071473a6cbae0e5b8250"><code>cad7274</code></a> fix(router): create correct URL relative to path with empty child (<a href="https://github.com/angular/angular/tree/HEAD/packages/router/issues/49691">#49691</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/9b6137909690d6cbfdd8cbef502e9e2ac0d28c4a"><code>9b61379</code></a> fix(router): Ensure initial navigation clears current navigation when blockin...</li>
+                <li><a href="https://github.com/angular/angular/commit/978d37f324ce4a1fe9b57f3d9430d7c28ecf6131"><code>978d37f</code></a> fix(router): Ensure Router preloading works with lazy component and static ch...</li>
+                <li><a href="https://github.com/angular/angular/commit/a844435514962c52f4fb480bcfab7ee6519a59cc"><code>a844435</code></a> fix(router): fix <a href="https://github.com/angular/angular/tree/HEAD/packages/router/issues/49457">#49457</a> outlet activating with old info (<a href="https://github.com/angular/angular/tree/HEAD/packages/router/issues/49459">#49459</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/be2db59a5568fddccb5bc99a03b578b29eedeb77"><code>be2db59</code></a> refactor(router): Remove deprecated loadChildren file (<a href="https://github.com/angular/angular/tree/HEAD/packages/router/issues/49504">#49504</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/9c57b656a149b51e8b7f256015376993d0a7f1e4"><code>9c57b65</code></a> refactor(router): Update router export location for deprecated interfaces (<a href="https://github.com/angular/angular/tree/HEAD/packages/router/issues/4">#4</a>...</li>
+                <li><a href="https://github.com/angular/angular/commit/6d6b76c59fc6c2123a491864b6a348bc512a980f"><code>6d6b76c</code></a> docs(router): Improving linking (<a href="https://github.com/angular/angular/tree/HEAD/packages/router/issues/49203">#49203</a>)</li>
+                <li><a href="https://github.com/angular/angular/commit/30624427289ad65bdbabd865d028146753c3a97a"><code>3062442</code></a> fix(router): add error message when using loadComponent with a NgModule (<a href="https://github.com/angular/angular/tree/HEAD/packages/router/issues/49164">#49164</a>)</li>
+                <li>Additional commits viewable in <a href="https://github.com/angular/angular/commits/15.2.10/packages/router">compare view</a></li>
+                </ul>
+                </details>
+                <br />
             commit-message: |-
                 Bump the major group in /npm/angular with 8 updates
 
@@ -2109,57 +1738,205 @@ output:
 
                 | Package | From | To |
                 | --- | --- | --- |
-                | [@angular/animations](https://github.com/angular/angular/tree/HEAD/packages/animations) | `15.0.0` | `16.2.0` |
-                | [@angular/common](https://github.com/angular/angular/tree/HEAD/packages/common) | `15.0.0` | `16.2.0` |
-                | [@angular/compiler](https://github.com/angular/angular/tree/HEAD/packages/compiler) | `15.0.0` | `16.2.0` |
-                | [@angular/core](https://github.com/angular/angular/tree/HEAD/packages/core) | `15.0.0` | `16.2.0` |
-                | [@angular/forms](https://github.com/angular/angular/tree/HEAD/packages/forms) | `15.0.0` | `16.2.0` |
-                | [@angular/platform-browser](https://github.com/angular/angular/tree/HEAD/packages/platform-browser) | `15.0.0` | `16.2.0` |
-                | [@angular/platform-browser-dynamic](https://github.com/angular/angular/tree/HEAD/packages/platform-browser-dynamic) | `15.0.0` | `16.2.0` |
-                | [@angular/router](https://github.com/angular/angular/tree/HEAD/packages/router) | `15.0.0` | `16.2.0` |
+                | [@angular/animations](https://github.com/angular/angular/tree/HEAD/packages/animations) | `15.0.0` | `18.2.7` |
+                | [@angular/common](https://github.com/angular/angular/tree/HEAD/packages/common) | `15.0.0` | `15.2.10` |
+                | [@angular/compiler](https://github.com/angular/angular/tree/HEAD/packages/compiler) | `15.0.0` | `15.2.10` |
+                | [@angular/core](https://github.com/angular/angular/tree/HEAD/packages/core) | `15.0.0` | `15.2.10` |
+                | [@angular/forms](https://github.com/angular/angular/tree/HEAD/packages/forms) | `15.0.0` | `15.2.10` |
+                | [@angular/platform-browser](https://github.com/angular/angular/tree/HEAD/packages/platform-browser) | `15.0.0` | `15.2.10` |
+                | [@angular/platform-browser-dynamic](https://github.com/angular/angular/tree/HEAD/packages/platform-browser-dynamic) | `15.0.0` | `15.2.10` |
+                | [@angular/router](https://github.com/angular/angular/tree/HEAD/packages/router) | `15.0.0` | `15.2.10` |
 
 
-                Updates `@angular/animations` from 15.0.0 to 16.2.0
+                Updates `@angular/animations` from 15.0.0 to 18.2.7
                 - [Release notes](https://github.com/angular/angular/releases)
                 - [Changelog](https://github.com/angular/angular/blob/main/CHANGELOG.md)
-                - [Commits](https://github.com/angular/angular/commits/16.2.0/packages/animations)
+                - [Commits](https://github.com/angular/angular/commits/18.2.7/packages/animations)
 
-                Updates `@angular/common` from 15.0.0 to 16.2.0
+                Updates `@angular/common` from 15.0.0 to 15.2.10
                 - [Release notes](https://github.com/angular/angular/releases)
                 - [Changelog](https://github.com/angular/angular/blob/main/CHANGELOG.md)
-                - [Commits](https://github.com/angular/angular/commits/16.2.0/packages/common)
+                - [Commits](https://github.com/angular/angular/commits/15.2.10/packages/common)
 
-                Updates `@angular/compiler` from 15.0.0 to 16.2.0
+                Updates `@angular/compiler` from 15.0.0 to 15.2.10
                 - [Release notes](https://github.com/angular/angular/releases)
                 - [Changelog](https://github.com/angular/angular/blob/main/CHANGELOG.md)
-                - [Commits](https://github.com/angular/angular/commits/16.2.0/packages/compiler)
+                - [Commits](https://github.com/angular/angular/commits/15.2.10/packages/compiler)
 
-                Updates `@angular/core` from 15.0.0 to 16.2.0
+                Updates `@angular/core` from 15.0.0 to 15.2.10
                 - [Release notes](https://github.com/angular/angular/releases)
                 - [Changelog](https://github.com/angular/angular/blob/main/CHANGELOG.md)
-                - [Commits](https://github.com/angular/angular/commits/16.2.0/packages/core)
+                - [Commits](https://github.com/angular/angular/commits/15.2.10/packages/core)
 
-                Updates `@angular/forms` from 15.0.0 to 16.2.0
+                Updates `@angular/forms` from 15.0.0 to 15.2.10
                 - [Release notes](https://github.com/angular/angular/releases)
                 - [Changelog](https://github.com/angular/angular/blob/main/CHANGELOG.md)
-                - [Commits](https://github.com/angular/angular/commits/16.2.0/packages/forms)
+                - [Commits](https://github.com/angular/angular/commits/15.2.10/packages/forms)
 
-                Updates `@angular/platform-browser` from 15.0.0 to 16.2.0
+                Updates `@angular/platform-browser` from 15.0.0 to 15.2.10
                 - [Release notes](https://github.com/angular/angular/releases)
                 - [Changelog](https://github.com/angular/angular/blob/main/CHANGELOG.md)
-                - [Commits](https://github.com/angular/angular/commits/16.2.0/packages/platform-browser)
+                - [Commits](https://github.com/angular/angular/commits/15.2.10/packages/platform-browser)
 
-                Updates `@angular/platform-browser-dynamic` from 15.0.0 to 16.2.0
+                Updates `@angular/platform-browser-dynamic` from 15.0.0 to 15.2.10
                 - [Release notes](https://github.com/angular/angular/releases)
                 - [Changelog](https://github.com/angular/angular/blob/main/CHANGELOG.md)
-                - [Commits](https://github.com/angular/angular/commits/16.2.0/packages/platform-browser-dynamic)
+                - [Commits](https://github.com/angular/angular/commits/15.2.10/packages/platform-browser-dynamic)
 
-                Updates `@angular/router` from 15.0.0 to 16.2.0
+                Updates `@angular/router` from 15.0.0 to 15.2.10
                 - [Release notes](https://github.com/angular/angular/releases)
                 - [Changelog](https://github.com/angular/angular/blob/main/CHANGELOG.md)
-                - [Commits](https://github.com/angular/angular/commits/16.2.0/packages/router)
+                - [Commits](https://github.com/angular/angular/commits/15.2.10/packages/router)
             dependency-group:
                 name: major
+    - type: create_pull_request
+      expect:
+        data:
+            base-commit-sha: 6cc5e623c6cb8284ce363010c05690f4661164dd
+            dependencies:
+                - name: tslib
+                  previous-requirements: []
+                  previous-version: 2.6.1
+                  requirements: []
+                  version: 2.7.0
+                  directory: /npm/angular
+            updated-dependency-files:
+                - content: |
+                    {
+                      "name": "my-angular",
+                      "version": "0.0.0",
+                      "lockfileVersion": 1,
+                      "requires": true,
+                      "dependencies": {
+                        "@angular/animations": {
+                          "version": "15.2.10",
+                          "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-15.2.10.tgz",
+                          "integrity": "sha512-yxfN8qQpMaukRU5LjFkJBmy85rqrOp86tYVCsf+hmPEFRiXBMUj6xYLeCMcpk3Mt1JtnWGBR34ivGx+7bNeAow==",
+                          "requires": {
+                            "tslib": "^2.3.0"
+                          }
+                        },
+                        "@angular/common": {
+                          "version": "15.2.10",
+                          "resolved": "https://registry.npmjs.org/@angular/common/-/common-15.2.10.tgz",
+                          "integrity": "sha512-jdBn3fctkqoNrJn9VLsUHpcCEhCxWSczdsR+BBbD6T0oLl6vMrAVNjPwfBejnlgfWN1KoRU9kgOYsMxa5apIWQ==",
+                          "requires": {
+                            "tslib": "^2.3.0"
+                          }
+                        },
+                        "@angular/compiler": {
+                          "version": "15.2.10",
+                          "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-15.2.10.tgz",
+                          "integrity": "sha512-M0XkeU0O73UlJZwDvOyp8/apetz9UKj78eTFDseMYJDLcxe6MpkbkxqpsGZnKYDj7LIep8PmCAKEkhtenE82zw==",
+                          "requires": {
+                            "tslib": "^2.3.0"
+                          }
+                        },
+                        "@angular/core": {
+                          "version": "15.2.10",
+                          "resolved": "https://registry.npmjs.org/@angular/core/-/core-15.2.10.tgz",
+                          "integrity": "sha512-meGGidnitQJGDxYd9/LrqYiVlId+vGaLoiLgJdKBz+o2ZO6OmXQGuNw2VBqf17/Cc0/UjzrOY7+kILNFKkk/WQ==",
+                          "requires": {
+                            "tslib": "^2.3.0"
+                          }
+                        },
+                        "@angular/forms": {
+                          "version": "15.2.10",
+                          "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-15.2.10.tgz",
+                          "integrity": "sha512-NIntGsNcN6o8L1txsbWXOf6f3K/CUBizdKsxsYVYGJIXEW5qU6UnWmfAZffNNXsT/XvbgUCjgDwT0cAwcqZPuQ==",
+                          "requires": {
+                            "tslib": "^2.3.0"
+                          }
+                        },
+                        "@angular/platform-browser": {
+                          "version": "15.2.10",
+                          "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-15.2.10.tgz",
+                          "integrity": "sha512-9tbgVGSJqwfrOzT8aA/kWBLNhJSQ9gUg0CJxwFBSJm8VkBUJrszoBlDsnSvlxx8/W2ejNULKHFTXeUzq0O/+RQ==",
+                          "requires": {
+                            "tslib": "^2.3.0"
+                          }
+                        },
+                        "@angular/platform-browser-dynamic": {
+                          "version": "15.2.10",
+                          "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-15.2.10.tgz",
+                          "integrity": "sha512-JHP6W+FX715Qv7DhqvfZLuBZXSDJrboiQsR06gUAgDSjAUyhbqmpVg/2YOtgeWpPkzNDtXdPU2PhcRdIv5J3Yg==",
+                          "requires": {
+                            "tslib": "^2.3.0"
+                          }
+                        },
+                        "@angular/router": {
+                          "version": "15.2.10",
+                          "resolved": "https://registry.npmjs.org/@angular/router/-/router-15.2.10.tgz",
+                          "integrity": "sha512-LmuqEg0iIXSw7bli6HKJ19cbxP91v37GtRwbGKswyLihqzTgvjBYpvcfMnB5FRQ5LWkTwq5JclkX03dZw290Yg==",
+                          "requires": {
+                            "tslib": "^2.3.0"
+                          }
+                        },
+                        "tslib": {
+                          "version": "2.7.0",
+                          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+                          "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+                        }
+                      }
+                    }
+                  content_encoding: utf-8
+                  deleted: false
+                  directory: /npm/angular
+                  name: package-lock.json
+                  operation: update
+                  support_file: false
+                  type: file
+            pr-title: Bump tslib from 2.6.1 to 2.7.0 in /npm/angular
+            pr-body: |
+                Bumps [tslib](https://github.com/Microsoft/tslib) from 2.6.1 to 2.7.0.
+                <details>
+                <summary>Release notes</summary>
+                <p><em>Sourced from <a href="https://github.com/Microsoft/tslib/releases">tslib's releases</a>.</em></p>
+                <blockquote>
+                <h2>v2.7.0</h2>
+                <h2>What's Changed</h2>
+                <ul>
+                <li>Implement deterministic collapse of <code>await</code> in <code>await using</code> by <a href="https://github.com/rbuckton"><code>@​rbuckton</code></a> in <a href="https://redirect.github.com/microsoft/tslib/pull/262">microsoft/tslib#262</a></li>
+                <li>Use global 'Iterator.prototype' for downlevel generators by <a href="https://github.com/rbuckton"><code>@​rbuckton</code></a> in <a href="https://redirect.github.com/microsoft/tslib/pull/267">microsoft/tslib#267</a></li>
+                </ul>
+                <p><strong>Full Changelog</strong>: <a href="https://github.com/microsoft/tslib/compare/v2.6.3...v2.7.0">https://github.com/microsoft/tslib/compare/v2.6.3...v2.7.0</a></p>
+                <h2>v2.6.3</h2>
+                <h2>What's Changed</h2>
+                <ul>
+                <li>'await using' normative changes by <a href="https://github.com/rbuckton"><code>@​rbuckton</code></a> in <a href="https://redirect.github.com/microsoft/tslib/pull/258">microsoft/tslib#258</a></li>
+                </ul>
+                <p><strong>Full Changelog</strong>: <a href="https://github.com/microsoft/tslib/compare/v2.6.2...v2.6.3">https://github.com/microsoft/tslib/compare/v2.6.2...v2.6.3</a></p>
+                <h2>tslib 2.6.2</h2>
+                <h2>What's Changed</h2>
+                <ul>
+                <li>Fix path to <code>exports[&quot;module&quot;][&quot;types&quot;]</code> by <a href="https://github.com/andrewbranch"><code>@​andrewbranch</code></a> in <a href="https://redirect.github.com/microsoft/tslib/pull/217">microsoft/tslib#217</a></li>
+                </ul>
+                <p><strong>Full Changelog</strong>: <a href="https://github.com/microsoft/tslib/compare/v2.6.1...v2.6.2">https://github.com/microsoft/tslib/compare/v2.6.1...v2.6.2</a></p>
+                </blockquote>
+                </details>
+                <details>
+                <summary>Commits</summary>
+                <ul>
+                <li><a href="https://github.com/microsoft/tslib/commit/6abc075910605cc5c6c74d8566190ee865c9e672"><code>6abc075</code></a> Bump version to 2.7.0.</li>
+                <li><a href="https://github.com/microsoft/tslib/commit/227b5d66a3e4c8c6c0bf2eb3eecbf78f4388b0fc"><code>227b5d6</code></a> Use global 'Iterator.prototype' for downlevel generators (<a href="https://redirect.github.com/Microsoft/tslib/issues/267">#267</a>)</li>
+                <li><a href="https://github.com/microsoft/tslib/commit/4f2902c1f4404a235368b5f80d1d12a816e32d80"><code>4f2902c</code></a> Implement deterministic collapse of 'await' in 'await using' (<a href="https://redirect.github.com/Microsoft/tslib/issues/262">#262</a>)</li>
+                <li><a href="https://github.com/microsoft/tslib/commit/a280d4b4e099238613d98d4f762c5f7ef896cdb1"><code>a280d4b</code></a> 2.6.3</li>
+                <li><a href="https://github.com/microsoft/tslib/commit/983d81bda622ca61fcb1210e2041a1aba57cfdc8"><code>983d81b</code></a> 'await using' normative changes (<a href="https://redirect.github.com/Microsoft/tslib/issues/258">#258</a>)</li>
+                <li><a href="https://github.com/microsoft/tslib/commit/54cd71cf9e496a287447b866d520e481702e8554"><code>54cd71c</code></a> Bump the github-actions group with 3 updates (<a href="https://redirect.github.com/Microsoft/tslib/issues/253">#253</a>)</li>
+                <li><a href="https://github.com/microsoft/tslib/commit/298efd9fdb5083cb088133f4885e7e627bfa5ce4"><code>298efd9</code></a> Bump the github-actions group with 1 update (<a href="https://redirect.github.com/Microsoft/tslib/issues/242">#242</a>)</li>
+                <li><a href="https://github.com/microsoft/tslib/commit/e8b4418fa08c9293a97cb84955a8928fbf348166"><code>e8b4418</code></a> Bump the github-actions group with 1 update (<a href="https://redirect.github.com/Microsoft/tslib/issues/241">#241</a>)</li>
+                <li><a href="https://github.com/microsoft/tslib/commit/ae8c5c3891f6be847ce4665d33eff65b86ec6421"><code>ae8c5c3</code></a> Bump the github-actions group with 2 updates (<a href="https://redirect.github.com/Microsoft/tslib/issues/240">#240</a>)</li>
+                <li><a href="https://github.com/microsoft/tslib/commit/2b38d8767fe7e9553e969ab9867f9cf899a1308e"><code>2b38d87</code></a> JSDoc typo on <code>__exportStar</code>. (<a href="https://redirect.github.com/Microsoft/tslib/issues/221">#221</a>)</li>
+                <li>Additional commits viewable in <a href="https://github.com/Microsoft/tslib/compare/v2.6.1...v2.7.0">compare view</a></li>
+                </ul>
+                </details>
+                <br />
+            commit-message: |-
+                Bump tslib from 2.6.1 to 2.7.0 in /npm/angular
+
+                Bumps [tslib](https://github.com/Microsoft/tslib) from 2.6.1 to 2.7.0.
+                - [Release notes](https://github.com/Microsoft/tslib/releases)
+                - [Commits](https://github.com/Microsoft/tslib/compare/v2.6.1...v2.7.0)
     - type: mark_as_processed
       expect:
         data:

--- a/tests/smoke-npm-group-semver.yaml
+++ b/tests/smoke-npm-group-semver.yaml
@@ -12,6 +12,7 @@ input:
         experiments:
             grouped-updates-experimental-rules: true
             grouped-updates-prototype: true
+            npm_fallback_version_above_v6: true
             record-ecosystem-versions: true
         ignore-conditions:
             - dependency-name: none
@@ -31,7 +32,7 @@ output:
         data:
             ecosystem_versions:
                 package_managers:
-                    npm: 8
+                    npm: 9
     - type: update_dependency_list
       expect:
         data:
@@ -42,9 +43,7 @@ output:
                       groups:
                         - dependencies
                       requirement: 0.27.1
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   version: 0.27.1
                 - name: fetch-factory
                   requirements:
@@ -52,9 +51,7 @@ output:
                       groups:
                         - dependencies
                       requirement: 0.0.1
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   version: 0.0.1
                 - name: lodash
                   requirements:
@@ -62,9 +59,7 @@ output:
                       groups:
                         - dependencies
                       requirement: 4.16.6
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   version: 4.16.6
                 - name: asynckit
                   requirements: []
@@ -125,18 +120,14 @@ output:
                       groups:
                         - dependencies
                       requirement: 0.0.1
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   previous-version: 0.0.1
                   requirements:
                     - file: package.json
                       groups:
                         - dependencies
                       requirement: 0.2.1
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   version: 0.2.1
                   directory: /npm/semver
                 - name: lodash
@@ -145,19 +136,27 @@ output:
                       groups:
                         - dependencies
                       requirement: 4.16.6
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   previous-version: 4.16.6
                   requirements:
                     - file: package.json
                       groups:
                         - dependencies
                       requirement: 4.17.21
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   version: 4.17.21
+                  directory: /npm/semver
+                - name: follow-redirects
+                  previous-requirements: []
+                  previous-version: 1.15.2
+                  requirements: []
+                  version: 1.15.9
+                  directory: /npm/semver
+                - name: whatwg-fetch
+                  previous-requirements: []
+                  previous-version: 3.6.17
+                  requirements: []
+                  version: 3.6.20
                   directory: /npm/semver
             updated-dependency-files:
                 - content: |
@@ -197,7 +196,6 @@ output:
                       "requires": true,
                       "packages": {
                         "": {
-                          "name": "npm-test",
                           "version": "1.0.0",
                           "license": "ISC",
                           "dependencies": {
@@ -230,12 +228,18 @@ output:
                           }
                         },
                         "node_modules/call-bind": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-                          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+                          "version": "1.0.7",
+                          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+                          "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
                           "dependencies": {
-                            "function-bind": "^1.1.1",
-                            "get-intrinsic": "^1.0.2"
+                            "es-define-property": "^1.0.0",
+                            "es-errors": "^1.3.0",
+                            "function-bind": "^1.1.2",
+                            "get-intrinsic": "^1.2.4",
+                            "set-function-length": "^1.2.1"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
                           },
                           "funding": {
                             "url": "https://github.com/sponsors/ljharb"
@@ -293,26 +297,46 @@ output:
                           }
                         },
                         "node_modules/deep-equal": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-                          "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+                          "version": "1.1.2",
+                          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+                          "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
                           "dependencies": {
-                            "is-arguments": "^1.0.4",
-                            "is-date-object": "^1.0.1",
-                            "is-regex": "^1.0.4",
-                            "object-is": "^1.0.1",
+                            "is-arguments": "^1.1.1",
+                            "is-date-object": "^1.0.5",
+                            "is-regex": "^1.1.4",
+                            "object-is": "^1.1.5",
                             "object-keys": "^1.1.1",
-                            "regexp.prototype.flags": "^1.2.0"
+                            "regexp.prototype.flags": "^1.5.1"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
+                          },
+                          "funding": {
+                            "url": "https://github.com/sponsors/ljharb"
+                          }
+                        },
+                        "node_modules/define-data-property": {
+                          "version": "1.1.4",
+                          "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+                          "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+                          "dependencies": {
+                            "es-define-property": "^1.0.0",
+                            "es-errors": "^1.3.0",
+                            "gopd": "^1.0.1"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
                           },
                           "funding": {
                             "url": "https://github.com/sponsors/ljharb"
                           }
                         },
                         "node_modules/define-properties": {
-                          "version": "1.2.0",
-                          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
-                          "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+                          "version": "1.2.1",
+                          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+                          "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
                           "dependencies": {
+                            "define-data-property": "^1.0.1",
                             "has-property-descriptors": "^1.0.0",
                             "object-keys": "^1.1.1"
                           },
@@ -339,6 +363,25 @@ output:
                             "iconv-lite": "^0.6.2"
                           }
                         },
+                        "node_modules/es-define-property": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+                          "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+                          "dependencies": {
+                            "get-intrinsic": "^1.2.4"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
+                          }
+                        },
+                        "node_modules/es-errors": {
+                          "version": "1.3.0",
+                          "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+                          "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+                          "engines": {
+                            "node": ">= 0.4"
+                          }
+                        },
                         "node_modules/es6-promise": {
                           "version": "3.3.1",
                           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
@@ -363,9 +406,9 @@ output:
                           "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ=="
                         },
                         "node_modules/follow-redirects": {
-                          "version": "1.15.2",
-                          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-                          "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+                          "version": "1.15.9",
+                          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+                          "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
                           "funding": [
                             {
                               "type": "individual",
@@ -395,9 +438,12 @@ output:
                           }
                         },
                         "node_modules/function-bind": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-                          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+                          "version": "1.1.2",
+                          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+                          "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+                          "funding": {
+                            "url": "https://github.com/sponsors/ljharb"
+                          }
                         },
                         "node_modules/functions-have-names": {
                           "version": "1.2.3",
@@ -408,45 +454,49 @@ output:
                           }
                         },
                         "node_modules/get-intrinsic": {
-                          "version": "1.2.1",
-                          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-                          "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+                          "version": "1.2.4",
+                          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+                          "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
                           "dependencies": {
-                            "function-bind": "^1.1.1",
-                            "has": "^1.0.3",
+                            "es-errors": "^1.3.0",
+                            "function-bind": "^1.1.2",
                             "has-proto": "^1.0.1",
-                            "has-symbols": "^1.0.3"
+                            "has-symbols": "^1.0.3",
+                            "hasown": "^2.0.0"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
                           },
                           "funding": {
                             "url": "https://github.com/sponsors/ljharb"
                           }
                         },
-                        "node_modules/has": {
-                          "version": "1.0.3",
-                          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-                          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+                        "node_modules/gopd": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+                          "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
                           "dependencies": {
-                            "function-bind": "^1.1.1"
+                            "get-intrinsic": "^1.1.3"
                           },
-                          "engines": {
-                            "node": ">= 0.4.0"
+                          "funding": {
+                            "url": "https://github.com/sponsors/ljharb"
                           }
                         },
                         "node_modules/has-property-descriptors": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-                          "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+                          "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
                           "dependencies": {
-                            "get-intrinsic": "^1.1.1"
+                            "es-define-property": "^1.0.0"
                           },
                           "funding": {
                             "url": "https://github.com/sponsors/ljharb"
                           }
                         },
                         "node_modules/has-proto": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-                          "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+                          "version": "1.0.3",
+                          "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+                          "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
                           "engines": {
                             "node": ">= 0.4"
                           },
@@ -466,17 +516,28 @@ output:
                           }
                         },
                         "node_modules/has-tostringtag": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-                          "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+                          "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
                           "dependencies": {
-                            "has-symbols": "^1.0.2"
+                            "has-symbols": "^1.0.3"
                           },
                           "engines": {
                             "node": ">= 0.4"
                           },
                           "funding": {
                             "url": "https://github.com/sponsors/ljharb"
+                          }
+                        },
+                        "node_modules/hasown": {
+                          "version": "2.0.2",
+                          "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+                          "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+                          "dependencies": {
+                            "function-bind": "^1.1.2"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
                           }
                         },
                         "node_modules/iconv-lite": {
@@ -634,12 +695,12 @@ output:
                           }
                         },
                         "node_modules/object-is": {
-                          "version": "1.1.5",
-                          "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-                          "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+                          "version": "1.1.6",
+                          "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+                          "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
                           "dependencies": {
-                            "call-bind": "^1.0.2",
-                            "define-properties": "^1.1.3"
+                            "call-bind": "^1.0.7",
+                            "define-properties": "^1.2.1"
                           },
                           "engines": {
                             "node": ">= 0.4"
@@ -676,13 +737,14 @@ output:
                           }
                         },
                         "node_modules/regexp.prototype.flags": {
-                          "version": "1.5.0",
-                          "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
-                          "integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
+                          "version": "1.5.3",
+                          "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.3.tgz",
+                          "integrity": "sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==",
                           "dependencies": {
-                            "call-bind": "^1.0.2",
-                            "define-properties": "^1.2.0",
-                            "functions-have-names": "^1.2.3"
+                            "call-bind": "^1.0.7",
+                            "define-properties": "^1.2.1",
+                            "es-errors": "^1.3.0",
+                            "set-function-name": "^2.0.2"
                           },
                           "engines": {
                             "node": ">= 0.4"
@@ -695,6 +757,36 @@ output:
                           "version": "2.1.2",
                           "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
                           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+                        },
+                        "node_modules/set-function-length": {
+                          "version": "1.2.2",
+                          "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+                          "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+                          "dependencies": {
+                            "define-data-property": "^1.1.4",
+                            "es-errors": "^1.3.0",
+                            "function-bind": "^1.1.2",
+                            "get-intrinsic": "^1.2.4",
+                            "gopd": "^1.0.1",
+                            "has-property-descriptors": "^1.0.2"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
+                          }
+                        },
+                        "node_modules/set-function-name": {
+                          "version": "2.0.2",
+                          "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+                          "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+                          "dependencies": {
+                            "define-data-property": "^1.1.4",
+                            "es-errors": "^1.3.0",
+                            "functions-have-names": "^1.2.3",
+                            "has-property-descriptors": "^1.0.2"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
+                          }
                         },
                         "node_modules/strict-uri-encode": {
                           "version": "1.1.0",
@@ -721,9 +813,9 @@ output:
                           }
                         },
                         "node_modules/whatwg-fetch": {
-                          "version": "3.6.17",
-                          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.17.tgz",
-                          "integrity": "sha512-c4ghIvG6th0eudYwKZY5keb81wtFz9/WeAHAoy8+r18kcWlitUIrmGFQ2rWEl4UCKUilD3zCLHOIPheHx5ypRQ=="
+                          "version": "3.6.20",
+                          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+                          "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="
                         }
                       }
                     }
@@ -734,9 +826,9 @@ output:
                   operation: update
                   support_file: false
                   type: file
-            pr-title: Bump the not major group in /npm/semver with 2 updates
+            pr-title: Bump the not major group in /npm/semver with 4 updates
             pr-body: |
-                Bumps the not major group in /npm/semver with 2 updates: fetch-factory and [lodash](https://github.com/lodash/lodash).
+                Bumps the not major group in /npm/semver with 4 updates: fetch-factory, [lodash](https://github.com/lodash/lodash), [follow-redirects](https://github.com/follow-redirects/follow-redirects) and [whatwg-fetch](https://github.com/github/fetch).
 
                 Updates `fetch-factory` from 0.0.1 to 0.2.1
 
@@ -762,10 +854,98 @@ output:
                 <p>This version was pushed to npm by <a href="https://www.npmjs.com/~bnjmnt4n">bnjmnt4n</a>, a new releaser for lodash since your current version.</p>
                 </details>
                 <br />
-            commit-message: |-
-                Bump the not major group in /npm/semver with 2 updates
 
-                Bumps the not major group in /npm/semver with 2 updates: fetch-factory and [lodash](https://github.com/lodash/lodash).
+                Updates `follow-redirects` from 1.15.2 to 1.15.9
+                <details>
+                <summary>Commits</summary>
+                <ul>
+                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/e4e55c77b2d849280d105943f49f42e0c735d05d"><code>e4e55c7</code></a> Release version 1.15.9 of the npm package.</li>
+                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/31a1abf2d659ac1c8fcbe7e614a8c8914d80e1e3"><code>31a1abf</code></a> Attempt much more gentle detection.</li>
+                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/d2aaa97439e8a7e4a9cd02513ec7b12f23c17638"><code>d2aaa97</code></a> Fix url field.</li>
+                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/62558f0cd106195f4c17ece3ad255eb93487d37f"><code>62558f0</code></a> Release version 1.15.8 of the npm package.</li>
+                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/a8d1ceed257d46758f913ff555b4f7e1cd758627"><code>a8d1cee</code></a> Return subtlety.</li>
+                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/458ca8e19fd80897e97746e476d7389cdf9b6494"><code>458ca8e</code></a> Fix native URL test for Node 20.</li>
+                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/ca49e4462651b07eb10452116235c1269cb79e1e"><code>ca49e44</code></a> Handle KeepAlive connections in tests.</li>
+                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/f3711d7e78b24695eae8d348a4e695d288bd450f"><code>f3711d7</code></a> Test on Node 20 and 22.</li>
+                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/fda0fafa0c8d197cbcd232d98c68445ed323c337"><code>fda0faf</code></a> Fix typo.</li>
+                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/760757f7b75cce429604492d91649cbbd473c8d4"><code>760757f</code></a> Release version 1.15.7 of the npm package.</li>
+                <li>Additional commits viewable in <a href="https://github.com/follow-redirects/follow-redirects/compare/v1.15.2...v1.15.9">compare view</a></li>
+                </ul>
+                </details>
+                <br />
+
+                Updates `whatwg-fetch` from 3.6.17 to 3.6.20
+                <details>
+                <summary>Release notes</summary>
+                <p><em>Sourced from <a href="https://github.com/github/fetch/releases">whatwg-fetch's releases</a>.</em></p>
+                <blockquote>
+                <h2>v3.6.20</h2>
+                <h2><a href="https://github.com/JakeChampion/fetch/compare/v3.6.19...v3.6.20">3.6.20</a> (2023-12-13)</h2>
+                <h3>Bug Fixes</h3>
+                <ul>
+                <li>Response.error().ok === false (<a href="https://redirect.github.com/JakeChampion/fetch/issues/1412">#1412</a>) (<a href="https://github.com/JakeChampion/fetch/commit/27e1c75f830f0b70a40b511e03652776951aca75">27e1c75</a>)</li>
+                </ul>
+                <h2>v3.6.19</h2>
+                <h2><a href="https://github.com/JakeChampion/fetch/compare/v3.6.18...v3.6.19">3.6.19</a> (2023-09-11)</h2>
+                <h3>Bug Fixes</h3>
+                <ul>
+                <li>Have unique error messages for xhr timeouts and errors (<a href="https://redirect.github.com/JakeChampion/fetch/issues/1380">#1380</a>) (<a href="https://github.com/JakeChampion/fetch/commit/7170f0b127d16c5895aba61c9168482834809046">7170f0b</a>)</li>
+                </ul>
+                <h2>v3.6.18</h2>
+                <h2>What's Changed</h2>
+                <ul>
+                <li>Fix - File fetching broken since commit 0c1d2b9 by <a href="https://github.com/mercpls"><code>@​mercpls</code></a> in <a href="https://redirect.github.com/JakeChampion/fetch/pull/1375">JakeChampion/fetch#1375</a></li>
+                </ul>
+                <h2>New Contributors</h2>
+                <ul>
+                <li><a href="https://github.com/mercpls"><code>@​mercpls</code></a> made their first contribution in <a href="https://redirect.github.com/JakeChampion/fetch/pull/1375">JakeChampion/fetch#1375</a></li>
+                </ul>
+                <p><strong>Full Changelog</strong>: <a href="https://github.com/JakeChampion/fetch/compare/v3.6.17...v3.6.18">https://github.com/JakeChampion/fetch/compare/v3.6.17...v3.6.18</a></p>
+                </blockquote>
+                </details>
+                <details>
+                <summary>Changelog</summary>
+                <p><em>Sourced from <a href="https://github.com/JakeChampion/fetch/blob/main/CHANGELOG.md">whatwg-fetch's changelog</a>.</em></p>
+                <blockquote>
+                <h2><a href="https://github.com/JakeChampion/fetch/compare/v3.6.19...v3.6.20">3.6.20</a> (2023-12-13)</h2>
+                <h3>Bug Fixes</h3>
+                <ul>
+                <li>Response.error().ok === false (<a href="https://redirect.github.com/JakeChampion/fetch/issues/1412">#1412</a>) (<a href="https://github.com/JakeChampion/fetch/commit/27e1c75f830f0b70a40b511e03652776951aca75">27e1c75</a>)</li>
+                </ul>
+                <h2><a href="https://github.com/JakeChampion/fetch/compare/v3.6.18...v3.6.19">3.6.19</a> (2023-09-11)</h2>
+                <h3>Bug Fixes</h3>
+                <ul>
+                <li>Have unique error messages for xhr timeouts and errors (<a href="https://redirect.github.com/JakeChampion/fetch/issues/1380">#1380</a>) (<a href="https://github.com/JakeChampion/fetch/commit/7170f0b127d16c5895aba61c9168482834809046">7170f0b</a>)</li>
+                </ul>
+                <h2><a href="https://github.com/JakeChampion/fetch/compare/v3.6.17...v3.6.18">v3.6.18</a></h2>
+                <ul>
+                <li>Fix - File fetching broken since commit 0c1d2b9 <a href="https://redirect.github.com/JakeChampion/fetch/pull/1375"><code>[#1375](https://github.com/github/fetch/issues/1375)</code></a></li>
+                <li>Remove broken links <a href="https://github.com/JakeChampion/fetch/commit/1dc07c6064a32e989306fb2324204c56c93140fe"><code>1dc07c6</code></a></li>
+                <li>automatically generate a changelog <a href="https://github.com/JakeChampion/fetch/commit/0e7d1dd95826b3b76510f0832784207f2609145e"><code>0e7d1dd</code></a></li>
+                </ul>
+                </blockquote>
+                </details>
+                <details>
+                <summary>Commits</summary>
+                <ul>
+                <li><a href="https://github.com/JakeChampion/fetch/commit/a0aea1004830a1976c0c70d2f23c42a71da21cc7"><code>a0aea10</code></a> chore(main): release 3.6.20 (<a href="https://redirect.github.com/github/fetch/issues/1417">#1417</a>)</li>
+                <li><a href="https://github.com/JakeChampion/fetch/commit/7d1998d211736ec49fc151eb4205d8d5790c58cb"><code>7d1998d</code></a> remove umd section from readme</li>
+                <li><a href="https://github.com/JakeChampion/fetch/commit/27e1c75f830f0b70a40b511e03652776951aca75"><code>27e1c75</code></a> Fix: Response.error().ok === false (<a href="https://redirect.github.com/github/fetch/issues/1412">#1412</a>)</li>
+                <li><a href="https://github.com/JakeChampion/fetch/commit/84256c8d91de08d6bf7a53e7798f7ae05b1d2f77"><code>84256c8</code></a> Bump the github-actions group with 1 update (<a href="https://redirect.github.com/github/fetch/issues/1416">#1416</a>)</li>
+                <li><a href="https://github.com/JakeChampion/fetch/commit/806ea66b1c42a0cbc252957c03f33b6f1fe35d37"><code>806ea66</code></a> Bump the github-actions group with 2 updates (<a href="https://redirect.github.com/github/fetch/issues/1414">#1414</a>)</li>
+                <li><a href="https://github.com/JakeChampion/fetch/commit/af519560bea0f7906d2aa6904f7c76298dcfb55c"><code>af51956</code></a> Bump the github-actions group with 1 update (<a href="https://redirect.github.com/github/fetch/issues/1413">#1413</a>)</li>
+                <li><a href="https://github.com/JakeChampion/fetch/commit/a71a60df483dcbd13ad5b5b5f7434d47e7b85c86"><code>a71a60d</code></a> Bump the github-actions group with 2 updates (<a href="https://redirect.github.com/github/fetch/issues/1410">#1410</a>)</li>
+                <li><a href="https://github.com/JakeChampion/fetch/commit/af5cf4b3b017c5821c48bc62d26e6a6236616820"><code>af5cf4b</code></a> Bump the github-actions group with 2 updates (<a href="https://redirect.github.com/github/fetch/issues/1407">#1407</a>)</li>
+                <li><a href="https://github.com/JakeChampion/fetch/commit/a686358611c631a8846e61683eccde75c30b487b"><code>a686358</code></a> enhance: replaced str.startsWith with str.indexOf (<a href="https://redirect.github.com/github/fetch/issues/1404">#1404</a>)</li>
+                <li><a href="https://github.com/JakeChampion/fetch/commit/b5cee5093bb4929239b74b9394e51355b231c460"><code>b5cee50</code></a> Bump the github-actions group with 1 update (<a href="https://redirect.github.com/github/fetch/issues/1402">#1402</a>)</li>
+                <li>Additional commits viewable in <a href="https://github.com/github/fetch/compare/v3.6.17...v3.6.20">compare view</a></li>
+                </ul>
+                </details>
+                <br />
+            commit-message: |-
+                Bump the not major group in /npm/semver with 4 updates
+
+                Bumps the not major group in /npm/semver with 4 updates: fetch-factory, [lodash](https://github.com/lodash/lodash), [follow-redirects](https://github.com/follow-redirects/follow-redirects) and [whatwg-fetch](https://github.com/github/fetch).
 
 
                 Updates `fetch-factory` from 0.0.1 to 0.2.1
@@ -773,6 +953,15 @@ output:
                 Updates `lodash` from 4.16.6 to 4.17.21
                 - [Release notes](https://github.com/lodash/lodash/releases)
                 - [Commits](https://github.com/lodash/lodash/compare/4.16.6...4.17.21)
+
+                Updates `follow-redirects` from 1.15.2 to 1.15.9
+                - [Release notes](https://github.com/follow-redirects/follow-redirects/releases)
+                - [Commits](https://github.com/follow-redirects/follow-redirects/compare/v1.15.2...v1.15.9)
+
+                Updates `whatwg-fetch` from 3.6.17 to 3.6.20
+                - [Release notes](https://github.com/github/fetch/releases)
+                - [Changelog](https://github.com/JakeChampion/fetch/blob/main/CHANGELOG.md)
+                - [Commits](https://github.com/github/fetch/compare/v3.6.17...v3.6.20)
             dependency-group:
                 name: not major
     - type: create_pull_request
@@ -786,19 +975,15 @@ output:
                       groups:
                         - dependencies
                       requirement: 0.27.1
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   previous-version: 0.27.1
                   requirements:
                     - file: package.json
                       groups:
                         - dependencies
-                      requirement: 1.4.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
-                  version: 1.4.0
+                      requirement: 1.7.7
+                      source: null
+                  version: 1.7.7
                   directory: /npm/semver
             updated-dependency-files:
                 - content: |
@@ -818,7 +1003,7 @@ output:
                       },
                       "homepage": "https://github.com/dsp-testing/dependabot-all-updates-test",
                       "dependencies": {
-                        "axios": "1.4.0",
+                        "axios": "1.7.7",
                         "fetch-factory": "0.0.1",
                         "lodash": "4.16.6"
                       }
@@ -834,188 +1019,145 @@ output:
                     {
                       "name": "npm-test",
                       "version": "1.0.0",
-                      "lockfileVersion": 3,
+                      "lockfileVersion": 1,
                       "requires": true,
-                      "packages": {
-                        "": {
-                          "name": "npm-test",
-                          "version": "1.0.0",
-                          "license": "ISC",
-                          "dependencies": {
-                            "axios": "1.4.0",
-                            "fetch-factory": "0.0.1",
-                            "lodash": "4.16.6"
-                          }
-                        },
-                        "node_modules/asynckit": {
+                      "dependencies": {
+                        "asynckit": {
                           "version": "0.4.0",
                           "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
                           "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
                         },
-                        "node_modules/axios": {
-                          "version": "1.4.0",
-                          "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-                          "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
-                          "dependencies": {
-                            "follow-redirects": "^1.15.0",
+                        "axios": {
+                          "version": "1.7.7",
+                          "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+                          "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+                          "requires": {
+                            "follow-redirects": "^1.15.6",
                             "form-data": "^4.0.0",
                             "proxy-from-env": "^1.1.0"
                           }
                         },
-                        "node_modules/combined-stream": {
+                        "combined-stream": {
                           "version": "1.0.8",
                           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
                           "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-                          "dependencies": {
+                          "requires": {
                             "delayed-stream": "~1.0.0"
-                          },
-                          "engines": {
-                            "node": ">= 0.8"
                           }
                         },
-                        "node_modules/delayed-stream": {
+                        "delayed-stream": {
                           "version": "1.0.0",
                           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                          "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-                          "engines": {
-                            "node": ">=0.4.0"
-                          }
+                          "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
                         },
-                        "node_modules/encoding": {
+                        "encoding": {
                           "version": "0.1.13",
                           "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
                           "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-                          "dependencies": {
+                          "requires": {
                             "iconv-lite": "^0.6.2"
                           }
                         },
-                        "node_modules/es6-promise": {
+                        "es6-promise": {
                           "version": "3.3.1",
                           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
                           "integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg=="
                         },
-                        "node_modules/fetch-factory": {
+                        "fetch-factory": {
                           "version": "0.0.1",
                           "resolved": "https://registry.npmjs.org/fetch-factory/-/fetch-factory-0.0.1.tgz",
                           "integrity": "sha512-gexRwqIhwzDJ2pJvL0UYfiZwW06/bdYWxAmswFFts7C87CF8i6liApihTk7TZFYMDcQjvvDIvyHv0q379z0aWA==",
-                          "dependencies": {
+                          "requires": {
                             "es6-promise": "^3.0.2",
                             "isomorphic-fetch": "^2.1.1",
                             "lodash": "^3.10.1"
-                          }
-                        },
-                        "node_modules/fetch-factory/node_modules/lodash": {
-                          "version": "3.10.1",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-                          "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ=="
-                        },
-                        "node_modules/follow-redirects": {
-                          "version": "1.15.2",
-                          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-                          "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
-                          "funding": [
-                            {
-                              "type": "individual",
-                              "url": "https://github.com/sponsors/RubenVerborgh"
-                            }
-                          ],
-                          "engines": {
-                            "node": ">=4.0"
                           },
-                          "peerDependenciesMeta": {
-                            "debug": {
-                              "optional": true
+                          "dependencies": {
+                            "lodash": {
+                              "version": "3.10.1",
+                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                              "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ=="
                             }
                           }
                         },
-                        "node_modules/form-data": {
+                        "follow-redirects": {
+                          "version": "1.15.9",
+                          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+                          "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="
+                        },
+                        "form-data": {
                           "version": "4.0.0",
                           "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
                           "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-                          "dependencies": {
+                          "requires": {
                             "asynckit": "^0.4.0",
                             "combined-stream": "^1.0.8",
                             "mime-types": "^2.1.12"
-                          },
-                          "engines": {
-                            "node": ">= 6"
                           }
                         },
-                        "node_modules/iconv-lite": {
+                        "iconv-lite": {
                           "version": "0.6.3",
                           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
                           "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-                          "dependencies": {
+                          "requires": {
                             "safer-buffer": ">= 2.1.2 < 3.0.0"
-                          },
-                          "engines": {
-                            "node": ">=0.10.0"
                           }
                         },
-                        "node_modules/is-stream": {
+                        "is-stream": {
                           "version": "1.1.0",
                           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-                          "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-                          "engines": {
-                            "node": ">=0.10.0"
-                          }
+                          "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="
                         },
-                        "node_modules/isomorphic-fetch": {
+                        "isomorphic-fetch": {
                           "version": "2.2.1",
                           "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
                           "integrity": "sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==",
-                          "dependencies": {
+                          "requires": {
                             "node-fetch": "^1.0.1",
                             "whatwg-fetch": ">=0.10.0"
                           }
                         },
-                        "node_modules/lodash": {
+                        "lodash": {
                           "version": "4.16.6",
                           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz",
                           "integrity": "sha512-QXrLkYI2gXjL0QoQ9j932ca+Oh/wCUBeZULjqsJy78KjntrohXawEoOfgA2fXwy4vKh7OTD00p757/pUROtv+w=="
                         },
-                        "node_modules/mime-db": {
+                        "mime-db": {
                           "version": "1.52.0",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-                          "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-                          "engines": {
-                            "node": ">= 0.6"
-                          }
+                          "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
                         },
-                        "node_modules/mime-types": {
+                        "mime-types": {
                           "version": "2.1.35",
                           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
                           "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-                          "dependencies": {
+                          "requires": {
                             "mime-db": "1.52.0"
-                          },
-                          "engines": {
-                            "node": ">= 0.6"
                           }
                         },
-                        "node_modules/node-fetch": {
+                        "node-fetch": {
                           "version": "1.7.3",
                           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
                           "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-                          "dependencies": {
+                          "requires": {
                             "encoding": "^0.1.11",
                             "is-stream": "^1.0.1"
                           }
                         },
-                        "node_modules/proxy-from-env": {
+                        "proxy-from-env": {
                           "version": "1.1.0",
                           "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
                           "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
                         },
-                        "node_modules/safer-buffer": {
+                        "safer-buffer": {
                           "version": "2.1.2",
                           "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
                           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
                         },
-                        "node_modules/whatwg-fetch": {
-                          "version": "3.6.17",
-                          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.17.tgz",
-                          "integrity": "sha512-c4ghIvG6th0eudYwKZY5keb81wtFz9/WeAHAoy8+r18kcWlitUIrmGFQ2rWEl4UCKUilD3zCLHOIPheHx5ypRQ=="
+                        "whatwg-fetch": {
+                          "version": "3.6.20",
+                          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+                          "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="
                         }
                       }
                     }
@@ -1026,61 +1168,64 @@ output:
                   operation: update
                   support_file: false
                   type: file
-            pr-title: Bump axios from 0.27.1 to 1.4.0 in /npm/semver
+            pr-title: Bump axios from 0.27.1 to 1.7.7 in /npm/semver
             pr-body: |
-                Bumps [axios](https://github.com/axios/axios) from 0.27.1 to 1.4.0.
+                Bumps [axios](https://github.com/axios/axios) from 0.27.1 to 1.7.7.
                 <details>
                 <summary>Release notes</summary>
                 <p><em>Sourced from <a href="https://github.com/axios/axios/releases">axios's releases</a>.</em></p>
                 <blockquote>
-                <h2>Release v1.4.0</h2>
+                <h2>Release v1.7.7</h2>
                 <h2>Release notes:</h2>
                 <h3>Bug Fixes</h3>
                 <ul>
-                <li><strong>formdata:</strong> add <code>multipart/form-data</code> content type for FormData payload on custom client environments; (<a href="https://redirect.github.com/axios/axios/issues/5678">#5678</a>) (<a href="https://github.com/axios/axios/commit/bbb61e70cb1185adfb1cbbb86eaf6652c48d89d1">bbb61e7</a>)</li>
-                <li><strong>package:</strong> export package internals with unsafe path prefix; (<a href="https://redirect.github.com/axios/axios/issues/5677">#5677</a>) (<a href="https://github.com/axios/axios/commit/df38c949f26414d88ba29ec1e353c4d4f97eaf09">df38c94</a>)</li>
-                </ul>
-                <h3>Features</h3>
-                <ul>
-                <li><strong>dns:</strong> added support for a custom lookup function; (<a href="https://redirect.github.com/axios/axios/issues/5339">#5339</a>) (<a href="https://github.com/axios/axios/commit/2701911260a1faa5cc5e1afe437121b330a3b7bb">2701911</a>)</li>
-                <li><strong>types:</strong> export <code>AxiosHeaderValue</code> type. (<a href="https://redirect.github.com/axios/axios/issues/5525">#5525</a>) (<a href="https://github.com/axios/axios/commit/726f1c8e00cffa0461a8813a9bdcb8f8b9d762cf">726f1c8</a>)</li>
-                </ul>
-                <h3>Performance Improvements</h3>
-                <ul>
-                <li><strong>merge-config:</strong> optimize mergeConfig performance by avoiding duplicate key visits; (<a href="https://redirect.github.com/axios/axios/issues/5679">#5679</a>) (<a href="https://github.com/axios/axios/commit/e6f7053bf1a3e87cf1f9da8677e12e3fe829d68e">e6f7053</a>)</li>
+                <li><strong>fetch:</strong> fix stream handling in Safari by fallback to using a stream reader instead of an async iterator; (<a href="https://redirect.github.com/axios/axios/issues/6584">#6584</a>) (<a href="https://github.com/axios/axios/commit/d1980854fee1765cd02fa0787adf5d6e34dd9dcf">d198085</a>)</li>
+                <li><strong>http:</strong> fixed support for IPv6 literal strings in url (<a href="https://redirect.github.com/axios/axios/issues/5731">#5731</a>) (<a href="https://github.com/axios/axios/commit/364993f0d8bc6e0e06f76b8a35d2d0a35cab054c">364993f</a>)</li>
                 </ul>
                 <h3>Contributors to this release</h3>
                 <ul>
-                <li><!-- raw HTML omitted --> <a href="https://github.com/DigitalBrainJS" title="+151/-16 ([#5684](https://github.com/axios/axios/issues/5684) [#5339](https://github.com/axios/axios/issues/5339) [#5679](https://github.com/axios/axios/issues/5679) [#5678](https://github.com/axios/axios/issues/5678) [#5677](https://github.com/axios/axios/issues/5677) )">Dmitriy Mozgovoy</a></li>
-                <li><!-- raw HTML omitted --> <a href="https://github.com/arthurfiorette" title="+19/-19 ([#5525](https://github.com/axios/axios/issues/5525) )">Arthur Fiorette</a></li>
-                <li><!-- raw HTML omitted --> <a href="https://github.com/npiyush97" title="+2/-18 ([#5670](https://github.com/axios/axios/issues/5670) )">PIYUSH NEGI</a></li>
+                <li><!-- raw HTML omitted --> <a href="https://github.com/Rishi556" title="+39/-1 ([#5731](https://github.com/axios/axios/issues/5731) )">Rishi556</a></li>
+                <li><!-- raw HTML omitted --> <a href="https://github.com/DigitalBrainJS" title="+27/-7 ([#6584](https://github.com/axios/axios/issues/6584) )">Dmitriy Mozgovoy</a></li>
                 </ul>
-                <h2>Release v1.3.6</h2>
+                <h2>Release v1.7.6</h2>
                 <h2>Release notes:</h2>
                 <h3>Bug Fixes</h3>
                 <ul>
-                <li><strong>types:</strong> added transport to RawAxiosRequestConfig (<a href="https://redirect.github.com/axios/axios/issues/5445">#5445</a>) (<a href="https://github.com/axios/axios/commit/6f360a2531d8d70363fd9becef6a45a323f170e2">6f360a2</a>)</li>
-                <li><strong>utils:</strong> make isFormData detection logic stricter to avoid unnecessary calling of the <code>toString</code> method on the target; (<a href="https://redirect.github.com/axios/axios/issues/5661">#5661</a>) (<a href="https://github.com/axios/axios/commit/aa372f7306295dfd1100c1c2c77ce95c95808e76">aa372f7</a>)</li>
+                <li><strong>fetch:</strong> fix content length calculation for FormData payload; (<a href="https://redirect.github.com/axios/axios/issues/6524">#6524</a>) (<a href="https://github.com/axios/axios/commit/085f56861a83e9ac02c140ad9d68dac540dfeeaa">085f568</a>)</li>
+                <li><strong>fetch:</strong> optimize signals composing logic; (<a href="https://redirect.github.com/axios/axios/issues/6582">#6582</a>) (<a href="https://github.com/axios/axios/commit/df9889b83c2cc37e9e6189675a73ab70c60f031f">df9889b</a>)</li>
                 </ul>
                 <h3>Contributors to this release</h3>
                 <ul>
-                <li><!-- raw HTML omitted --> <a href="https://github.com/DigitalBrainJS" title="+48/-10 ([#5665](https://github.com/axios/axios/issues/5665) [#5661](https://github.com/axios/axios/issues/5661) [#5663](https://github.com/axios/axios/issues/5663) )">Dmitriy Mozgovoy</a></li>
-                <li><!-- raw HTML omitted --> <a href="https://github.com/Cadienvan" title="+2/-0 ([#5445](https://github.com/axios/axios/issues/5445) )">Michael Di Prisco</a></li>
+                <li><!-- raw HTML omitted --> <a href="https://github.com/DigitalBrainJS" title="+98/-46 ([#6582](https://github.com/axios/axios/issues/6582) )">Dmitriy Mozgovoy</a></li>
+                <li><!-- raw HTML omitted --> <a href="https://github.com/jacquesg" title="+5/-1 ([#6524](https://github.com/axios/axios/issues/6524) )">Jacques Germishuys</a></li>
+                <li><!-- raw HTML omitted --> <a href="https://github.com/kuroino721" title="+3/-1 ([#6575](https://github.com/axios/axios/issues/6575) )">kuroino721</a></li>
                 </ul>
-                <h2>Release v1.3.5</h2>
+                <h2>Release v1.7.5</h2>
                 <h2>Release notes:</h2>
                 <h3>Bug Fixes</h3>
                 <ul>
-                <li><strong>headers:</strong> fixed isValidHeaderName to support full list of allowed characters; (<a href="https://redirect.github.com/axios/axios/issues/5584">#5584</a>) (<a href="https://github.com/axios/axios/commit/e7decef6a99f4627e27ed9ea5b00ce8e201c3841">e7decef</a>)</li>
-                <li><strong>params:</strong> re-added the ability to set the function as <code>paramsSerializer</code> config; (<a href="https://redirect.github.com/axios/axios/issues/5633">#5633</a>) (<a href="https://github.com/axios/axios/commit/a56c8661209d5ce5a645a05f294a0e08a6c1f6b3">a56c866</a>)</li>
+                <li><strong>adapter:</strong> fix undefined reference to hasBrowserEnv (<a href="https://redirect.github.com/axios/axios/issues/6572">#6572</a>) (<a href="https://github.com/axios/axios/commit/7004707c4180b416341863bd86913fe4fc2f1df1">7004707</a>)</li>
+                <li><strong>core:</strong> add the missed implementation of AxiosError#status property; (<a href="https://redirect.github.com/axios/axios/issues/6573">#6573</a>) (<a href="https://github.com/axios/axios/commit/6700a8adac06942205f6a7a21421ecb36c4e0852">6700a8a</a>)</li>
+                <li><strong>core:</strong> fix <code>ReferenceError: navigator is not defined</code> for custom environments; (<a href="https://redirect.github.com/axios/axios/issues/6567">#6567</a>) (<a href="https://github.com/axios/axios/commit/fed1a4b2d78ed4a588c84e09d32749ed01dc2794">fed1a4b</a>)</li>
+                <li><strong>fetch:</strong> fix credentials handling in Cloudflare workers (<a href="https://redirect.github.com/axios/axios/issues/6533">#6533</a>) (<a href="https://github.com/axios/axios/commit/550d885eb90fd156add7b93bbdc54d30d2f9a98d">550d885</a>)</li>
                 </ul>
                 <h3>Contributors to this release</h3>
                 <ul>
-                <li><!-- raw HTML omitted --> <a href="https://github.com/DigitalBrainJS" title="+28/-10 ([#5633](https://github.com/axios/axios/issues/5633) [#5584](https://github.com/axios/axios/issues/5584) )">Dmitriy Mozgovoy</a></li>
+                <li><!-- raw HTML omitted --> <a href="https://github.com/DigitalBrainJS" title="+187/-83 ([#6573](https://github.com/axios/axios/issues/6573) [#6567](https://github.com/axios/axios/issues/6567) [#6566](https://github.com/axios/axios/issues/6566) [#6564](https://github.com/axios/axios/issues/6564) [#6563](https://github.com/axios/axios/issues/6563) [#6557](https://github.com/axios/axios/issues/6557) [#6556](https://github.com/axios/axios/issues/6556) [#6555](https://github.com/axios/axios/issues/6555) [#6554](https://github.com/axios/axios/issues/6554) [#6552](https://github.com/axios/axios/issues/6552) )">Dmitriy Mozgovoy</a></li>
+                <li><!-- raw HTML omitted --> <a href="https://github.com/antoninbas" title="+6/-6 ([#6572](https://github.com/axios/axios/issues/6572) )">Antonin Bas</a></li>
+                <li><!-- raw HTML omitted --> <a href="https://github.com/hansottowirtz" title="+4/-1 ([#6533](https://github.com/axios/axios/issues/6533) )">Hans Otto Wirtz</a></li>
                 </ul>
-                <h2>Release v1.3.4</h2>
+                <h2>Release v1.7.4</h2>
                 <h2>Release notes:</h2>
                 <h3>Bug Fixes</h3>
+                <ul>
+                <li><strong>sec:</strong> CVE-2024-39338 (<a href="https://redirect.github.com/axios/axios/issues/6539">#6539</a>) (<a href="https://redirect.github.com/axios/axios/issues/6543">#6543</a>) (<a href="https://github.com/axios/axios/commit/6b6b605eaf73852fb2dae033f1e786155959de3a">6b6b605</a>)</li>
+                <li><strong>sec:</strong> disregard protocol-relative URL to remediate SSRF (<a href="https://redirect.github.com/axios/axios/issues/6539">#6539</a>) (<a href="https://github.com/axios/axios/commit/07a661a2a6b9092c4aa640dcc7f724ec5e65bdda">07a661a</a>)</li>
+                </ul>
+                <h3>Contributors to this release</h3>
+                <ul>
+                <li><!-- raw HTML omitted --> <a href="https://github.com/levpachmanov" title="+47/-11 ([#6543](https://github.com/axios/axios/issues/6543) )">Lev Pachmanov</a></li>
+                </ul>
                 <!-- raw HTML omitted -->
                 </blockquote>
                 <p>... (truncated)</p>
@@ -1089,47 +1234,48 @@ output:
                 <summary>Changelog</summary>
                 <p><em>Sourced from <a href="https://github.com/axios/axios/blob/v1.x/CHANGELOG.md">axios's changelog</a>.</em></p>
                 <blockquote>
-                <h1><a href="https://github.com/axios/axios/compare/v1.3.6...v1.4.0">1.4.0</a> (2023-04-27)</h1>
+                <h2><a href="https://github.com/axios/axios/compare/v1.7.6...v1.7.7">1.7.7</a> (2024-08-31)</h2>
                 <h3>Bug Fixes</h3>
                 <ul>
-                <li><strong>formdata:</strong> add <code>multipart/form-data</code> content type for FormData payload on custom client environments; (<a href="https://redirect.github.com/axios/axios/issues/5678">#5678</a>) (<a href="https://github.com/axios/axios/commit/bbb61e70cb1185adfb1cbbb86eaf6652c48d89d1">bbb61e7</a>)</li>
-                <li><strong>package:</strong> export package internals with unsafe path prefix; (<a href="https://redirect.github.com/axios/axios/issues/5677">#5677</a>) (<a href="https://github.com/axios/axios/commit/df38c949f26414d88ba29ec1e353c4d4f97eaf09">df38c94</a>)</li>
-                </ul>
-                <h3>Features</h3>
-                <ul>
-                <li><strong>dns:</strong> added support for a custom lookup function; (<a href="https://redirect.github.com/axios/axios/issues/5339">#5339</a>) (<a href="https://github.com/axios/axios/commit/2701911260a1faa5cc5e1afe437121b330a3b7bb">2701911</a>)</li>
-                <li><strong>types:</strong> export <code>AxiosHeaderValue</code> type. (<a href="https://redirect.github.com/axios/axios/issues/5525">#5525</a>) (<a href="https://github.com/axios/axios/commit/726f1c8e00cffa0461a8813a9bdcb8f8b9d762cf">726f1c8</a>)</li>
-                </ul>
-                <h3>Performance Improvements</h3>
-                <ul>
-                <li><strong>merge-config:</strong> optimize mergeConfig performance by avoiding duplicate key visits; (<a href="https://redirect.github.com/axios/axios/issues/5679">#5679</a>) (<a href="https://github.com/axios/axios/commit/e6f7053bf1a3e87cf1f9da8677e12e3fe829d68e">e6f7053</a>)</li>
+                <li><strong>fetch:</strong> fix stream handling in Safari by fallback to using a stream reader instead of an async iterator; (<a href="https://redirect.github.com/axios/axios/issues/6584">#6584</a>) (<a href="https://github.com/axios/axios/commit/d1980854fee1765cd02fa0787adf5d6e34dd9dcf">d198085</a>)</li>
+                <li><strong>http:</strong> fixed support for IPv6 literal strings in url (<a href="https://redirect.github.com/axios/axios/issues/5731">#5731</a>) (<a href="https://github.com/axios/axios/commit/364993f0d8bc6e0e06f76b8a35d2d0a35cab054c">364993f</a>)</li>
                 </ul>
                 <h3>Contributors to this release</h3>
                 <ul>
-                <li><!-- raw HTML omitted --> <a href="https://github.com/DigitalBrainJS" title="+151/-16 ([#5684](https://github.com/axios/axios/issues/5684) [#5339](https://github.com/axios/axios/issues/5339) [#5679](https://github.com/axios/axios/issues/5679) [#5678](https://github.com/axios/axios/issues/5678) [#5677](https://github.com/axios/axios/issues/5677) )">Dmitriy Mozgovoy</a></li>
-                <li><!-- raw HTML omitted --> <a href="https://github.com/arthurfiorette" title="+19/-19 ([#5525](https://github.com/axios/axios/issues/5525) )">Arthur Fiorette</a></li>
-                <li><!-- raw HTML omitted --> <a href="https://github.com/npiyush97" title="+2/-18 ([#5670](https://github.com/axios/axios/issues/5670) )">PIYUSH NEGI</a></li>
+                <li><!-- raw HTML omitted --> <a href="https://github.com/Rishi556" title="+39/-1 ([#5731](https://github.com/axios/axios/issues/5731) )">Rishi556</a></li>
+                <li><!-- raw HTML omitted --> <a href="https://github.com/DigitalBrainJS" title="+27/-7 ([#6584](https://github.com/axios/axios/issues/6584) )">Dmitriy Mozgovoy</a></li>
                 </ul>
-                <h2><a href="https://github.com/axios/axios/compare/v1.3.5...v1.3.6">1.3.6</a> (2023-04-19)</h2>
+                <h2><a href="https://github.com/axios/axios/compare/v1.7.5...v1.7.6">1.7.6</a> (2024-08-30)</h2>
                 <h3>Bug Fixes</h3>
                 <ul>
-                <li><strong>types:</strong> added transport to RawAxiosRequestConfig (<a href="https://redirect.github.com/axios/axios/issues/5445">#5445</a>) (<a href="https://github.com/axios/axios/commit/6f360a2531d8d70363fd9becef6a45a323f170e2">6f360a2</a>)</li>
-                <li><strong>utils:</strong> make isFormData detection logic stricter to avoid unnecessary calling of the <code>toString</code> method on the target; (<a href="https://redirect.github.com/axios/axios/issues/5661">#5661</a>) (<a href="https://github.com/axios/axios/commit/aa372f7306295dfd1100c1c2c77ce95c95808e76">aa372f7</a>)</li>
+                <li><strong>fetch:</strong> fix content length calculation for FormData payload; (<a href="https://redirect.github.com/axios/axios/issues/6524">#6524</a>) (<a href="https://github.com/axios/axios/commit/085f56861a83e9ac02c140ad9d68dac540dfeeaa">085f568</a>)</li>
+                <li><strong>fetch:</strong> optimize signals composing logic; (<a href="https://redirect.github.com/axios/axios/issues/6582">#6582</a>) (<a href="https://github.com/axios/axios/commit/df9889b83c2cc37e9e6189675a73ab70c60f031f">df9889b</a>)</li>
                 </ul>
                 <h3>Contributors to this release</h3>
                 <ul>
-                <li><!-- raw HTML omitted --> <a href="https://github.com/DigitalBrainJS" title="+48/-10 ([#5665](https://github.com/axios/axios/issues/5665) [#5661](https://github.com/axios/axios/issues/5661) [#5663](https://github.com/axios/axios/issues/5663) )">Dmitriy Mozgovoy</a></li>
-                <li><!-- raw HTML omitted --> <a href="https://github.com/Cadienvan" title="+2/-0 ([#5445](https://github.com/axios/axios/issues/5445) )">Michael Di Prisco</a></li>
+                <li><!-- raw HTML omitted --> <a href="https://github.com/DigitalBrainJS" title="+98/-46 ([#6582](https://github.com/axios/axios/issues/6582) )">Dmitriy Mozgovoy</a></li>
+                <li><!-- raw HTML omitted --> <a href="https://github.com/jacquesg" title="+5/-1 ([#6524](https://github.com/axios/axios/issues/6524) )">Jacques Germishuys</a></li>
+                <li><!-- raw HTML omitted --> <a href="https://github.com/kuroino721" title="+3/-1 ([#6575](https://github.com/axios/axios/issues/6575) )">kuroino721</a></li>
                 </ul>
-                <h2><a href="https://github.com/axios/axios/compare/v1.3.4...v1.3.5">1.3.5</a> (2023-04-05)</h2>
+                <h2><a href="https://github.com/axios/axios/compare/v1.7.4...v1.7.5">1.7.5</a> (2024-08-23)</h2>
                 <h3>Bug Fixes</h3>
                 <ul>
-                <li><strong>headers:</strong> fixed isValidHeaderName to support full list of allowed characters; (<a href="https://redirect.github.com/axios/axios/issues/5584">#5584</a>) (<a href="https://github.com/axios/axios/commit/e7decef6a99f4627e27ed9ea5b00ce8e201c3841">e7decef</a>)</li>
-                <li><strong>params:</strong> re-added the ability to set the function as <code>paramsSerializer</code> config; (<a href="https://redirect.github.com/axios/axios/issues/5633">#5633</a>) (<a href="https://github.com/axios/axios/commit/a56c8661209d5ce5a645a05f294a0e08a6c1f6b3">a56c866</a>)</li>
+                <li><strong>adapter:</strong> fix undefined reference to hasBrowserEnv (<a href="https://redirect.github.com/axios/axios/issues/6572">#6572</a>) (<a href="https://github.com/axios/axios/commit/7004707c4180b416341863bd86913fe4fc2f1df1">7004707</a>)</li>
+                <li><strong>core:</strong> add the missed implementation of AxiosError#status property; (<a href="https://redirect.github.com/axios/axios/issues/6573">#6573</a>) (<a href="https://github.com/axios/axios/commit/6700a8adac06942205f6a7a21421ecb36c4e0852">6700a8a</a>)</li>
+                <li><strong>core:</strong> fix <code>ReferenceError: navigator is not defined</code> for custom environments; (<a href="https://redirect.github.com/axios/axios/issues/6567">#6567</a>) (<a href="https://github.com/axios/axios/commit/fed1a4b2d78ed4a588c84e09d32749ed01dc2794">fed1a4b</a>)</li>
+                <li><strong>fetch:</strong> fix credentials handling in Cloudflare workers (<a href="https://redirect.github.com/axios/axios/issues/6533">#6533</a>) (<a href="https://github.com/axios/axios/commit/550d885eb90fd156add7b93bbdc54d30d2f9a98d">550d885</a>)</li>
                 </ul>
                 <h3>Contributors to this release</h3>
                 <ul>
-                <li><!-- raw HTML omitted --> <a href="https://github.com/DigitalBrainJS" title="+28/-10 ([#5633](https://github.com/axios/axios/issues/5633) [#5584](https://github.com/axios/axios/issues/5584) )">Dmitriy Mozgovoy</a></li>
+                <li><!-- raw HTML omitted --> <a href="https://github.com/DigitalBrainJS" title="+187/-83 ([#6573](https://github.com/axios/axios/issues/6573) [#6567](https://github.com/axios/axios/issues/6567) [#6566](https://github.com/axios/axios/issues/6566) [#6564](https://github.com/axios/axios/issues/6564) [#6563](https://github.com/axios/axios/issues/6563) [#6557](https://github.com/axios/axios/issues/6557) [#6556](https://github.com/axios/axios/issues/6556) [#6555](https://github.com/axios/axios/issues/6555) [#6554](https://github.com/axios/axios/issues/6554) [#6552](https://github.com/axios/axios/issues/6552) )">Dmitriy Mozgovoy</a></li>
+                <li><!-- raw HTML omitted --> <a href="https://github.com/antoninbas" title="+6/-6 ([#6572](https://github.com/axios/axios/issues/6572) )">Antonin Bas</a></li>
+                <li><!-- raw HTML omitted --> <a href="https://github.com/hansottowirtz" title="+4/-1 ([#6533](https://github.com/axios/axios/issues/6533) )">Hans Otto Wirtz</a></li>
+                </ul>
+                <h2><a href="https://github.com/axios/axios/compare/v1.7.3...v1.7.4">1.7.4</a> (2024-08-13)</h2>
+                <h3>Bug Fixes</h3>
+                <ul>
+                <li><strong>sec:</strong> CVE-2024-39338 (<a href="https://redirect.github.com/axios/axios/issues/6539">#6539</a>) (<a href="https://redirect.github.com/axios/axios/issues/6543">#6543</a>) (<a href="https://github.com/axios/axios/commit/6b6b605eaf73852fb2dae033f1e786155959de3a">6b6b605</a>)</li>
+                <li><strong>sec:</strong> disregard protocol-relative URL to remediate SSRF (<a href="https://redirect.github.com/axios/axios/issues/6539">#6539</a>) (<a href="https://github.com/axios/axios/commit/07a661a2a6b9092c4aa640dcc7f724ec5e65bdda">07a661a</a>)</li>
                 </ul>
                 <!-- raw HTML omitted -->
                 </blockquote>
@@ -1138,27 +1284,27 @@ output:
                 <details>
                 <summary>Commits</summary>
                 <ul>
-                <li><a href="https://github.com/axios/axios/commit/21a5ad34c4a5956d81d338059ac0dd34a19ed094"><code>21a5ad3</code></a> chore(release): v1.4.0 (<a href="https://redirect.github.com/axios/axios/issues/5683">#5683</a>)</li>
-                <li><a href="https://github.com/axios/axios/commit/d627610d0c427de57c10618b36fa97814e2a75f0"><code>d627610</code></a> chore(utils): refactored isAsyncFn util to avoid inlining additional Babel he...</li>
-                <li><a href="https://github.com/axios/axios/commit/e18fdd893dfc67630c33fb6744d1b99d72857d92"><code>e18fdd8</code></a> refactor: remove deprecated url-search-params polyfill for URLSearchParams (#...</li>
-                <li><a href="https://github.com/axios/axios/commit/726f1c8e00cffa0461a8813a9bdcb8f8b9d762cf"><code>726f1c8</code></a> feat(types): export <code>AxiosHeaderValue</code> type. (<a href="https://redirect.github.com/axios/axios/issues/5525">#5525</a>)</li>
-                <li><a href="https://github.com/axios/axios/commit/2701911260a1faa5cc5e1afe437121b330a3b7bb"><code>2701911</code></a> feat(dns): added support for a custom lookup function; (<a href="https://redirect.github.com/axios/axios/issues/5339">#5339</a>)</li>
-                <li><a href="https://github.com/axios/axios/commit/e6f7053bf1a3e87cf1f9da8677e12e3fe829d68e"><code>e6f7053</code></a> perf(merge-config): optimize mergeConfig performance by avoiding duplicate ke...</li>
-                <li><a href="https://github.com/axios/axios/commit/bbb61e70cb1185adfb1cbbb86eaf6652c48d89d1"><code>bbb61e7</code></a> fix(formdata): add <code>multipart/form-data</code> content type for FormData payload on...</li>
-                <li><a href="https://github.com/axios/axios/commit/df38c949f26414d88ba29ec1e353c4d4f97eaf09"><code>df38c94</code></a> fix(package): export package internals with unsafe path prefix; (<a href="https://redirect.github.com/axios/axios/issues/5677">#5677</a>)</li>
-                <li><a href="https://github.com/axios/axios/commit/59eb99183546d822bc27e881f5dcd748daa04173"><code>59eb991</code></a> chore(release): v1.3.6 (<a href="https://redirect.github.com/axios/axios/issues/5666">#5666</a>)</li>
-                <li><a href="https://github.com/axios/axios/commit/1b8cc3b02b13f5d16ad988460edbda463113177e"><code>1b8cc3b</code></a> chore(template): improve issue template; (<a href="https://redirect.github.com/axios/axios/issues/5665">#5665</a>)</li>
-                <li>Additional commits viewable in <a href="https://github.com/axios/axios/compare/v0.27.1...v1.4.0">compare view</a></li>
+                <li><a href="https://github.com/axios/axios/commit/5b8a826771b77ab30081d033fdba9ef3b90e439a"><code>5b8a826</code></a> chore(release): v1.7.7 (<a href="https://redirect.github.com/axios/axios/issues/6585">#6585</a>)</li>
+                <li><a href="https://github.com/axios/axios/commit/364993f0d8bc6e0e06f76b8a35d2d0a35cab054c"><code>364993f</code></a> fix(http): fixed support for IPv6 literal strings in url (<a href="https://redirect.github.com/axios/axios/issues/5731">#5731</a>)</li>
+                <li><a href="https://github.com/axios/axios/commit/d1980854fee1765cd02fa0787adf5d6e34dd9dcf"><code>d198085</code></a> fix(fetch): fix stream handling in Safari by fallback to using a stream reade...</li>
+                <li><a href="https://github.com/axios/axios/commit/d584fcfa62ba5217baf2be0748b7c5eda6da16ad"><code>d584fcf</code></a> chore(release): v1.7.6 (<a href="https://redirect.github.com/axios/axios/issues/6583">#6583</a>)</li>
+                <li><a href="https://github.com/axios/axios/commit/bc03c6cbc41eb8449daa2f4b6b8048671a05bded"><code>bc03c6c</code></a> chore(examples): fix module import (<a href="https://redirect.github.com/axios/axios/issues/6575">#6575</a>)</li>
+                <li><a href="https://github.com/axios/axios/commit/df9889b83c2cc37e9e6189675a73ab70c60f031f"><code>df9889b</code></a> fix(fetch): optimize signals composing logic; (<a href="https://redirect.github.com/axios/axios/issues/6582">#6582</a>)</li>
+                <li><a href="https://github.com/axios/axios/commit/ee208cfcae8770ac579f26e7278867567886e026"><code>ee208cf</code></a> chore(sponsor): update sponsor block (<a href="https://redirect.github.com/axios/axios/issues/6576">#6576</a>)</li>
+                <li><a href="https://github.com/axios/axios/commit/085f56861a83e9ac02c140ad9d68dac540dfeeaa"><code>085f568</code></a> fix(fetch): fix content length calculation for FormData payload; (<a href="https://redirect.github.com/axios/axios/issues/6524">#6524</a>)</li>
+                <li><a href="https://github.com/axios/axios/commit/59cd6b0dece4050b190717a7c5cdf77906ce2104"><code>59cd6b0</code></a> chore(release): v1.7.5 (<a href="https://redirect.github.com/axios/axios/issues/6574">#6574</a>)</li>
+                <li><a href="https://github.com/axios/axios/commit/6700a8adac06942205f6a7a21421ecb36c4e0852"><code>6700a8a</code></a> fix(core): add the missed implementation of AxiosError#status property; (<a href="https://redirect.github.com/axios/axios/issues/6573">#6573</a>)</li>
+                <li>Additional commits viewable in <a href="https://github.com/axios/axios/compare/v0.27.1...v1.7.7">compare view</a></li>
                 </ul>
                 </details>
                 <br />
             commit-message: |-
-                Bump axios from 0.27.1 to 1.4.0 in /npm/semver
+                Bump axios from 0.27.1 to 1.7.7 in /npm/semver
 
-                Bumps [axios](https://github.com/axios/axios) from 0.27.1 to 1.4.0.
+                Bumps [axios](https://github.com/axios/axios) from 0.27.1 to 1.7.7.
                 - [Release notes](https://github.com/axios/axios/releases)
                 - [Changelog](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md)
-                - [Commits](https://github.com/axios/axios/compare/v0.27.1...v1.4.0)
+                - [Commits](https://github.com/axios/axios/compare/v0.27.1...v1.7.7)
     - type: mark_as_processed
       expect:
         data:

--- a/tests/smoke-npm-group-transitive.yaml
+++ b/tests/smoke-npm-group-transitive.yaml
@@ -9,6 +9,7 @@ input:
                 patterns:
                     - '@hapi/*'
         experiments:
+            npm_fallback_version_above_v6: true
             record-ecosystem-versions: true
         ignore-conditions:
             - dependency-name: '@hapi/hoek'
@@ -42,7 +43,7 @@ output:
         data:
             ecosystem_versions:
                 package_managers:
-                    npm: 8
+                    npm: 9
     - type: update_dependency_list
       expect:
         data:
@@ -53,9 +54,7 @@ output:
                       groups:
                         - dependencies
                       requirement: ^17.9.2
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   version: 17.9.2
                 - name: '@hapi/hoek'
                   requirements: []
@@ -97,59 +96,51 @@ output:
                     {
                       "name": "transitive",
                       "version": "1.0.0",
-                      "lockfileVersion": 3,
+                      "lockfileVersion": 1,
                       "requires": true,
-                      "packages": {
-                        "": {
-                          "name": "transitive",
-                          "version": "1.0.0",
-                          "license": "ISC",
-                          "dependencies": {
-                            "joi": "^17.9.2"
-                          }
-                        },
-                        "node_modules/@hapi/hoek": {
+                      "dependencies": {
+                        "@hapi/hoek": {
                           "version": "9.3.0",
                           "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
                           "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
                         },
-                        "node_modules/@hapi/topo": {
+                        "@hapi/topo": {
                           "version": "5.1.0",
                           "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
                           "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
-                          "dependencies": {
+                          "requires": {
                             "@hapi/hoek": "^9.0.0"
                           }
                         },
-                        "node_modules/@sideway/address": {
-                          "version": "4.1.4",
-                          "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
-                          "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
-                          "dependencies": {
+                        "@sideway/address": {
+                          "version": "4.1.5",
+                          "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+                          "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+                          "requires": {
                             "@hapi/hoek": "^9.0.0"
                           }
                         },
-                        "node_modules/@sideway/pinpoint": {
+                        "@sideway/formula": {
+                          "version": "3.0.1",
+                          "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+                          "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
+                        },
+                        "@sideway/pinpoint": {
                           "version": "2.0.0",
                           "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
                           "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
                         },
-                        "node_modules/joi": {
-                          "version": "17.9.2",
-                          "resolved": "https://registry.npmjs.org/joi/-/joi-17.9.2.tgz",
-                          "integrity": "sha512-Itk/r+V4Dx0V3c7RLFdRh12IOjySm2/WGPMubBT92cQvRfYZhPM2W0hZlctjj72iES8jsRCwp7S/cRmWBnJ4nw==",
-                          "dependencies": {
-                            "@hapi/hoek": "^9.0.0",
-                            "@hapi/topo": "^5.0.0",
-                            "@sideway/address": "^4.1.3",
+                        "joi": {
+                          "version": "17.13.3",
+                          "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+                          "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+                          "requires": {
+                            "@hapi/hoek": "^9.3.0",
+                            "@hapi/topo": "^5.1.0",
+                            "@sideway/address": "^4.1.5",
                             "@sideway/formula": "^3.0.1",
                             "@sideway/pinpoint": "^2.0.0"
                           }
-                        },
-                        "node_modules/joi/node_modules/@sideway/formula": {
-                          "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-                          "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
                         }
                       }
                     }
@@ -219,6 +210,112 @@ output:
         data:
             base-commit-sha: dde3e21e99b5237377d6e8a4858615e293bfacc4
             dependencies:
+                - name: joi
+                  previous-requirements:
+                    - file: package.json
+                      groups:
+                        - dependencies
+                      requirement: ^17.9.2
+                      source: null
+                  previous-version: 17.9.2
+                  requirements:
+                    - file: package.json
+                      groups:
+                        - dependencies
+                      requirement: ^17.9.2
+                      source: null
+                  version: 17.13.3
+                  directory: /npm/transitive
+            updated-dependency-files:
+                - content: |
+                    {
+                      "name": "transitive",
+                      "version": "1.0.0",
+                      "lockfileVersion": 1,
+                      "requires": true,
+                      "dependencies": {
+                        "@hapi/hoek": {
+                          "version": "9.3.0",
+                          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+                          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+                        },
+                        "@hapi/topo": {
+                          "version": "5.1.0",
+                          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+                          "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+                          "requires": {
+                            "@hapi/hoek": "^9.0.0"
+                          }
+                        },
+                        "@sideway/address": {
+                          "version": "4.1.5",
+                          "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+                          "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+                          "requires": {
+                            "@hapi/hoek": "^9.0.0"
+                          }
+                        },
+                        "@sideway/formula": {
+                          "version": "3.0.1",
+                          "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+                          "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
+                        },
+                        "@sideway/pinpoint": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+                          "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
+                        },
+                        "joi": {
+                          "version": "17.13.3",
+                          "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+                          "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+                          "requires": {
+                            "@hapi/hoek": "^9.3.0",
+                            "@hapi/topo": "^5.1.0",
+                            "@sideway/address": "^4.1.5",
+                            "@sideway/formula": "^3.0.1",
+                            "@sideway/pinpoint": "^2.0.0"
+                          }
+                        }
+                      }
+                    }
+                  content_encoding: utf-8
+                  deleted: false
+                  directory: /npm/transitive
+                  name: package-lock.json
+                  operation: update
+                  support_file: false
+                  type: file
+            pr-title: Bump joi from 17.9.2 to 17.13.3 in /npm/transitive
+            pr-body: |
+                Bumps [joi](https://github.com/hapijs/joi) from 17.9.2 to 17.13.3.
+                <details>
+                <summary>Commits</summary>
+                <ul>
+                <li><a href="https://github.com/hapijs/joi/commit/3cb73d6cded39fa49a46069b64d638a0ba0f7d14"><code>3cb73d6</code></a> 17.13.3</li>
+                <li><a href="https://github.com/hapijs/joi/commit/1653c478486227728942ebd8544bb068448cb814"><code>1653c47</code></a> fix: correct function type in alternatives error (<a href="https://redirect.github.com/hapijs/joi/issues/3043">#3043</a>)</li>
+                <li><a href="https://github.com/hapijs/joi/commit/7373136d149be0cc727096325f22f748d22aef46"><code>7373136</code></a> 17.13.2</li>
+                <li><a href="https://github.com/hapijs/joi/commit/add65979a3d2f93a08e60824ed1a02e56536fa69"><code>add6597</code></a> <code>strictUnknown</code> should honor local explicit <code>.unknown(false)</code></li>
+                <li><a href="https://github.com/hapijs/joi/commit/0066a4ef16706b722b81818a8608aea1129f4cc7"><code>0066a4e</code></a> 17.13.1</li>
+                <li><a href="https://github.com/hapijs/joi/commit/2d260302e75ed50e1f2658887dcd11fcc5b5e05c"><code>2d26030</code></a> fix: label false should also hide explicit labels (<a href="https://redirect.github.com/hapijs/joi/issues/3034">#3034</a>)</li>
+                <li><a href="https://github.com/hapijs/joi/commit/f02df4c011253d3573be19261a45c6765157d054"><code>f02df4c</code></a> 17.13.0</li>
+                <li><a href="https://github.com/hapijs/joi/commit/1ed2d4e615920c57d78ad139b6d53f62c1dec489"><code>1ed2d4e</code></a> feat: support encoding uri (follow-up to <a href="https://redirect.github.com/hapijs/joi/issues/3027">#3027</a>) (<a href="https://redirect.github.com/hapijs/joi/issues/3032">#3032</a>)</li>
+                <li><a href="https://github.com/hapijs/joi/commit/9af6f1f2347a4ffa4a131231b74978e1242fd585"><code>9af6f1f</code></a> feat: Support encoding uri (<a href="https://redirect.github.com/hapijs/joi/issues/3027">#3027</a>)</li>
+                <li><a href="https://github.com/hapijs/joi/commit/554a437a5569015479887f69033bcd1357fb55d6"><code>554a437</code></a> 17.12.3</li>
+                <li>Additional commits viewable in <a href="https://github.com/hapijs/joi/compare/v17.9.2...v17.13.3">compare view</a></li>
+                </ul>
+                </details>
+                <br />
+            commit-message: |-
+                Bump joi from 17.9.2 to 17.13.3 in /npm/transitive
+
+                Bumps [joi](https://github.com/hapijs/joi) from 17.9.2 to 17.13.3.
+                - [Commits](https://github.com/hapijs/joi/compare/v17.9.2...v17.13.3)
+    - type: create_pull_request
+      expect:
+        data:
+            base-commit-sha: dde3e21e99b5237377d6e8a4858615e293bfacc4
+            dependencies:
                 - name: '@sideway/formula'
                   previous-requirements: []
                   previous-version: 3.0.0
@@ -230,56 +327,48 @@ output:
                     {
                       "name": "transitive",
                       "version": "1.0.0",
-                      "lockfileVersion": 3,
+                      "lockfileVersion": 1,
                       "requires": true,
-                      "packages": {
-                        "": {
-                          "name": "transitive",
-                          "version": "1.0.0",
-                          "license": "ISC",
-                          "dependencies": {
-                            "joi": "^17.9.2"
-                          }
+                      "dependencies": {
+                        "@hapi/hoek": {
+                          "version": "9.3.0",
+                          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+                          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
                         },
-                        "node_modules/@hapi/hoek": {
-                          "version": "9.2.0",
-                          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
-                          "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug=="
-                        },
-                        "node_modules/@hapi/topo": {
-                          "version": "5.0.0",
-                          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
-                          "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
-                          "dependencies": {
+                        "@hapi/topo": {
+                          "version": "5.1.0",
+                          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+                          "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+                          "requires": {
                             "@hapi/hoek": "^9.0.0"
                           }
                         },
-                        "node_modules/@sideway/address": {
-                          "version": "4.1.4",
-                          "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
-                          "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
-                          "dependencies": {
+                        "@sideway/address": {
+                          "version": "4.1.5",
+                          "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+                          "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+                          "requires": {
                             "@hapi/hoek": "^9.0.0"
                           }
                         },
-                        "node_modules/@sideway/formula": {
+                        "@sideway/formula": {
                           "version": "3.0.1",
                           "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
                           "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
                         },
-                        "node_modules/@sideway/pinpoint": {
+                        "@sideway/pinpoint": {
                           "version": "2.0.0",
                           "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
                           "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
                         },
-                        "node_modules/joi": {
-                          "version": "17.9.2",
-                          "resolved": "https://registry.npmjs.org/joi/-/joi-17.9.2.tgz",
-                          "integrity": "sha512-Itk/r+V4Dx0V3c7RLFdRh12IOjySm2/WGPMubBT92cQvRfYZhPM2W0hZlctjj72iES8jsRCwp7S/cRmWBnJ4nw==",
-                          "dependencies": {
-                            "@hapi/hoek": "^9.0.0",
-                            "@hapi/topo": "^5.0.0",
-                            "@sideway/address": "^4.1.3",
+                        "joi": {
+                          "version": "17.13.3",
+                          "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+                          "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+                          "requires": {
+                            "@hapi/hoek": "^9.3.0",
+                            "@hapi/topo": "^5.1.0",
+                            "@sideway/address": "^4.1.5",
                             "@sideway/formula": "^3.0.1",
                             "@sideway/pinpoint": "^2.0.0"
                           }

--- a/tests/smoke-npm-version-multidir.yaml
+++ b/tests/smoke-npm-version-multidir.yaml
@@ -11,6 +11,8 @@ input:
                     - '@dependabot/dummy-pkg-a'
                     - '@dependabot/dummy-pkg-b'
                     - left-pad
+        experiments:
+            npm_fallback_version_above_v6: true
         ignore-conditions:
             - dependency-name: '@dependabot/dummy-pkg-b'
               source: tests/smoke-npm-version-multidir.yaml
@@ -44,9 +46,7 @@ output:
                       groups:
                         - dependencies
                       requirement: ^1.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   version: 1.0.0
                 - name: left-pad
                   requirements:
@@ -54,9 +54,7 @@ output:
                       groups:
                         - dependencies
                       requirement: ^1.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   version: 1.0.0
                 - name: '@dependabot/dummy-pkg-a'
                   requirements: []
@@ -67,9 +65,7 @@ output:
                       groups:
                         - dependencies
                       requirement: ^1.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   version: 1.0.0
                 - name: left-pad
                   requirements:
@@ -77,9 +73,7 @@ output:
                       groups:
                         - dependencies
                       requirement: ^1.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   version: 1.0.0
             dependency_files:
                 - /npm/multi-dir/foo/package.json
@@ -97,18 +91,14 @@ output:
                       groups:
                         - dependencies
                       requirement: ^1.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   previous-version: 1.0.0
                   requirements:
                     - file: package.json
                       groups:
                         - dependencies
                       requirement: ^1.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   version: 1.2.0
                   directory: /npm/multi-dir/foo
                 - name: left-pad
@@ -117,18 +107,14 @@ output:
                       groups:
                         - dependencies
                       requirement: ^1.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   previous-version: 1.0.0
                   requirements:
                     - file: package.json
                       groups:
                         - dependencies
                       requirement: ^1.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   version: 1.3.0
                   directory: /npm/multi-dir/foo
                 - name: '@dependabot/dummy-pkg-a'
@@ -143,18 +129,14 @@ output:
                       groups:
                         - dependencies
                       requirement: ^1.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   previous-version: 1.0.0
                   requirements:
                     - file: package.json
                       groups:
                         - dependencies
                       requirement: ^1.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   version: 1.3.0
                   directory: /npm/multi-dir/bar
                 - name: '@dependabot/dummy-pkg-a'
@@ -163,55 +145,41 @@ output:
                       groups:
                         - dependencies
                       requirement: ^1.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
+                      source: null
                   previous-version: 1.0.0
                   requirements:
                     - file: package.json
                       groups:
                         - dependencies
-                      requirement: ^2.0.0
-                      source:
-                        type: registry
-                        url: https://registry.npmjs.org
-                  version: 2.0.0
+                      requirement: ^1.0.0
+                      source: null
+                  version: 1.1.0
                   directory: /npm/multi-dir/bar
             updated-dependency-files:
                 - content: |
                     {
                       "name": "foo",
                       "version": "1.0.0",
-                      "lockfileVersion": 3,
+                      "lockfileVersion": 1,
                       "requires": true,
-                      "packages": {
-                        "": {
-                          "name": "foo",
-                          "version": "1.0.0",
-                          "license": "ISC",
-                          "dependencies": {
-                            "@dependabot/dummy-pkg-b": "^1.0.0",
-                            "left-pad": "^1.0.0"
-                          }
-                        },
-                        "node_modules/@dependabot/dummy-pkg-a": {
+                      "dependencies": {
+                        "@dependabot/dummy-pkg-a": {
                           "version": "2.0.0",
                           "resolved": "https://registry.npmjs.org/@dependabot/dummy-pkg-a/-/dummy-pkg-a-2.0.0.tgz",
                           "integrity": "sha512-kUkqhjyK+9PgJMiwoBrkfX7NTkZiw2s94gGnSRSP1ZFaoBqpwTuvQbZhDCa+mKPgpP5719qsW2YzuSK4RXhGAg=="
                         },
-                        "node_modules/@dependabot/dummy-pkg-b": {
+                        "@dependabot/dummy-pkg-b": {
                           "version": "1.2.0",
                           "resolved": "https://registry.npmjs.org/@dependabot/dummy-pkg-b/-/dummy-pkg-b-1.2.0.tgz",
                           "integrity": "sha512-fATgitB2jmBgmm9smHE2fMdMWZlFUgnVnkGdeZ5llKkgyvsiI3XiIhwiGXGdqaVyMDJshK9PEf5/V/puaZ0m6w==",
-                          "dependencies": {
+                          "requires": {
                             "@dependabot/dummy-pkg-a": "^2.0.0"
                           }
                         },
-                        "node_modules/left-pad": {
+                        "left-pad": {
                           "version": "1.3.0",
                           "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-                          "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
-                          "deprecated": "use String.prototype.padStart()"
+                          "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
                         }
                       }
                     }
@@ -226,51 +194,18 @@ output:
                     {
                       "name": "bar",
                       "version": "1.0.0",
-                      "description": "",
-                      "main": "index.js",
-                      "scripts": {
-                        "test": "echo \"Error: no test specified\" && exit 1"
-                      },
-                      "author": "",
-                      "license": "ISC",
-                      "dependencies": {
-                        "@dependabot/dummy-pkg-a": "^2.0.0",
-                        "left-pad": "^1.0.0"
-                      }
-                    }
-                  content_encoding: utf-8
-                  deleted: false
-                  directory: /npm/multi-dir/bar
-                  name: package.json
-                  operation: update
-                  support_file: false
-                  type: file
-                - content: |
-                    {
-                      "name": "bar",
-                      "version": "1.0.0",
-                      "lockfileVersion": 3,
+                      "lockfileVersion": 1,
                       "requires": true,
-                      "packages": {
-                        "": {
-                          "name": "bar",
-                          "version": "1.0.0",
-                          "license": "ISC",
-                          "dependencies": {
-                            "@dependabot/dummy-pkg-a": "^2.0.0",
-                            "left-pad": "^1.0.0"
-                          }
+                      "dependencies": {
+                        "@dependabot/dummy-pkg-a": {
+                          "version": "1.1.0",
+                          "resolved": "https://registry.npmjs.org/@dependabot/dummy-pkg-a/-/dummy-pkg-a-1.1.0.tgz",
+                          "integrity": "sha512-mjJzV5MdCP389oz3J0j3CiOZjF6h0R+36HqhG0Rl4Y0uCj0xdX+r0QboLZBugPwb7yBxrRHs6ZIe8J182r9Ssw=="
                         },
-                        "node_modules/@dependabot/dummy-pkg-a": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/@dependabot/dummy-pkg-a/-/dummy-pkg-a-2.0.0.tgz",
-                          "integrity": "sha512-kUkqhjyK+9PgJMiwoBrkfX7NTkZiw2s94gGnSRSP1ZFaoBqpwTuvQbZhDCa+mKPgpP5719qsW2YzuSK4RXhGAg=="
-                        },
-                        "node_modules/left-pad": {
+                        "left-pad": {
                           "version": "1.3.0",
                           "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-                          "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
-                          "deprecated": "use String.prototype.padStart()"
+                          "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
                         }
                       }
                     }
@@ -283,8 +218,8 @@ output:
                   type: file
             pr-title: Bump the npm_pkgs group across 2 directories with 3 updates
             pr-body: |
-                Bumps the npm_pkgs group with 2 updates in the /npm/multi-dir/foo directory: @dependabot/dummy-pkg-b and [left-pad](https://github.com/stevemao/left-pad).
-                Bumps the npm_pkgs group with 2 updates in the /npm/multi-dir/bar directory: [left-pad](https://github.com/stevemao/left-pad) and @dependabot/dummy-pkg-a.
+                Bumps the npm_pkgs group with 1 update in the /npm/multi-dir/foo directory: @dependabot/dummy-pkg-b.
+                Bumps the npm_pkgs group with 1 update in the /npm/multi-dir/bar directory: [left-pad](https://github.com/stevemao/left-pad).
 
                 Updates `@dependabot/dummy-pkg-b` from 1.0.0 to 1.2.0
 
@@ -308,12 +243,12 @@ output:
                 </details>
                 <br />
 
-                Updates `@dependabot/dummy-pkg-a` from 1.0.0 to 2.0.0
+                Updates `@dependabot/dummy-pkg-a` from 1.0.0 to 1.1.0
             commit-message: |-
                 Bump the npm_pkgs group across 2 directories with 3 updates
 
-                Bumps the npm_pkgs group with 2 updates in the /npm/multi-dir/foo directory: @dependabot/dummy-pkg-b and [left-pad](https://github.com/stevemao/left-pad).
-                Bumps the npm_pkgs group with 2 updates in the /npm/multi-dir/bar directory: [left-pad](https://github.com/stevemao/left-pad) and @dependabot/dummy-pkg-a.
+                Bumps the npm_pkgs group with 1 update in the /npm/multi-dir/foo directory: @dependabot/dummy-pkg-b.
+                Bumps the npm_pkgs group with 1 update in the /npm/multi-dir/bar directory: [left-pad](https://github.com/stevemao/left-pad).
 
 
                 Updates `@dependabot/dummy-pkg-b` from 1.0.0 to 1.2.0
@@ -326,7 +261,7 @@ output:
                 Updates `left-pad` from 1.0.0 to 1.3.0
                 - [Commits](https://github.com/stevemao/left-pad/commits/v1.3.0)
 
-                Updates `@dependabot/dummy-pkg-a` from 1.0.0 to 2.0.0
+                Updates `@dependabot/dummy-pkg-a` from 1.0.0 to 1.1.0
             dependency-group:
                 name: npm_pkgs
     - type: mark_as_processed


### PR DESCRIPTION
### Purpose

This PR updates our smoke tests to align with recent changes in the Dependabot Core project, specifically PR [#10757](https://github.com/dependabot/dependabot-core/pull/10757), which sets npm 8 as the default and fallback version under the `npm_fallback_version_above_v6` feature flag and assigns `lockfileVersion: 3` to npm 9. These changes ensure our tests reflect the supported npm versions (7, 8, and 9), with npm 8 as the fallback and compatibility adjustments for lockfile versioning under npm 9.

### Key Updates

- Updated smoke tests to validate functionality under npm 8 as the fallback version and lockfile version 3 with npm 9.
- Adjusted test expectations for dependency fields and lockfile structures to match npm 8 and npm 9’s handling of dependencies, lockfile formats, and source URL representation.
- Removed references to deprecated fields and structures specific to npm 6, aligning with the current support policy.

### Why This is Important

Ensuring our smoke tests reflect npm 8 as the fallback and lockfile version 3 for npm 9 improves accuracy for projects without explicit npm versioning, providing reliable dependency resolution. These updates also validate the `npm_fallback_version_above_v6` feature flag’s behavior, confirming that npm 8 is chosen as the fallback where applicable.

### Additional Notes

- **Compatibility Validation**: Tests confirm fallback behavior with npm 8 and lockfile versioning behavior with npm 9, focusing on dependency resolution and registry source handling.
- **Focus on Version-Specific Differences**: Tests cover unique behaviors across npm versions 7, 8, and 9 while removing references to npm 6, ensuring alignment with our current support policy.