### PR TITLE
Checking in credentials metadata

### DIFF
--- a/tests/smoke-composer.yaml
+++ b/tests/smoke-composer.yaml
@@ -26,6 +26,9 @@ input:
             repo: dependabot/smoke-tests
             directory: /composer
             commit: 509a98a45a6f933ffd49ca7f2c26815c693b3d76
+        credentials-metadata:
+          - host: github.com
+            type: git_source
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN


### PR DESCRIPTION
Accidentally removed [this on previous PR](https://github.com/dependabot/smoke-tests/pull/245), Re adding credentials metadata