### PR TITLE
Fix Smoke Tests for Bundler

### DIFF
--- a/tests/smoke-bundler.yaml
+++ b/tests/smoke-bundler.yaml
@@ -163,7 +163,7 @@ output:
                         parser (3.3.6.0)
                           ast (~> 2.4.1)
                           racc
-                        racc (1.7.3)
+                        racc (1.8.1)
                         rainbow (3.1.1)
                         regexp_parser (2.9.3)
                         rexml (3.4.0)

--- a/tests/smoke-bundler.yaml
+++ b/tests/smoke-bundler.yaml
@@ -157,16 +157,16 @@ output:
                       specs:
                         ast (2.4.2)
                         citrus (3.0.2)
-                        json (2.7.1)
+                        json (2.9.1)
                         netaddr (2.0.1)
-                        parallel (1.24.0)
-                        parser (3.3.0.5)
+                        parallel (1.26.3)
+                        parser (3.3.6.0)
                           ast (~> 2.4.1)
                           racc
                         racc (1.7.3)
                         rainbow (3.1.1)
-                        regexp_parser (2.9.0)
-                        rexml (3.2.6)
+                        regexp_parser (2.9.3)
+                        rexml (3.4.0)
                         rubocop (1.32.0)
                           json (~> 2.3)
                           parallel (~> 1.10)
@@ -177,12 +177,12 @@ output:
                           rubocop-ast (>= 1.19.1, < 2.0)
                           ruby-progressbar (~> 1.7)
                           unicode-display_width (>= 1.4.0, < 3.0)
-                        rubocop-ast (1.30.0)
-                          parser (>= 3.2.1.0)
+                        rubocop-ast (1.37.0)
+                          parser (>= 3.3.1.0)
                         ruby-progressbar (1.13.0)
                         toml-rb (2.2.0)
                           citrus (~> 3.0, > 3.0)
-                        unicode-display_width (2.5.0)
+                        unicode-display_width (2.6.0)
 
                     PLATFORMS
                       ruby


### PR DESCRIPTION
The Bundler registry that provides version information has changed, causing our smoke tests to fail. This Pull Request addresses the resulting issues, ensuring our pipeline runs successfully again.

For more details, please refer to the error log:
https://github.com/dependabot/dependabot-core/actions/runs/12404835515/job/34630668600?pr=11153
