### PR TITLE
Fixing the smoke test error after bump to php8.

### DIFF
--- a/tests/smoke-composer.yaml
+++ b/tests/smoke-composer.yaml
@@ -26,9 +26,6 @@ input:
             repo: dependabot/smoke-tests
             directory: /composer
             commit: 509a98a45a6f933ffd49ca7f2c26815c693b3d76
-        credentials-metadata:
-            - host: github.com
-              type: git_source
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN
@@ -330,7 +327,7 @@ output:
                         "prefer-lowest": false,
                         "platform": [],
                         "platform-dev": [],
-                        "plugin-api-version": "2.6.0"
+                        "plugin-api-version": "2.3.0"
                     }
                   content_encoding: utf-8
                   deleted: false
@@ -616,7 +613,7 @@ output:
                         "prefer-lowest": false,
                         "platform": [],
                         "platform-dev": [],
-                        "plugin-api-version": "2.6.0"
+                        "plugin-api-version": "2.3.0"
                     }
                   content_encoding: utf-8
                   deleted: false


### PR DESCRIPTION
[Fix for this CI error](https://github.com/dependabot/dependabot-core/actions/runs/12733490542/job/35489929394?pr=6506),  after bumping to PHP8, I have noticed below changes in the smoke test file.

Related PR: https://github.com/dependabot/dependabot-core/pull/6506

![image](https://github.com/user-attachments/assets/0e5de45f-48d5-40ae-9a14-d84c010692df)
