### PR TITLE
Smoke test logs updated after corepack is removed from npm update.

### DIFF
--- a/tests/smoke-npm-group-multidir.yaml
+++ b/tests/smoke-npm-group-multidir.yaml
@@ -220,12 +220,14 @@ output:
                         "node_modules/@dependabot/dummy-pkg-a": {
                           "version": "2.0.0",
                           "resolved": "https://registry.npmjs.org/@dependabot/dummy-pkg-a/-/dummy-pkg-a-2.0.0.tgz",
-                          "integrity": "sha512-kUkqhjyK+9PgJMiwoBrkfX7NTkZiw2s94gGnSRSP1ZFaoBqpwTuvQbZhDCa+mKPgpP5719qsW2YzuSK4RXhGAg=="
+                          "integrity": "sha512-kUkqhjyK+9PgJMiwoBrkfX7NTkZiw2s94gGnSRSP1ZFaoBqpwTuvQbZhDCa+mKPgpP5719qsW2YzuSK4RXhGAg==",
+                          "license": "MIT"
                         },
                         "node_modules/@dependabot/dummy-pkg-b": {
                           "version": "1.1.0",
                           "resolved": "https://registry.npmjs.org/@dependabot/dummy-pkg-b/-/dummy-pkg-b-1.1.0.tgz",
                           "integrity": "sha512-6r/5iuUs49Hln9Dl05waRoyzgkY9gwt8Yaa5SlhDmM5c2LwJ8tIG23+690FlXSUZ9c6xmOeuhHbcXGBMXsawbw==",
+                          "license": "MIT",
                           "dependencies": {
                             "@dependabot/dummy-pkg-a": "^2.0.0"
                           }
@@ -234,7 +236,8 @@ output:
                           "version": "1.3.0",
                           "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
                           "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
-                          "deprecated": "use String.prototype.padStart()"
+                          "deprecated": "use String.prototype.padStart()",
+                          "license": "WTFPL"
                         }
                       }
                     }
@@ -264,13 +267,15 @@ output:
                         "node_modules/@dependabot/dummy-pkg-a": {
                           "version": "1.1.0",
                           "resolved": "https://registry.npmjs.org/@dependabot/dummy-pkg-a/-/dummy-pkg-a-1.1.0.tgz",
-                          "integrity": "sha512-mjJzV5MdCP389oz3J0j3CiOZjF6h0R+36HqhG0Rl4Y0uCj0xdX+r0QboLZBugPwb7yBxrRHs6ZIe8J182r9Ssw=="
+                          "integrity": "sha512-mjJzV5MdCP389oz3J0j3CiOZjF6h0R+36HqhG0Rl4Y0uCj0xdX+r0QboLZBugPwb7yBxrRHs6ZIe8J182r9Ssw==",
+                          "license": "MIT"
                         },
                         "node_modules/left-pad": {
                           "version": "1.3.0",
                           "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
                           "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
-                          "deprecated": "use String.prototype.padStart()"
+                          "deprecated": "use String.prototype.padStart()",
+                          "license": "WTFPL"
                         }
                       }
                     }

--- a/tests/smoke-npm-group-multiple.yaml
+++ b/tests/smoke-npm-group-multiple.yaml
@@ -360,6 +360,7 @@ output:
                           "version": "16.2.0",
                           "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-16.2.0.tgz",
                           "integrity": "sha512-SgOjldgRlU6XL1f6OUmFa+1iiy1OCWXH8i7q7g0yGCeQ4XAlvNRjDj++xxvUwDhE2pLKJLPYDJmCH98mvjKZcA==",
+                          "license": "MIT",
                           "dependencies": {
                             "tslib": "^2.3.0"
                           },
@@ -374,6 +375,7 @@ output:
                           "version": "16.2.0",
                           "resolved": "https://registry.npmjs.org/@angular/common/-/common-16.2.0.tgz",
                           "integrity": "sha512-ByrDLsTBarzqRmq4GS841Ku0lvB4L2wfOCfGEIw2ZuiNbZlDA5O/qohQgJnHR5d9meVJnu9NgdbeyMzk90xZNg==",
+                          "license": "MIT",
                           "dependencies": {
                             "tslib": "^2.3.0"
                           },
@@ -389,6 +391,7 @@ output:
                           "version": "16.2.0",
                           "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.2.0.tgz",
                           "integrity": "sha512-Ai0CKRUDlMY6iFCeoRsC+soVFTU7eyMDmNzeakdmNvGYMdLdjH8WvgaNukesi6WX7YBIQIKTPJVral8fXBQroQ==",
+                          "license": "MIT",
                           "dependencies": {
                             "tslib": "^2.3.0"
                           },
@@ -408,6 +411,7 @@ output:
                           "version": "16.2.0",
                           "resolved": "https://registry.npmjs.org/@angular/core/-/core-16.2.0.tgz",
                           "integrity": "sha512-iwUWFw+JmRxw0chcNoqhXVR8XUTE+Rszhy22iSCkK0Jo8IJqEad1d2dQoFu1QfqOVdPMZtpJDmC/ppQ/f5c5aA==",
+                          "license": "MIT",
                           "dependencies": {
                             "tslib": "^2.3.0"
                           },
@@ -423,6 +427,7 @@ output:
                           "version": "16.2.0",
                           "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-16.2.0.tgz",
                           "integrity": "sha512-Z/IFw319ZSgGbJFkR5Ba0sRIIqDxQDVH4I+vnVoOYqq2NxuHYfLJDHAB9uHln9GWj86b1SrJBZe8qiS7Sxb7yQ==",
+                          "license": "MIT",
                           "dependencies": {
                             "tslib": "^2.3.0"
                           },
@@ -440,6 +445,7 @@ output:
                           "version": "16.2.0",
                           "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-16.2.0.tgz",
                           "integrity": "sha512-6xjZFnSD0C8ylDbzKpsxCJ4pLJDRvippr9Wj9RCeDQvAzMibsqIjpbesyOccw3hO+jheJQRhM/rZeO1ubZU94w==",
+                          "license": "MIT",
                           "dependencies": {
                             "tslib": "^2.3.0"
                           },
@@ -461,6 +467,7 @@ output:
                           "version": "16.2.0",
                           "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-16.2.0.tgz",
                           "integrity": "sha512-kLxgR+ichWb6dNA1JUAh0JB+iSrObkomd10porGQWVxAGmHqg1eiB3bBaSAgcaLftsrmEguIH8O9AEfq+HLfrA==",
+                          "license": "MIT",
                           "dependencies": {
                             "tslib": "^2.3.0"
                           },
@@ -478,6 +485,7 @@ output:
                           "version": "16.2.0",
                           "resolved": "https://registry.npmjs.org/@angular/router/-/router-16.2.0.tgz",
                           "integrity": "sha512-bFOaE7PNF0UHgVhl8BvyHiZHizTRZO7w3V29VqsdXUMMugBR4kr1/FXGzXTaz+9/eK7LokUwN9pjKKENNmhdyg==",
+                          "license": "MIT",
                           "dependencies": {
                             "tslib": "^2.3.0"
                           },
@@ -506,9 +514,10 @@ output:
                           "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
                         },
                         "node_modules/zone.js": {
-                          "version": "0.13.1",
-                          "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.13.1.tgz",
-                          "integrity": "sha512-+bIeDAFEBYuXRuU3qGQvzdPap+N1zjM4KkBAiiQuVVCrHrhjDuY6VkUhNa5+U27+9w0q3fbKiMCbpJ0XzMmSWA==",
+                          "version": "0.13.3",
+                          "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.13.3.tgz",
+                          "integrity": "sha512-MKPbmZie6fASC/ps4dkmIhaT5eonHkEt6eAy80K42tAm0G2W+AahLJjbfi6X9NPdciOE9GRFTTM8u2IiF6O3ww==",
+                          "license": "MIT",
                           "peer": true,
                           "dependencies": {
                             "tslib": "^2.3.0"

--- a/tests/smoke-npm-group-rules.yaml
+++ b/tests/smoke-npm-group-rules.yaml
@@ -253,6 +253,7 @@ output:
                           "version": "1.1.0",
                           "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
                           "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+                          "license": "MIT",
                           "engines": {
                             "node": "*"
                           }
@@ -266,6 +267,7 @@ output:
                           "version": "1.4.0",
                           "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
                           "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+                          "license": "MIT",
                           "dependencies": {
                             "follow-redirects": "^1.15.0",
                             "form-data": "^4.0.0",
@@ -273,21 +275,57 @@ output:
                           }
                         },
                         "node_modules/call-bind": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-                          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+                          "version": "1.0.8",
+                          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+                          "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+                          "license": "MIT",
                           "dependencies": {
-                            "function-bind": "^1.1.1",
-                            "get-intrinsic": "^1.0.2"
+                            "call-bind-apply-helpers": "^1.0.0",
+                            "es-define-property": "^1.0.0",
+                            "get-intrinsic": "^1.2.4",
+                            "set-function-length": "^1.2.2"
+                          },
+                          "engines": {
+                             "node": ">= 0.4"
                           },
                           "funding": {
                             "url": "https://github.com/sponsors/ljharb"
                           }
                         },
+                        "node_modules/call-bind-apply-helpers": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+                          "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+                          "license": "MIT",
+                          "dependencies": {
+                              "es-errors": "^1.3.0",
+                              "function-bind": "^1.1.2"
+                           },
+                          "engines": {
+                              "node": ">= 0.4"
+                           }
+                         },
+                        "node_modules/call-bound": {
+                            "version": "1.0.3",
+                            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+                            "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+                            "license": "MIT",
+                            "dependencies": {
+                                "call-bind-apply-helpers": "^1.0.1",
+                                "get-intrinsic": "^1.2.6"
+                            },
+                            "engines": {
+                                "node": ">= 0.4"
+                             },
+                            "funding": {
+                                "url": "https://github.com/sponsors/ljharb"
+                             }
+                        },
                         "node_modules/chai": {
                           "version": "3.5.0",
                           "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
                           "integrity": "sha512-eRYY0vPS2a9zt5w5Z0aCeWbrXTEyvk7u/Xf71EzNObrjSCPgMm1Nku/D/u2tiqHBX5j40wWhj54YJLtgn8g55A==",
+                          "license": "MIT",
                           "dependencies": {
                             "assertion-error": "^1.0.1",
                             "deep-eql": "^0.1.3",
@@ -320,6 +358,7 @@ output:
                           "version": "0.1.3",
                           "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
                           "integrity": "sha512-6sEotTRGBFiNcqVoeHwnfopbSpi5NbH1VWJmYCVkmxMmaVTT0bUTrNaGyBwhgP4MZL012W/mkzIn3Da+iDYweg==",
+                          "license": "MIT",
                           "dependencies": {
                             "type-detect": "0.1.1"
                           },
@@ -331,43 +370,53 @@ output:
                           "version": "0.1.1",
                           "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
                           "integrity": "sha512-5rqszGVwYgBoDkIm2oUtvkfZMQ0vk29iDMU0W2qCa3rG0vPDNczCMT4hV/bLBgLg8k8ri6+u3Zbt+S/14eMzlA==",
+                          "license": "MIT",
                           "engines": {
                             "node": "*"
                           }
                         },
                         "node_modules/deep-equal": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-                          "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+                          "version": "1.1.2",
+                          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+                          "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+                          "license": "MIT",
                           "dependencies": {
-                            "is-arguments": "^1.0.4",
-                            "is-date-object": "^1.0.1",
-                            "is-regex": "^1.0.4",
-                            "object-is": "^1.0.1",
+                            "is-arguments": "^1.1.1",
+                            "is-date-object": "^1.0.5",
+                            "is-regex": "^1.1.4",
+                            "object-is": "^1.1.5",
                             "object-keys": "^1.1.1",
-                            "regexp.prototype.flags": "^1.2.0"
+                            "regexp.prototype.flags": "^1.5.1"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
                           },
                           "funding": {
                             "url": "https://github.com/sponsors/ljharb"
                           }
                         },
                         "node_modules/define-data-property": {
-                          "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.0.tgz",
-                          "integrity": "sha512-UzGwzcjyv3OtAvolTj1GoyNYzfFR+iqbGjcnBEENZVCpM4/Ng1yhGNvS3lR/xDS74Tb2wGG9WzNSNIOS9UVb2g==",
+                          "version": "1.1.4",
+                          "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+                          "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+                          "license": "MIT",
                           "dependencies": {
-                            "get-intrinsic": "^1.2.1",
-                            "gopd": "^1.0.1",
-                            "has-property-descriptors": "^1.0.0"
+                            "es-define-property": "^1.0.0",
+                            "es-errors": "^1.3.0",
+                            "gopd": "^1.0.1"
                           },
                           "engines": {
                             "node": ">= 0.4"
+                          },
+                          "funding": {
+                            "url": "https://github.com/sponsors/ljharb"
                           }
                         },
                         "node_modules/define-properties": {
                           "version": "1.2.1",
                           "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
                           "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+                          "license": "MIT",
                           "dependencies": {
                             "define-data-property": "^1.0.1",
                             "has-property-descriptors": "^1.0.0",
@@ -388,12 +437,56 @@ output:
                             "node": ">=0.4.0"
                           }
                         },
+                        "node_modules/dunder-proto": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+                          "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+                          "license": "MIT",
+                          "dependencies": {
+                              "call-bind-apply-helpers": "^1.0.1",
+                              "es-errors": "^1.3.0",
+                              "gopd": "^1.2.0"
+                          },
+                          "engines": {
+                              "node": ">= 0.4"
+                          }
+                        },
                         "node_modules/encoding": {
                           "version": "0.1.12",
                           "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
                           "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
                           "dependencies": {
                             "iconv-lite": "0.4.19"
+                          }
+                        },
+                        "node_modules/es-define-property": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+                          "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+                          "license": "MIT",
+                          "engines": {
+                            "node": ">= 0.4"
+                          }
+                        },
+                        "node_modules/es-errors": {
+                          "version": "1.3.0",
+                          "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+                          "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+                          "license": "MIT",
+                          "engines": {
+                            "node": ">= 0.4"
+                          }
+                        },
+                        "node_modules/es-object-atoms": {
+                          "version": "1.1.1",
+                          "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+                          "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+                          "license": "MIT",
+                          "dependencies": {
+                            "es-errors": "^1.3.0"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
                           }
                         },
                         "node_modules/es6-promise": {
@@ -411,6 +504,7 @@ output:
                           "version": "0.2.1",
                           "resolved": "https://registry.npmjs.org/fetch-factory/-/fetch-factory-0.2.1.tgz",
                           "integrity": "sha512-sqt1ONiKIRec2E66VSBI6+vRQSTdpsfJc7ZF3T0N3MnG1q7thE0w6B8nGhiffLoqPF7yLcKY/y4CPjldBbT2wA==",
+                          "license": "ISC",
                           "dependencies": {
                             "es6-promise": "^3.0.2",
                             "isomorphic-fetch": "^2.1.1",
@@ -458,80 +552,89 @@ output:
                           }
                         },
                         "node_modules/function-bind": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-                          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+                          "version": "1.1.2",
+                          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+                          "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+                          "license": "MIT",
+                          "funding": {
+                            "url": "https://github.com/sponsors/ljharb"
+                          }
                         },
                         "node_modules/functions-have-names": {
                           "version": "1.2.3",
                           "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
                           "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+                          "license": "MIT",
                           "funding": {
                             "url": "https://github.com/sponsors/ljharb"
                           }
                         },
                         "node_modules/get-intrinsic": {
-                          "version": "1.2.1",
-                          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-                          "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+                          "version": "1.2.7",
+                          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+                          "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+                          "license": "MIT",
                           "dependencies": {
-                            "function-bind": "^1.1.1",
-                            "has": "^1.0.3",
-                            "has-proto": "^1.0.1",
-                            "has-symbols": "^1.0.3"
+                            "call-bind-apply-helpers": "^1.0.1",
+                            "es-define-property": "^1.0.1",
+                            "es-errors": "^1.3.0",
+                            "es-object-atoms": "^1.0.0",
+                            "function-bind": "^1.1.2",
+                            "get-proto": "^1.0.0",
+                            "gopd": "^1.2.0",
+                            "has-symbols": "^1.1.0",
+                            "hasown": "^2.0.2",
+                            "math-intrinsics": "^1.1.0"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
                           },
                           "funding": {
                             "url": "https://github.com/sponsors/ljharb"
+                          }
+                        },
+                        "node_modules/get-proto": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+                          "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+                          "license": "MIT",
+                          "dependencies": {
+                            "dunder-proto": "^1.0.1",
+                            "es-object-atoms": "^1.0.0"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
                           }
                         },
                         "node_modules/gopd": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-                          "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-                          "dependencies": {
-                            "get-intrinsic": "^1.1.3"
+                          "version": "1.2.0",
+                          "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+                          "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+                          "license": "MIT",
+                          "engines": {
+                            "node": ">= 0.4"
                           },
                           "funding": {
                             "url": "https://github.com/sponsors/ljharb"
-                          }
-                        },
-                        "node_modules/has": {
-                          "version": "1.0.3",
-                          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-                          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-                          "dependencies": {
-                            "function-bind": "^1.1.1"
-                          },
-                          "engines": {
-                            "node": ">= 0.4.0"
                           }
                         },
                         "node_modules/has-property-descriptors": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-                          "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+                          "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+                          "license": "MIT",
                           "dependencies": {
-                            "get-intrinsic": "^1.1.1"
-                          },
-                          "funding": {
-                            "url": "https://github.com/sponsors/ljharb"
-                          }
-                        },
-                        "node_modules/has-proto": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-                          "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
-                          "engines": {
-                            "node": ">= 0.4"
+                            "es-define-property": "^1.0.0"
                           },
                           "funding": {
                             "url": "https://github.com/sponsors/ljharb"
                           }
                         },
                         "node_modules/has-symbols": {
-                          "version": "1.0.3",
-                          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-                          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+                          "version": "1.1.0",
+                          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+                          "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+                          "license": "MIT",
                           "engines": {
                             "node": ">= 0.4"
                           },
@@ -539,18 +642,31 @@ output:
                             "url": "https://github.com/sponsors/ljharb"
                           }
                         },
-                        "node_modules/has-tostringtag": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-                          "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+                       "node_modules/has-tostringtag": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+                          "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+                          "license": "MIT",
                           "dependencies": {
-                            "has-symbols": "^1.0.2"
+                            "has-symbols": "^1.0.3"
                           },
                           "engines": {
                             "node": ">= 0.4"
                           },
                           "funding": {
                             "url": "https://github.com/sponsors/ljharb"
+                          }
+                        },
+                         "node_modules/hasown": {
+                          "version": "2.0.2",
+                          "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+                          "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+                          "license": "MIT",
+                          "dependencies": {
+                            "function-bind": "^1.1.2"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
                           }
                         },
                         "node_modules/iconv-lite": {
@@ -562,12 +678,13 @@ output:
                           }
                         },
                         "node_modules/is-arguments": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-                          "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+                          "version": "1.2.0",
+                          "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+                          "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+                          "license": "MIT",
                           "dependencies": {
-                            "call-bind": "^1.0.2",
-                            "has-tostringtag": "^1.0.0"
+                            "call-bound": "^1.0.2",
+                            "has-tostringtag": "^1.0.2"
                           },
                           "engines": {
                             "node": ">= 0.4"
@@ -577,11 +694,13 @@ output:
                           }
                         },
                         "node_modules/is-date-object": {
-                          "version": "1.0.5",
-                          "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-                          "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+                          "version": "1.1.0",
+                          "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+                          "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+                          "license": "MIT",
                           "dependencies": {
-                            "has-tostringtag": "^1.0.0"
+                            "call-bound": "^1.0.2",
+                            "has-tostringtag": "^1.0.2"
                           },
                           "engines": {
                             "node": ">= 0.4"
@@ -591,12 +710,15 @@ output:
                           }
                         },
                         "node_modules/is-regex": {
-                          "version": "1.1.4",
-                          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-                          "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+                          "version": "1.2.1",
+                          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+                          "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+                          "license": "MIT",
                           "dependencies": {
-                            "call-bind": "^1.0.2",
-                            "has-tostringtag": "^1.0.0"
+                            "call-bound": "^1.0.2",
+                            "gopd": "^1.2.0",
+                            "has-tostringtag": "^1.0.2",
+                            "hasown": "^2.0.2"
                           },
                           "engines": {
                             "node": ">= 0.4"
@@ -625,7 +747,17 @@ output:
                         "node_modules/lodash": {
                           "version": "4.17.21",
                           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-                          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+                          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+                          "license": "MIT"
+                        },
+                         "node_modules/math-intrinsics": {
+                          "version": "1.1.0",
+                          "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+                          "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+                          "license": "MIT",
+                          "engines": {
+                            "node": ">= 0.4"
+                          }
                         },
                         "node_modules/mime-db": {
                           "version": "1.52.0",
@@ -650,6 +782,7 @@ output:
                           "version": "1.2.8",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
                           "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+                          "license": "MIT",
                           "funding": {
                             "url": "https://github.com/sponsors/ljharb"
                           }
@@ -658,6 +791,7 @@ output:
                           "version": "0.5.6",
                           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
                           "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+                          "license": "MIT",
                           "dependencies": {
                             "minimist": "^1.2.6"
                           },
@@ -668,7 +802,8 @@ output:
                         "node_modules/ms": {
                           "version": "2.0.0",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+                          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+                          "license": "MIT",
                         },
                         "node_modules/nock": {
                           "version": "2.18.2",
@@ -677,6 +812,7 @@ output:
                           "engines": [
                             "node >= 0.10.0"
                           ],
+                          "license": "MIT",
                           "dependencies": {
                             "chai": ">=1.9.2 <4.0.0",
                             "debug": "^1.0.4",
@@ -693,7 +829,8 @@ output:
                           "engines": [
                             "node",
                             "rhino"
-                          ]
+                          ],
+                          "license": "MIT"
                         },
                         "node_modules/node-fetch": {
                           "version": "1.7.3",
@@ -705,12 +842,13 @@ output:
                           }
                         },
                         "node_modules/object-is": {
-                          "version": "1.1.5",
-                          "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-                          "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+                          "version": "1.1.6",
+                          "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+                          "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+                          "license": "MIT",
                           "dependencies": {
-                            "call-bind": "^1.0.2",
-                            "define-properties": "^1.1.3"
+                            "call-bind": "^1.0.7",
+                            "define-properties": "^1.2.1"
                           },
                           "engines": {
                             "node": ">= 0.4"
@@ -723,6 +861,7 @@ output:
                           "version": "1.1.1",
                           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
                           "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+                          "license": "MIT",
                           "engines": {
                             "node": ">= 0.4"
                           }
@@ -733,17 +872,20 @@ output:
                           "integrity": "sha512-GOc8Eoa3MWbN905b5l2PNNt1Pf+I/CF6uAPt3IGT+v9WExDE7WPT/kDfLe7vYXtG11KbTnBhTNfcoq9+umDrSw==",
                           "engines": [
                             "node >= 0.8.1"
-                          ]
+                          ],
+                          "license": "MIT"
                         },
                         "node_modules/proxy-from-env": {
                           "version": "1.1.0",
                           "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-                          "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+                          "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+                          "license": "MIT"
                         },
                         "node_modules/query-string": {
                           "version": "2.4.2",
                           "resolved": "https://registry.npmjs.org/query-string/-/query-string-2.4.2.tgz",
                           "integrity": "sha512-Y+OMYUuY7HxznI6WBN822fi/FMvnCTiuqd6KNcidPColOmMWPoV1RGYyyzObve1T/dD1i0ZgCCbO8ytu0ZUrkA==",
+                          "license": "MIT",
                           "dependencies": {
                             "strict-uri-encode": "^1.0.0"
                           },
@@ -752,13 +894,17 @@ output:
                           }
                         },
                         "node_modules/regexp.prototype.flags": {
-                          "version": "1.5.1",
-                          "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
-                          "integrity": "sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==",
+                          "version": "1.5.4",
+                          "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+                          "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+                          "license": "MIT",
                           "dependencies": {
-                            "call-bind": "^1.0.2",
-                            "define-properties": "^1.2.0",
-                            "set-function-name": "^2.0.0"
+                            "call-bind": "^1.0.8",
+                            "define-properties": "^1.2.1",
+                            "es-errors": "^1.3.0",
+                            "get-proto": "^1.0.1",
+                            "gopd": "^1.2.0",
+                            "set-function-name": "^2.0.2"
                           },
                           "engines": {
                             "node": ">= 0.4"
@@ -767,14 +913,33 @@ output:
                             "url": "https://github.com/sponsors/ljharb"
                           }
                         },
-                        "node_modules/set-function-name": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
-                          "integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
+                        "node_modules/set-function-length": {
+                          "version": "1.2.2",
+                          "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+                          "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+                          "license": "MIT",
                           "dependencies": {
-                            "define-data-property": "^1.0.1",
+                            "define-data-property": "^1.1.4",
+                            "es-errors": "^1.3.0",
+                            "function-bind": "^1.1.2",
+                            "get-intrinsic": "^1.2.4",
+                            "gopd": "^1.0.1",
+                            "has-property-descriptors": "^1.0.2"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
+                          }
+                        },
+                        "node_modules/set-function-name": {
+                          "version": "2.0.2",
+                          "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+                          "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+                          "license": "MIT",
+                          "dependencies": {
+                            "define-data-property": "^1.1.4",
+                            "es-errors": "^1.3.0",
                             "functions-have-names": "^1.2.3",
-                            "has-property-descriptors": "^1.0.0"
+                            "has-property-descriptors": "^1.0.2"
                           },
                           "engines": {
                             "node": ">= 0.4"
@@ -784,6 +949,7 @@ output:
                           "version": "1.1.0",
                           "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
                           "integrity": "sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==",
+                          "license": "MIT",
                           "engines": {
                             "node": ">=0.10.0"
                           }
@@ -792,6 +958,7 @@ output:
                           "version": "1.0.0",
                           "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
                           "integrity": "sha512-f9Uv6ezcpvCQjJU0Zqbg+65qdcszv3qUQsZfjdRbWiZ7AMenrX1u0lNk9EoWWX6e1F+NULyg27mtdeZ5WhpljA==",
+                          "license": "MIT",
                           "engines": {
                             "node": "*"
                           }
@@ -832,12 +999,32 @@ output:
                           }
                         },
                         "call-bind": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-                          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+                          "version": "1.0.8",
+                          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+                          "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
                           "requires": {
-                            "function-bind": "^1.1.1",
-                            "get-intrinsic": "^1.0.2"
+                            "call-bind-apply-helpers": "^1.0.0",
+                            "es-define-property": "^1.0.0",
+                            "get-intrinsic": "^1.2.4",
+                            "set-function-length": "^1.2.2"
+                          }
+                        },
+                        "call-bind-apply-helpers": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+                          "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+                          "requires": {
+                            "es-errors": "^1.3.0",
+                            "function-bind": "^1.1.2"
+                          }
+                        },
+                        "call-bound": {
+                          "version": "1.0.3",
+                          "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+                          "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+                          "requires": {
+                            "call-bind-apply-helpers": "^1.0.1",
+                            "get-intrinsic": "^1.2.6"
                           }
                         },
                         "chai": {
@@ -882,26 +1069,26 @@ output:
                           }
                         },
                         "deep-equal": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-                          "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+                          "version": "1.1.2",
+                          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+                          "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
                           "requires": {
-                            "is-arguments": "^1.0.4",
-                            "is-date-object": "^1.0.1",
-                            "is-regex": "^1.0.4",
-                            "object-is": "^1.0.1",
+                            "is-arguments": "^1.1.1",
+                            "is-date-object": "^1.0.5",
+                            "is-regex": "^1.1.4",
+                            "object-is": "^1.1.5",,
                             "object-keys": "^1.1.1",
-                            "regexp.prototype.flags": "^1.2.0"
+                            "regexp.prototype.flags": "^1.5.1"
                           }
                         },
                         "define-data-property": {
-                          "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.0.tgz",
-                          "integrity": "sha512-UzGwzcjyv3OtAvolTj1GoyNYzfFR+iqbGjcnBEENZVCpM4/Ng1yhGNvS3lR/xDS74Tb2wGG9WzNSNIOS9UVb2g==",
+                          "version": "1.1.4",
+                          "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+                          "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
                           "requires": {
-                            "get-intrinsic": "^1.2.1",
-                            "gopd": "^1.0.1",
-                            "has-property-descriptors": "^1.0.0"
+                            "es-define-property": "^1.0.0",
+                            "es-errors": "^1.3.0",
+                            "gopd": "^1.0.1"
                           }
                         },
                         "define-properties": {
@@ -919,12 +1106,40 @@ output:
                           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
                           "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
                         },
+                        "dunder-proto": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+                          "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+                          "requires": {
+                            "call-bind-apply-helpers": "^1.0.1",
+                            "es-errors": "^1.3.0",
+                            "gopd": "^1.2.0"
+                          }
+                        },
                         "encoding": {
                           "version": "0.1.12",
                           "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
                           "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
                           "requires": {
                             "iconv-lite": "0.4.19"
+                          }
+                        },
+                        "es-define-property": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+                          "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+                        },
+                        "es-errors": {
+                          "version": "1.3.0",
+                          "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+                          "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+                        },
+                        "es-object-atoms": {
+                          "version": "1.1.1",
+                          "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+                          "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+                          "requires": {
+                            "es-errors": "^1.3.0"
                           }
                         },
                         "es6-promise": {
@@ -974,9 +1189,9 @@ output:
                           }
                         },
                         "function-bind": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-                          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+                          "version": "1.1.2",
+                          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+                          "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
                         },
                         "functions-have-names": {
                           "version": "1.2.3",
@@ -984,56 +1199,63 @@ output:
                           "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
                         },
                         "get-intrinsic": {
-                          "version": "1.2.1",
-                          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-                          "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+                          "version": "1.2.7",
+                          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+                          "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
                           "requires": {
-                            "function-bind": "^1.1.1",
-                            "has": "^1.0.3",
-                            "has-proto": "^1.0.1",
-                            "has-symbols": "^1.0.3"
+                            "call-bind-apply-helpers": "^1.0.1",
+                            "es-define-property": "^1.0.1",
+                            "es-errors": "^1.3.0",
+                            "es-object-atoms": "^1.0.0",
+                            "function-bind": "^1.1.2",
+                            "get-proto": "^1.0.0",
+                            "gopd": "^1.2.0",
+                            "has-symbols": "^1.1.0",
+                            "hasown": "^2.0.2",
+                            "math-intrinsics": "^1.1.0"
+                          }
+                        },
+                        "get-proto": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+                          "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+                          "requires": {
+                            "dunder-proto": "^1.0.1",
+                            "es-object-atoms": "^1.0.0"
                           }
                         },
                         "gopd": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-                          "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-                          "requires": {
-                            "get-intrinsic": "^1.1.3"
-                          }
-                        },
-                        "has": {
-                          "version": "1.0.3",
-                          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-                          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-                          "requires": {
-                            "function-bind": "^1.1.1"
-                          }
-                        },
+                          "version": "1.2.0",
+                          "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+                          "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+                        },                      
                         "has-property-descriptors": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-                          "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+                          "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
                           "requires": {
-                            "get-intrinsic": "^1.1.1"
+                            "es-define-property": "^1.0.0"
                           }
-                        },
-                        "has-proto": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-                          "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg=="
                         },
                         "has-symbols": {
-                          "version": "1.0.3",
-                          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-                          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+                          "version": "1.1.0",
+                          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+                          "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
                         },
                         "has-tostringtag": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-                          "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+                          "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
                           "requires": {
-                            "has-symbols": "^1.0.2"
+                            "has-symbols": "^1.0.3"
+                          }
+                        },
+                         "hasown": {
+                          "version": "2.0.2",
+                          "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+                          "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+                          "requires": {
+                            "function-bind": "^1.1.2"
                           }
                         },
                         "iconv-lite": {
@@ -1042,29 +1264,32 @@ output:
                           "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
                         },
                         "is-arguments": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-                          "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+                          "version": "1.2.0",
+                          "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+                          "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
                           "requires": {
-                            "call-bind": "^1.0.2",
-                            "has-tostringtag": "^1.0.0"
+                            "call-bound": "^1.0.2",
+                            "has-tostringtag": "^1.0.2"
                           }
                         },
                         "is-date-object": {
-                          "version": "1.0.5",
-                          "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-                          "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+                          "version": "1.1.0",
+                          "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+                          "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
                           "requires": {
-                            "has-tostringtag": "^1.0.0"
+                            "call-bound": "^1.0.2",
+                            "has-tostringtag": "^1.0.2"
                           }
                         },
                         "is-regex": {
-                          "version": "1.1.4",
-                          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-                          "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+                          "version": "1.2.1",
+                          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+                          "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
                           "requires": {
-                            "call-bind": "^1.0.2",
-                            "has-tostringtag": "^1.0.0"
+                            "call-bound": "^1.0.2",
+                            "gopd": "^1.2.0",
+                            "has-tostringtag": "^1.0.2",
+                            "hasown": "^2.0.2"
                           }
                         },
                         "is-stream": {
@@ -1085,6 +1310,11 @@ output:
                           "version": "4.17.21",
                           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
                           "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+                        },
+                        "math-intrinsics": {
+                          "version": "1.1.0",
+                          "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+                          "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
                         },
                         "mime-db": {
                           "version": "1.52.0",
@@ -1147,12 +1377,12 @@ output:
                           }
                         },
                         "object-is": {
-                          "version": "1.1.5",
-                          "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-                          "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+                          "version": "1.1.6",
+                          "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+                          "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
                           "requires": {
-                            "call-bind": "^1.0.2",
-                            "define-properties": "^1.1.3"
+                            "call-bind": "^1.0.7",
+                            "define-properties": "^1.2.1"
                           }
                         },
                         "object-keys": {
@@ -1179,23 +1409,40 @@ output:
                           }
                         },
                         "regexp.prototype.flags": {
-                          "version": "1.5.1",
-                          "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
-                          "integrity": "sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==",
+                          "version": "1.5.4",
+                          "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+                          "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
                           "requires": {
-                            "call-bind": "^1.0.2",
-                            "define-properties": "^1.2.0",
-                            "set-function-name": "^2.0.0"
+                            "call-bind": "^1.0.8",
+                            "define-properties": "^1.2.1",
+                            "es-errors": "^1.3.0",
+                            "get-proto": "^1.0.1",
+                            "gopd": "^1.2.0",
+                            "set-function-name": "^2.0.2"
+                          }
+                        },
+                        "set-function-length": {
+                          "version": "1.2.2",
+                          "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+                          "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+                          "requires": {
+                            "define-data-property": "^1.1.4",
+                            "es-errors": "^1.3.0",
+                            "function-bind": "^1.1.2",
+                            "get-intrinsic": "^1.2.4",
+                            "gopd": "^1.0.1",
+                            "has-property-descriptors": "^1.0.2"
                           }
                         },
                         "set-function-name": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
-                          "integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
+                          "version": "2.0.2",
+                          "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+                          "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
                           "requires": {
-                            "define-data-property": "^1.0.1",
+                            "define-data-property": "^1.1.4",
+                            "es-errors": "^1.3.0",
                             "functions-have-names": "^1.2.3",
-                            "has-property-descriptors": "^1.0.0"
+                            "has-property-descriptors": "^1.0.2"
                           }
                         },
                         "strict-uri-encode": {
@@ -1495,6 +1742,7 @@ output:
                           "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
                           "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
                           "dev": true,
+                          "license": "MIT",
                           "engines": {
                             "node": ">= 0.6"
                           }

--- a/tests/smoke-npm-group-semver.yaml
+++ b/tests/smoke-npm-group-semver.yaml
@@ -210,6 +210,7 @@ output:
                           "version": "1.1.0",
                           "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
                           "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+                          "license": "MIT",
                           "engines": {
                             "node": "*"
                           }
@@ -230,12 +231,48 @@ output:
                           }
                         },
                         "node_modules/call-bind": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-                          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+                          "version": "1.0.8",
+                          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+                          "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+                          "license": "MIT",
                           "dependencies": {
                             "function-bind": "^1.1.1",
-                            "get-intrinsic": "^1.0.2"
+                            "call-bind-apply-helpers": "^1.0.0",
+                            "es-define-property": "^1.0.0",
+                            "get-intrinsic": "^1.2.4",
+                            "set-function-length": "^1.2.2"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
+                          },
+                          "funding": {
+                            "url": "https://github.com/sponsors/ljharb"
+                          }
+                        },
+                        "node_modules/call-bind-apply-helpers": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+                          "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+                          "license": "MIT",
+                          "dependencies": {
+                            "es-errors": "^1.3.0",
+                            "function-bind": "^1.1.2"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
+                          }
+                        },
+                        "node_modules/call-bound": {
+                          "version": "1.0.3",
+                          "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+                          "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+                          "license": "MIT",
+                          "dependencies": {
+                            "call-bind-apply-helpers": "^1.0.1",
+                            "get-intrinsic": "^1.2.6"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
                           },
                           "funding": {
                             "url": "https://github.com/sponsors/ljharb"
@@ -245,6 +282,7 @@ output:
                           "version": "3.5.0",
                           "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
                           "integrity": "sha512-eRYY0vPS2a9zt5w5Z0aCeWbrXTEyvk7u/Xf71EzNObrjSCPgMm1Nku/D/u2tiqHBX5j40wWhj54YJLtgn8g55A==",
+                          "license": "MIT",
                           "dependencies": {
                             "assertion-error": "^1.0.1",
                             "deep-eql": "^0.1.3",
@@ -277,6 +315,7 @@ output:
                           "version": "0.1.3",
                           "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
                           "integrity": "sha512-6sEotTRGBFiNcqVoeHwnfopbSpi5NbH1VWJmYCVkmxMmaVTT0bUTrNaGyBwhgP4MZL012W/mkzIn3Da+iDYweg==",
+                          "license": "MIT",
                           "dependencies": {
                             "type-detect": "0.1.1"
                           },
@@ -288,31 +327,55 @@ output:
                           "version": "0.1.1",
                           "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
                           "integrity": "sha512-5rqszGVwYgBoDkIm2oUtvkfZMQ0vk29iDMU0W2qCa3rG0vPDNczCMT4hV/bLBgLg8k8ri6+u3Zbt+S/14eMzlA==",
+                          "license": "MIT",
                           "engines": {
                             "node": "*"
                           }
                         },
                         "node_modules/deep-equal": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-                          "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+                          "version": "1.1.2",
+                          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+                          "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+                          "license": "MIT",
                           "dependencies": {
-                            "is-arguments": "^1.0.4",
-                            "is-date-object": "^1.0.1",
-                            "is-regex": "^1.0.4",
-                            "object-is": "^1.0.1",
+                            "is-arguments": "^1.1.1",
+                            "is-date-object": "^1.0.5",
+                            "is-regex": "^1.1.4",
+                            "object-is": "^1.1.5",
                             "object-keys": "^1.1.1",
-                            "regexp.prototype.flags": "^1.2.0"
+                            "regexp.prototype.flags": "^1.5.1"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
+                          },
+                          "funding": {
+                            "url": "https://github.com/sponsors/ljharb"
+                          }
+                        },
+                        "node_modules/define-data-property": {
+                          "version": "1.1.4",
+                          "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+                          "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+                          "license": "MIT",
+                          "dependencies": {
+                            "es-define-property": "^1.0.0",
+                            "es-errors": "^1.3.0",
+                            "gopd": "^1.0.1"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
                           },
                           "funding": {
                             "url": "https://github.com/sponsors/ljharb"
                           }
                         },
                         "node_modules/define-properties": {
-                          "version": "1.2.0",
-                          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
-                          "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+                          "version": "1.2.1",
+                          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+                          "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+                          "license": "MIT",
                           "dependencies": {
+                            "define-data-property": "^1.0.1",
                             "has-property-descriptors": "^1.0.0",
                             "object-keys": "^1.1.1"
                           },
@@ -331,12 +394,56 @@ output:
                             "node": ">=0.4.0"
                           }
                         },
+                        "node_modules/dunder-proto": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+                          "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+                          "license": "MIT",
+                          "dependencies": {
+                            "call-bind-apply-helpers": "^1.0.1",
+                            "es-errors": "^1.3.0",
+                            "gopd": "^1.2.0"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
+                          }
+                        },
                         "node_modules/encoding": {
                           "version": "0.1.13",
                           "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
                           "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
                           "dependencies": {
                             "iconv-lite": "^0.6.2"
+                          }
+                        },
+                        "node_modules/es-define-property": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+                          "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+                          "license": "MIT",
+                          "engines": {
+                            "node": ">= 0.4"
+                          }
+                        },
+                        "node_modules/es-errors": {
+                          "version": "1.3.0",
+                          "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+                          "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+                          "license": "MIT",
+                          "engines": {
+                            "node": ">= 0.4"
+                          }
+                        },
+                        "node_modules/es-object-atoms": {
+                          "version": "1.1.1",
+                          "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+                          "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+                          "license": "MIT",
+                          "dependencies": {
+                            "es-errors": "^1.3.0"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
                           }
                         },
                         "node_modules/es6-promise": {
@@ -348,6 +455,7 @@ output:
                           "version": "0.2.1",
                           "resolved": "https://registry.npmjs.org/fetch-factory/-/fetch-factory-0.2.1.tgz",
                           "integrity": "sha512-sqt1ONiKIRec2E66VSBI6+vRQSTdpsfJc7ZF3T0N3MnG1q7thE0w6B8nGhiffLoqPF7yLcKY/y4CPjldBbT2wA==",
+                          "license": "ISC"
                           "dependencies": {
                             "es6-promise": "^3.0.2",
                             "isomorphic-fetch": "^2.1.1",
@@ -395,58 +503,40 @@ output:
                           }
                         },
                         "node_modules/function-bind": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-                          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+                          "version": "1.1.2",
+                          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+                          "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+                          "license": "MIT",
+                          "funding": {
+                            "url": "https://github.com/sponsors/ljharb"
+                          }
                         },
                         "node_modules/functions-have-names": {
                           "version": "1.2.3",
                           "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
                           "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+                          "license": "MIT",
                           "funding": {
                             "url": "https://github.com/sponsors/ljharb"
                           }
                         },
                         "node_modules/get-intrinsic": {
-                          "version": "1.2.1",
-                          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-                          "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+                          "version": "1.2.7",
+                          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+                          "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+                          "license": "MIT",
                           "dependencies": {
-                            "function-bind": "^1.1.1",
-                            "has": "^1.0.3",
-                            "has-proto": "^1.0.1",
-                            "has-symbols": "^1.0.3"
+                            "call-bind-apply-helpers": "^1.0.1",
+                            "es-define-property": "^1.0.1",
+                            "es-errors": "^1.3.0",
+                            "es-object-atoms": "^1.0.0",
+                            "function-bind": "^1.1.2",
+                            "get-proto": "^1.0.0",
+                            "gopd": "^1.2.0",
+                            "has-symbols": "^1.1.0",
+                            "hasown": "^2.0.2",
+                            "math-intrinsics": "^1.1.0"
                           },
-                          "funding": {
-                            "url": "https://github.com/sponsors/ljharb"
-                          }
-                        },
-                        "node_modules/has": {
-                          "version": "1.0.3",
-                          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-                          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-                          "dependencies": {
-                            "function-bind": "^1.1.1"
-                          },
-                          "engines": {
-                            "node": ">= 0.4.0"
-                          }
-                        },
-                        "node_modules/has-property-descriptors": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-                          "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
-                          "dependencies": {
-                            "get-intrinsic": "^1.1.1"
-                          },
-                          "funding": {
-                            "url": "https://github.com/sponsors/ljharb"
-                          }
-                        },
-                        "node_modules/has-proto": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-                          "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
                           "engines": {
                             "node": ">= 0.4"
                           },
@@ -454,10 +544,48 @@ output:
                             "url": "https://github.com/sponsors/ljharb"
                           }
                         },
+                        "node_modules/get-proto": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+                          "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+                          "license": "MIT",
+                          "dependencies": {
+                            "dunder-proto": "^1.0.1",
+                            "es-object-atoms": "^1.0.0"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
+                          }
+                        },
+                        "node_modules/gopd": {
+                          "version": "1.2.0",
+                          "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+                          "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+                          "license": "MIT",
+                          "engines": {
+                            "node": ">= 0.4"
+                          },
+                          "funding": {
+                            "url": "https://github.com/sponsors/ljharb"
+                          }
+                        },
+                        "node_modules/has-property-descriptors": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+                          "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+                          "license": "MIT",
+                          "dependencies": {
+                            "es-define-property": "^1.0.0"
+                          },
+                          "funding": {
+                            "url": "https://github.com/sponsors/ljharb"
+                          }
+                        },
                         "node_modules/has-symbols": {
-                          "version": "1.0.3",
-                          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-                          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+                          "version": "1.1.0",
+                          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+                          "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+                          "license": "MIT",
                           "engines": {
                             "node": ">= 0.4"
                           },
@@ -466,17 +594,30 @@ output:
                           }
                         },
                         "node_modules/has-tostringtag": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-                          "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+                          "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+                          "license": "MIT",
                           "dependencies": {
-                            "has-symbols": "^1.0.2"
+                            "has-symbols": "^1.0.3"
                           },
                           "engines": {
                             "node": ">= 0.4"
                           },
                           "funding": {
                             "url": "https://github.com/sponsors/ljharb"
+                          }
+                        },
+                        "node_modules/hasown": {
+                          "version": "2.0.2",
+                          "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+                          "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+                          "license": "MIT",
+                          "dependencies": {
+                            "function-bind": "^1.1.2"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
                           }
                         },
                         "node_modules/iconv-lite": {
@@ -491,12 +632,13 @@ output:
                           }
                         },
                         "node_modules/is-arguments": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-                          "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+                          "version": "1.2.0",
+                          "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+                          "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+                          "license": "MIT",
                           "dependencies": {
-                            "call-bind": "^1.0.2",
-                            "has-tostringtag": "^1.0.0"
+                            "call-bound": "^1.0.2",
+                            "has-tostringtag": "^1.0.2"
                           },
                           "engines": {
                             "node": ">= 0.4"
@@ -506,11 +648,13 @@ output:
                           }
                         },
                         "node_modules/is-date-object": {
-                          "version": "1.0.5",
-                          "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-                          "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+                          "version": "1.1.0",
+                          "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+                          "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+                          "license": "MIT",
                           "dependencies": {
-                            "has-tostringtag": "^1.0.0"
+                            "call-bound": "^1.0.2",
+                            "has-tostringtag": "^1.0.2"
                           },
                           "engines": {
                             "node": ">= 0.4"
@@ -520,12 +664,15 @@ output:
                           }
                         },
                         "node_modules/is-regex": {
-                          "version": "1.1.4",
-                          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-                          "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+                          "version": "1.2.1",
+                          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+                          "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+                          "license": "MIT",
                           "dependencies": {
-                            "call-bind": "^1.0.2",
-                            "has-tostringtag": "^1.0.0"
+                            "call-bound": "^1.0.2",
+                            "gopd": "^1.2.0",
+                            "has-tostringtag": "^1.0.2",
+                            "hasown": "^2.0.2"
                           },
                           "engines": {
                             "node": ">= 0.4"
@@ -555,6 +702,16 @@ output:
                           "version": "4.17.21",
                           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
                           "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+                          "license": "MIT"
+                        },
+                        "node_modules/math-intrinsics": {
+                          "version": "1.1.0",
+                          "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+                          "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+                          "license": "MIT",
+                          "engines": {
+                            "node": ">= 0.4"
+                          }
                         },
                         "node_modules/mime-db": {
                           "version": "1.52.0",
@@ -579,6 +736,7 @@ output:
                           "version": "1.2.8",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
                           "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+                          "license": "MIT",
                           "funding": {
                             "url": "https://github.com/sponsors/ljharb"
                           }
@@ -587,6 +745,7 @@ output:
                           "version": "0.5.6",
                           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
                           "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+                          "license": "MIT",
                           "dependencies": {
                             "minimist": "^1.2.6"
                           },
@@ -597,7 +756,8 @@ output:
                         "node_modules/ms": {
                           "version": "2.0.0",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+                          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+                          "license": "MIT"
                         },
                         "node_modules/nock": {
                           "version": "2.18.2",
@@ -606,6 +766,7 @@ output:
                           "engines": [
                             "node >= 0.10.0"
                           ],
+                          "license": "MIT",
                           "dependencies": {
                             "chai": ">=1.9.2 <4.0.0",
                             "debug": "^1.0.4",
@@ -622,7 +783,8 @@ output:
                           "engines": [
                             "node",
                             "rhino"
-                          ]
+                          ],
+                          "license": "MIT"
                         },
                         "node_modules/node-fetch": {
                           "version": "1.7.3",
@@ -634,12 +796,13 @@ output:
                           }
                         },
                         "node_modules/object-is": {
-                          "version": "1.1.5",
-                          "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-                          "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+                          "version": "1.1.6",
+                          "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+                          "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+                          "license": "MIT",
                           "dependencies": {
-                            "call-bind": "^1.0.2",
-                            "define-properties": "^1.1.3"
+                            "call-bind": "^1.0.7",
+                            "define-properties": "^1.2.1"
                           },
                           "engines": {
                             "node": ">= 0.4"
@@ -652,6 +815,7 @@ output:
                           "version": "1.1.1",
                           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
                           "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+                          "license": "MIT",
                           "engines": {
                             "node": ">= 0.4"
                           }
@@ -662,12 +826,14 @@ output:
                           "integrity": "sha512-GOc8Eoa3MWbN905b5l2PNNt1Pf+I/CF6uAPt3IGT+v9WExDE7WPT/kDfLe7vYXtG11KbTnBhTNfcoq9+umDrSw==",
                           "engines": [
                             "node >= 0.8.1"
-                          ]
+                          ],
+                          "license": "MIT"
                         },
                         "node_modules/query-string": {
                           "version": "2.4.2",
                           "resolved": "https://registry.npmjs.org/query-string/-/query-string-2.4.2.tgz",
                           "integrity": "sha512-Y+OMYUuY7HxznI6WBN822fi/FMvnCTiuqd6KNcidPColOmMWPoV1RGYyyzObve1T/dD1i0ZgCCbO8ytu0ZUrkA==",
+                          "license": "MIT",
                           "dependencies": {
                             "strict-uri-encode": "^1.0.0"
                           },
@@ -676,13 +842,17 @@ output:
                           }
                         },
                         "node_modules/regexp.prototype.flags": {
-                          "version": "1.5.0",
-                          "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
-                          "integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
+                          "version": "1.5.4",
+                          "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+                          "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+                          "license": "MIT",
                           "dependencies": {
-                            "call-bind": "^1.0.2",
-                            "define-properties": "^1.2.0",
-                            "functions-have-names": "^1.2.3"
+                            "call-bind": "^1.0.8",
+                            "define-properties": "^1.2.1",
+                            "es-errors": "^1.3.0",
+                            "get-proto": "^1.0.1",
+                            "gopd": "^1.2.0",
+                            "set-function-name": "^2.0.2"
                           },
                           "engines": {
                             "node": ">= 0.4"
@@ -696,10 +866,43 @@ output:
                           "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
                           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
                         },
+                        "node_modules/set-function-length": {
+                          "version": "1.2.2",
+                          "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+                          "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+                          "license": "MIT",
+                          "dependencies": {
+                            "define-data-property": "^1.1.4",
+                            "es-errors": "^1.3.0",
+                            "function-bind": "^1.1.2",
+                            "get-intrinsic": "^1.2.4",
+                            "gopd": "^1.0.1",
+                            "has-property-descriptors": "^1.0.2"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
+                          }
+                        },
+                        "node_modules/set-function-name": {
+                          "version": "2.0.2",
+                          "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+                          "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+                          "license": "MIT",
+                          "dependencies": {
+                            "define-data-property": "^1.1.4",
+                            "es-errors": "^1.3.0",
+                            "functions-have-names": "^1.2.3",
+                            "has-property-descriptors": "^1.0.2"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
+                          }
+                        },
                         "node_modules/strict-uri-encode": {
                           "version": "1.1.0",
                           "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
                           "integrity": "sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==",
+                          "license": "MIT",
                           "engines": {
                             "node": ">=0.10.0"
                           }
@@ -708,6 +911,7 @@ output:
                           "version": "1.0.0",
                           "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
                           "integrity": "sha512-f9Uv6ezcpvCQjJU0Zqbg+65qdcszv3qUQsZfjdRbWiZ7AMenrX1u0lNk9EoWWX6e1F+NULyg27mtdeZ5WhpljA==",
+                          "license": "MIT",
                           "engines": {
                             "node": "*"
                           }
@@ -856,6 +1060,7 @@ output:
                           "version": "1.4.0",
                           "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
                           "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+                          "license": "MIT",
                           "dependencies": {
                             "follow-redirects": "^1.15.0",
                             "form-data": "^4.0.0",
@@ -1005,7 +1210,8 @@ output:
                         "node_modules/proxy-from-env": {
                           "version": "1.1.0",
                           "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-                          "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+                          "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+                          "license": "MIT"
                         },
                         "node_modules/safer-buffer": {
                           "version": "2.1.2",

--- a/tests/smoke-npm-group-transitive.yaml
+++ b/tests/smoke-npm-group-transitive.yaml
@@ -111,12 +111,14 @@ output:
                         "node_modules/@hapi/hoek": {
                           "version": "9.3.0",
                           "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-                          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+                          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+                          "license": "BSD-3-Clause"
                         },
                         "node_modules/@hapi/topo": {
                           "version": "5.1.0",
                           "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
                           "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+                          "license": "BSD-3-Clause",
                           "dependencies": {
                             "@hapi/hoek": "^9.0.0"
                           }
@@ -149,7 +151,8 @@ output:
                         "node_modules/joi/node_modules/@sideway/formula": {
                           "version": "3.0.1",
                           "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-                          "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
+                          "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
+                          "license": "BSD-3-Clause"
                         }
                       }
                     }

--- a/tests/smoke-npm-remove-transitive.yaml
+++ b/tests/smoke-npm-remove-transitive.yaml
@@ -132,7 +132,8 @@ output:
                         "node_modules/@dependabot-fixtures/npm-remove-dependency": {
                           "version": "10.0.1",
                           "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-remove-dependency/-/npm-remove-dependency-10.0.1.tgz",
-                          "integrity": "sha512-acz1nPaB5TR8A5FBmOyZcYE8YQVs5TwrSGtqCyT0hbKJPtDYBt8yxRdbgC36fPrP/4JZn++bvaohG7IQq6NrPA=="
+                          "integrity": "sha512-acz1nPaB5TR8A5FBmOyZcYE8YQVs5TwrSGtqCyT0hbKJPtDYBt8yxRdbgC36fPrP/4JZn++bvaohG7IQq6NrPA==",
+                          "license": "ISC"
                         }
                       },
                       "dependencies": {

--- a/tests/smoke-npm-version-multidir.yaml
+++ b/tests/smoke-npm-version-multidir.yaml
@@ -197,12 +197,14 @@ output:
                         "node_modules/@dependabot/dummy-pkg-a": {
                           "version": "2.0.0",
                           "resolved": "https://registry.npmjs.org/@dependabot/dummy-pkg-a/-/dummy-pkg-a-2.0.0.tgz",
-                          "integrity": "sha512-kUkqhjyK+9PgJMiwoBrkfX7NTkZiw2s94gGnSRSP1ZFaoBqpwTuvQbZhDCa+mKPgpP5719qsW2YzuSK4RXhGAg=="
+                          "integrity": "sha512-kUkqhjyK+9PgJMiwoBrkfX7NTkZiw2s94gGnSRSP1ZFaoBqpwTuvQbZhDCa+mKPgpP5719qsW2YzuSK4RXhGAg==",
+                          "license": "MIT"
                         },
                         "node_modules/@dependabot/dummy-pkg-b": {
                           "version": "1.2.0",
                           "resolved": "https://registry.npmjs.org/@dependabot/dummy-pkg-b/-/dummy-pkg-b-1.2.0.tgz",
                           "integrity": "sha512-fATgitB2jmBgmm9smHE2fMdMWZlFUgnVnkGdeZ5llKkgyvsiI3XiIhwiGXGdqaVyMDJshK9PEf5/V/puaZ0m6w==",
+                          "license": "MIT",
                           "dependencies": {
                             "@dependabot/dummy-pkg-a": "^2.0.0"
                           }
@@ -211,7 +213,8 @@ output:
                           "version": "1.3.0",
                           "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
                           "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
-                          "deprecated": "use String.prototype.padStart()"
+                          "deprecated": "use String.prototype.padStart()",
+                          "license": "MIT"
                         }
                       }
                     }
@@ -264,13 +267,15 @@ output:
                         "node_modules/@dependabot/dummy-pkg-a": {
                           "version": "2.0.0",
                           "resolved": "https://registry.npmjs.org/@dependabot/dummy-pkg-a/-/dummy-pkg-a-2.0.0.tgz",
-                          "integrity": "sha512-kUkqhjyK+9PgJMiwoBrkfX7NTkZiw2s94gGnSRSP1ZFaoBqpwTuvQbZhDCa+mKPgpP5719qsW2YzuSK4RXhGAg=="
+                          "integrity": "sha512-kUkqhjyK+9PgJMiwoBrkfX7NTkZiw2s94gGnSRSP1ZFaoBqpwTuvQbZhDCa+mKPgpP5719qsW2YzuSK4RXhGAg==",
+                          "license": "MIT"
                         },
                         "node_modules/left-pad": {
                           "version": "1.3.0",
                           "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
                           "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
-                          "deprecated": "use String.prototype.padStart()"
+                          "deprecated": "use String.prototype.padStart()",
+                          "license": "WTFPL"
                         }
                       }
                     }

--- a/tests/smoke-npm.yaml
+++ b/tests/smoke-npm.yaml
@@ -214,6 +214,7 @@ output:
                           "version": "1.4.0",
                           "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
                           "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+                          "license": "MIT",
                           "dependencies": {
                             "follow-redirects": "^1.15.0",
                             "form-data": "^4.0.0",
@@ -366,7 +367,8 @@ output:
                         "node_modules/proxy-from-env": {
                           "version": "1.1.0",
                           "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-                          "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+                          "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+                          "license": "MIT"
                         },
                         "node_modules/whatwg-fetch": {
                           "version": "2.0.3",
@@ -734,6 +736,7 @@ output:
                           "version": "1.1.0",
                           "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
                           "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+                          "license": "MIT",
                           "engines": {
                             "node": "*"
                           }
@@ -753,21 +756,57 @@ output:
                           }
                         },
                         "node_modules/call-bind": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-                          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+                          "version": "1.0.8",
+                          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+                          "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+                          "license": "MIT",
                           "dependencies": {
-                            "function-bind": "^1.1.1",
-                            "get-intrinsic": "^1.0.2"
+                            "call-bind-apply-helpers": "^1.0.0",
+                            "es-define-property": "^1.0.0",
+                            "get-intrinsic": "^1.2.4",
+                            "set-function-length": "^1.2.2"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
                           },
                           "funding": {
                             "url": "https://github.com/sponsors/ljharb"
+                          }
+                        },
+                        "node_modules/call-bind-apply-helpers": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+                          "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+                          "license": "MIT",
+                          "dependencies": {
+                            "es-errors": "^1.3.0",
+                            "function-bind": "^1.1.2"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
+                          }
+                        },
+                        "node_modules/call-bound": {
+                          "version": "1.0.3",
+                          "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+                          "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+                          "license": "MIT",
+                          "dependencies": {
+                              "call-bind-apply-helpers": "^1.0.1",
+                              "get-intrinsic": "^1.2.6"
+                            },
+                            "engines": {
+                              "node": ">= 0.4"
+                            },
+                            "funding": {
+                              "url": "https://github.com/sponsors/ljharb"
                           }
                         },
                         "node_modules/chai": {
                           "version": "3.5.0",
                           "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
                           "integrity": "sha512-eRYY0vPS2a9zt5w5Z0aCeWbrXTEyvk7u/Xf71EzNObrjSCPgMm1Nku/D/u2tiqHBX5j40wWhj54YJLtgn8g55A==",
+                          "license": "MIT",
                           "dependencies": {
                             "assertion-error": "^1.0.1",
                             "deep-eql": "^0.1.3",
@@ -800,6 +839,7 @@ output:
                           "version": "0.1.3",
                           "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
                           "integrity": "sha512-6sEotTRGBFiNcqVoeHwnfopbSpi5NbH1VWJmYCVkmxMmaVTT0bUTrNaGyBwhgP4MZL012W/mkzIn3Da+iDYweg==",
+                          "license": "MIT",
                           "dependencies": {
                             "type-detect": "0.1.1"
                           },
@@ -811,43 +851,53 @@ output:
                           "version": "0.1.1",
                           "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
                           "integrity": "sha512-5rqszGVwYgBoDkIm2oUtvkfZMQ0vk29iDMU0W2qCa3rG0vPDNczCMT4hV/bLBgLg8k8ri6+u3Zbt+S/14eMzlA==",
+                          "license": "MIT",
                           "engines": {
                             "node": "*"
                           }
                         },
                         "node_modules/deep-equal": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-                          "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+                          "version": "1.1.2",
+                          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+                          "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+                          "license": "MIT",
                           "dependencies": {
-                            "is-arguments": "^1.0.4",
-                            "is-date-object": "^1.0.1",
-                            "is-regex": "^1.0.4",
-                            "object-is": "^1.0.1",
+                            "is-arguments": "^1.1.1",
+                            "is-date-object": "^1.0.5",
+                            "is-regex": "^1.1.4",
+                            "object-is": "^1.1.5",
                             "object-keys": "^1.1.1",
-                            "regexp.prototype.flags": "^1.2.0"
+                            "regexp.prototype.flags": "^1.5.1"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
                           },
                           "funding": {
                             "url": "https://github.com/sponsors/ljharb"
                           }
                         },
                         "node_modules/define-data-property": {
-                          "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.0.tgz",
-                          "integrity": "sha512-UzGwzcjyv3OtAvolTj1GoyNYzfFR+iqbGjcnBEENZVCpM4/Ng1yhGNvS3lR/xDS74Tb2wGG9WzNSNIOS9UVb2g==",
+                          "version": "1.1.4",
+                          "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+                          "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+                          "license": "MIT",
                           "dependencies": {
-                            "get-intrinsic": "^1.2.1",
-                            "gopd": "^1.0.1",
-                            "has-property-descriptors": "^1.0.0"
+                            "es-define-property": "^1.0.0",
+                            "es-errors": "^1.3.0",
+                            "gopd": "^1.0.1"
                           },
                           "engines": {
                             "node": ">= 0.4"
+                          },
+                          "funding": {
+                            "url": "https://github.com/sponsors/ljharb"
                           }
                         },
                         "node_modules/define-properties": {
                           "version": "1.2.1",
                           "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
                           "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+                          "license": "MIT",
                           "dependencies": {
                             "define-data-property": "^1.0.1",
                             "has-property-descriptors": "^1.0.0",
@@ -868,12 +918,56 @@ output:
                             "node": ">=0.4.0"
                           }
                         },
+                        "node_modules/dunder-proto": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+                          "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+                          "license": "MIT",
+                          "dependencies": {
+                            "call-bind-apply-helpers": "^1.0.1",
+                            "es-errors": "^1.3.0",
+                            "gopd": "^1.2.0"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
+                          }
+                        },
                         "node_modules/encoding": {
                           "version": "0.1.12",
                           "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
                           "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
                           "dependencies": {
                             "iconv-lite": "0.4.19"
+                          }
+                        },
+                        "node_modules/es-define-property": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+                          "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+                          "license": "MIT",
+                          "engines": {
+                            "node": ">= 0.4"
+                          }
+                        },
+                        "node_modules/es-errors": {
+                          "version": "1.3.0",
+                          "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+                          "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+                          "license": "MIT",
+                          "engines": {
+                            "node": ">= 0.4"
+                          }
+                        },
+                        "node_modules/es-object-atoms": {
+                          "version": "1.1.1",
+                          "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+                          "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+                          "license": "MIT",
+                          "dependencies": {
+                            "es-errors": "^1.3.0"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
                           }
                         },
                         "node_modules/es6-promise": {
@@ -891,6 +985,7 @@ output:
                           "version": "0.2.1",
                           "resolved": "https://registry.npmjs.org/fetch-factory/-/fetch-factory-0.2.1.tgz",
                           "integrity": "sha512-sqt1ONiKIRec2E66VSBI6+vRQSTdpsfJc7ZF3T0N3MnG1q7thE0w6B8nGhiffLoqPF7yLcKY/y4CPjldBbT2wA==",
+                          "license": "ISC",
                           "dependencies": {
                             "es6-promise": "^3.0.2",
                             "isomorphic-fetch": "^2.1.1",
@@ -938,69 +1033,40 @@ output:
                           }
                         },
                         "node_modules/function-bind": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-                          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+                          "version": "1.1.2",
+                          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+                          "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+                          "license": "MIT",
+                          "funding": {
+                            "url": "https://github.com/sponsors/ljharb"
+                          }
                         },
                         "node_modules/functions-have-names": {
                           "version": "1.2.3",
                           "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
                           "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+                          "license": "MIT",
                           "funding": {
                             "url": "https://github.com/sponsors/ljharb"
                           }
                         },
                         "node_modules/get-intrinsic": {
-                          "version": "1.2.1",
-                          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-                          "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+                          "version": "1.2.7",
+                          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+                          "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+                          "license": "MIT",
                           "dependencies": {
-                            "function-bind": "^1.1.1",
-                            "has": "^1.0.3",
-                            "has-proto": "^1.0.1",
-                            "has-symbols": "^1.0.3"
+                            "call-bind-apply-helpers": "^1.0.1",
+                            "es-define-property": "^1.0.1",
+                            "es-errors": "^1.3.0",
+                            "es-object-atoms": "^1.0.0",
+                            "function-bind": "^1.1.2",
+                            "get-proto": "^1.0.0",
+                            "gopd": "^1.2.0",
+                            "has-symbols": "^1.1.0",
+                            "hasown": "^2.0.2",
+                            "math-intrinsics": "^1.1.0"
                           },
-                          "funding": {
-                            "url": "https://github.com/sponsors/ljharb"
-                          }
-                        },
-                        "node_modules/gopd": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-                          "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-                          "dependencies": {
-                            "get-intrinsic": "^1.1.3"
-                          },
-                          "funding": {
-                            "url": "https://github.com/sponsors/ljharb"
-                          }
-                        },
-                        "node_modules/has": {
-                          "version": "1.0.3",
-                          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-                          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-                          "dependencies": {
-                            "function-bind": "^1.1.1"
-                          },
-                          "engines": {
-                            "node": ">= 0.4.0"
-                          }
-                        },
-                        "node_modules/has-property-descriptors": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-                          "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
-                          "dependencies": {
-                            "get-intrinsic": "^1.1.1"
-                          },
-                          "funding": {
-                            "url": "https://github.com/sponsors/ljharb"
-                          }
-                        },
-                        "node_modules/has-proto": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-                          "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
                           "engines": {
                             "node": ">= 0.4"
                           },
@@ -1008,10 +1074,48 @@ output:
                             "url": "https://github.com/sponsors/ljharb"
                           }
                         },
+                        "node_modules/get-proto": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+                          "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+                          "license": "MIT",
+                          "dependencies": {
+                            "dunder-proto": "^1.0.1",
+                            "es-object-atoms": "^1.0.0"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
+                          }
+                        },
+                        "node_modules/gopd": {
+                          "version": "1.2.0",
+                          "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+                          "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+                          "license": "MIT",
+                          "engines": {
+                            "node": ">= 0.4"
+                          },
+                          "funding": {
+                            "url": "https://github.com/sponsors/ljharb"
+                          }
+                        },
+                        "node_modules/has-property-descriptors": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+                          "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+                          "license": "MIT",
+                          "dependencies": {
+                            "es-define-property": "^1.0.0"
+                          },
+                          "funding": {
+                            "url": "https://github.com/sponsors/ljharb"
+                          }
+                        },
                         "node_modules/has-symbols": {
-                          "version": "1.0.3",
-                          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-                          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+                          "version": "1.1.0",
+                          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+                          "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+                          "license": "MIT",
                           "engines": {
                             "node": ">= 0.4"
                           },
@@ -1020,17 +1124,30 @@ output:
                           }
                         },
                         "node_modules/has-tostringtag": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-                          "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+                          "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+                          "license": "MIT",
                           "dependencies": {
-                            "has-symbols": "^1.0.2"
+                            "has-symbols": "^1.0.3"
                           },
                           "engines": {
                             "node": ">= 0.4"
                           },
                           "funding": {
                             "url": "https://github.com/sponsors/ljharb"
+                          }
+                        },
+                        "node_modules/hasown": {
+                          "version": "2.0.2",
+                          "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+                          "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+                          "license": "MIT",
+                          "dependencies": {
+                            "function-bind": "^1.1.2"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
                           }
                         },
                         "node_modules/iconv-lite": {
@@ -1042,12 +1159,13 @@ output:
                           }
                         },
                         "node_modules/is-arguments": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-                          "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+                          "version": "1.2.0",
+                          "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+                          "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+                          "license": "MIT",
                           "dependencies": {
-                            "call-bind": "^1.0.2",
-                            "has-tostringtag": "^1.0.0"
+                            "call-bound": "^1.0.2",
+                            "has-tostringtag": "^1.0.2"
                           },
                           "engines": {
                             "node": ">= 0.4"
@@ -1057,11 +1175,13 @@ output:
                           }
                         },
                         "node_modules/is-date-object": {
-                          "version": "1.0.5",
-                          "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-                          "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+                          "version": "1.1.0",
+                          "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+                          "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+                          "license": "MIT",
                           "dependencies": {
-                            "has-tostringtag": "^1.0.0"
+                            "call-bound": "^1.0.2",
+                            "has-tostringtag": "^1.0.2"
                           },
                           "engines": {
                             "node": ">= 0.4"
@@ -1071,12 +1191,15 @@ output:
                           }
                         },
                         "node_modules/is-regex": {
-                          "version": "1.1.4",
-                          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-                          "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+                          "version": "1.2.1",
+                          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+                          "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+                          "license": "MIT",
                           "dependencies": {
-                            "call-bind": "^1.0.2",
-                            "has-tostringtag": "^1.0.0"
+                            "call-bound": "^1.0.2",
+                            "gopd": "^1.2.0",
+                            "has-tostringtag": "^1.0.2",
+                            "hasown": "^2.0.2"
                           },
                           "engines": {
                             "node": ">= 0.4"
@@ -1107,6 +1230,15 @@ output:
                           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
                           "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
                         },
+                        "node_modules/math-intrinsics": {
+                          "version": "1.1.0",
+                          "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+                          "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+                          "license": "MIT",
+                          "engines": {
+                            "node": ">= 0.4"
+                          }
+                        },
                         "node_modules/mime-db": {
                           "version": "1.52.0",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -1130,6 +1262,7 @@ output:
                           "version": "1.2.8",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
                           "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+                          "license": "MIT",
                           "funding": {
                             "url": "https://github.com/sponsors/ljharb"
                           }
@@ -1138,6 +1271,7 @@ output:
                           "version": "0.5.6",
                           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
                           "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+                          "license": "MIT",
                           "dependencies": {
                             "minimist": "^1.2.6"
                           },
@@ -1148,7 +1282,8 @@ output:
                         "node_modules/ms": {
                           "version": "2.0.0",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+                          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+                          "license": "MIT"
                         },
                         "node_modules/nock": {
                           "version": "2.18.2",
@@ -1157,6 +1292,7 @@ output:
                           "engines": [
                             "node >= 0.10.0"
                           ],
+                          "license": "MIT",
                           "dependencies": {
                             "chai": ">=1.9.2 <4.0.0",
                             "debug": "^1.0.4",
@@ -1173,7 +1309,8 @@ output:
                           "engines": [
                             "node",
                             "rhino"
-                          ]
+                          ],
+                          "license": "MIT"
                         },
                         "node_modules/node-fetch": {
                           "version": "1.7.3",
@@ -1185,12 +1322,13 @@ output:
                           }
                         },
                         "node_modules/object-is": {
-                          "version": "1.1.5",
-                          "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-                          "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+                          "version": "1.1.6",
+                          "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+                          "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+                          "license": "MIT",
                           "dependencies": {
-                            "call-bind": "^1.0.2",
-                            "define-properties": "^1.1.3"
+                            "call-bind": "^1.0.7",
+                            "define-properties": "^1.2.1"
                           },
                           "engines": {
                             "node": ">= 0.4"
@@ -1203,6 +1341,7 @@ output:
                           "version": "1.1.1",
                           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
                           "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+                          "license": "MIT",
                           "engines": {
                             "node": ">= 0.4"
                           }
@@ -1213,12 +1352,14 @@ output:
                           "integrity": "sha512-GOc8Eoa3MWbN905b5l2PNNt1Pf+I/CF6uAPt3IGT+v9WExDE7WPT/kDfLe7vYXtG11KbTnBhTNfcoq9+umDrSw==",
                           "engines": [
                             "node >= 0.8.1"
-                          ]
+                          ],
+                          "license": "MIT"
                         },
                         "node_modules/query-string": {
                           "version": "2.4.2",
                           "resolved": "https://registry.npmjs.org/query-string/-/query-string-2.4.2.tgz",
                           "integrity": "sha512-Y+OMYUuY7HxznI6WBN822fi/FMvnCTiuqd6KNcidPColOmMWPoV1RGYyyzObve1T/dD1i0ZgCCbO8ytu0ZUrkA==",
+                          "license": "MIT",
                           "dependencies": {
                             "strict-uri-encode": "^1.0.0"
                           },
@@ -1227,13 +1368,17 @@ output:
                           }
                         },
                         "node_modules/regexp.prototype.flags": {
-                          "version": "1.5.1",
-                          "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
-                          "integrity": "sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==",
+                          "version": "1.5.4",
+                          "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+                          "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+                          "license": "MIT",
                           "dependencies": {
-                            "call-bind": "^1.0.2",
-                            "define-properties": "^1.2.0",
-                            "set-function-name": "^2.0.0"
+                            "call-bind": "^1.0.8",
+                            "define-properties": "^1.2.1",
+                            "es-errors": "^1.3.0",
+                            "get-proto": "^1.0.1",
+                            "gopd": "^1.2.0",
+                            "set-function-name": "^2.0.2"
                           },
                           "engines": {
                             "node": ">= 0.4"
@@ -1242,14 +1387,33 @@ output:
                             "url": "https://github.com/sponsors/ljharb"
                           }
                         },
-                        "node_modules/set-function-name": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
-                          "integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
+                        "node_modules/set-function-length": {
+                          "version": "1.2.2",
+                          "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+                          "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+                          "license": "MIT",
                           "dependencies": {
-                            "define-data-property": "^1.0.1",
+                            "define-data-property": "^1.1.4",
+                            "es-errors": "^1.3.0",
+                            "function-bind": "^1.1.2",
+                            "get-intrinsic": "^1.2.4",
+                            "gopd": "^1.0.1",
+                            "has-property-descriptors": "^1.0.2"
+                          },
+                          "engines": {
+                            "node": ">= 0.4"
+                          }
+                        },
+                        "node_modules/set-function-name": {
+                          "version": "2.0.2",
+                          "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+                          "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+                          "license": "MIT",
+                          "dependencies": {
+                            "define-data-property": "^1.1.4",
+                            "es-errors": "^1.3.0",
                             "functions-have-names": "^1.2.3",
-                            "has-property-descriptors": "^1.0.0"
+                            "has-property-descriptors": "^1.0.2"
                           },
                           "engines": {
                             "node": ">= 0.4"
@@ -1259,6 +1423,7 @@ output:
                           "version": "1.1.0",
                           "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
                           "integrity": "sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==",
+                          "license": "MIT",
                           "engines": {
                             "node": ">=0.10.0"
                           }
@@ -1267,6 +1432,7 @@ output:
                           "version": "1.0.0",
                           "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
                           "integrity": "sha512-f9Uv6ezcpvCQjJU0Zqbg+65qdcszv3qUQsZfjdRbWiZ7AMenrX1u0lNk9EoWWX6e1F+NULyg27mtdeZ5WhpljA==",
+                          "license": "MIT",
                           "engines": {
                             "node": "*"
                           }
@@ -1306,12 +1472,32 @@ output:
                           }
                         },
                         "call-bind": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-                          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+                          "version": "1.0.8",
+                          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+                          "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
                           "requires": {
-                            "function-bind": "^1.1.1",
-                            "get-intrinsic": "^1.0.2"
+                            "call-bind-apply-helpers": "^1.0.0",
+                            "es-define-property": "^1.0.0",
+                            "get-intrinsic": "^1.2.4",
+                            "set-function-length": "^1.2.2"
+                          }
+                        },
+                        "call-bind-apply-helpers": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+                          "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+                          "requires": {
+                            "es-errors": "^1.3.0",
+                            "function-bind": "^1.1.2"
+                          }
+                        },
+                        "call-bound": {
+                          "version": "1.0.3",
+                          "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+                          "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+                          "requires": {
+                            "call-bind-apply-helpers": "^1.0.1",
+                            "get-intrinsic": "^1.2.6"
                           }
                         },
                         "chai": {
@@ -1356,26 +1542,26 @@ output:
                           }
                         },
                         "deep-equal": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-                          "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+                          "version": "1.1.2",
+                          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+                          "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
                           "requires": {
-                            "is-arguments": "^1.0.4",
-                            "is-date-object": "^1.0.1",
-                            "is-regex": "^1.0.4",
-                            "object-is": "^1.0.1",
+                            "is-arguments": "^1.1.1",
+                            "is-date-object": "^1.0.5",
+                            "is-regex": "^1.1.4",
+                            "object-is": "^1.1.5",
                             "object-keys": "^1.1.1",
-                            "regexp.prototype.flags": "^1.2.0"
+                            "regexp.prototype.flags": "^1.5.1"
                           }
                         },
                         "define-data-property": {
-                          "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.0.tgz",
-                          "integrity": "sha512-UzGwzcjyv3OtAvolTj1GoyNYzfFR+iqbGjcnBEENZVCpM4/Ng1yhGNvS3lR/xDS74Tb2wGG9WzNSNIOS9UVb2g==",
+                          "version": "1.1.4",
+                          "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+                          "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
                           "requires": {
-                            "get-intrinsic": "^1.2.1",
-                            "gopd": "^1.0.1",
-                            "has-property-descriptors": "^1.0.0"
+                            "es-define-property": "^1.0.0",
+                            "es-errors": "^1.3.0",
+                            "gopd": "^1.0.1"
                           }
                         },
                         "define-properties": {
@@ -1393,12 +1579,40 @@ output:
                           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
                           "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
                         },
+                        "dunder-proto": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+                          "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+                          "requires": {
+                            "call-bind-apply-helpers": "^1.0.1",
+                            "es-errors": "^1.3.0",
+                            "gopd": "^1.2.0"
+                          }
+                        },
                         "encoding": {
                           "version": "0.1.12",
                           "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
                           "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
                           "requires": {
                             "iconv-lite": "0.4.19"
+                          }
+                        },
+                         "es-define-property": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+                          "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+                        },
+                        "es-errors": {
+                          "version": "1.3.0",
+                          "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+                          "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+                        },
+                        "es-object-atoms": {
+                          "version": "1.1.1",
+                          "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+                          "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+                          "requires": {
+                            "es-errors": "^1.3.0"
                           }
                         },
                         "es6-promise": {
@@ -1448,9 +1662,9 @@ output:
                           }
                         },
                         "function-bind": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-                          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+                          "version": "1.1.2",
+                          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+                          "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
                         },
                         "functions-have-names": {
                           "version": "1.2.3",
@@ -1458,56 +1672,63 @@ output:
                           "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
                         },
                         "get-intrinsic": {
-                          "version": "1.2.1",
-                          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-                          "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+                          "version": "1.2.7",
+                          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+                          "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
                           "requires": {
-                            "function-bind": "^1.1.1",
-                            "has": "^1.0.3",
-                            "has-proto": "^1.0.1",
-                            "has-symbols": "^1.0.3"
+                             "call-bind-apply-helpers": "^1.0.1",
+                            "es-define-property": "^1.0.1",
+                            "es-errors": "^1.3.0",
+                            "es-object-atoms": "^1.0.0",
+                            "function-bind": "^1.1.2",
+                            "get-proto": "^1.0.0",
+                            "gopd": "^1.2.0",
+                            "has-symbols": "^1.1.0",
+                            "hasown": "^2.0.2",
+                            "math-intrinsics": "^1.1.0"
+                          }
+                        },
+                        "get-proto": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+                          "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+                          "requires": {
+                            "dunder-proto": "^1.0.1",
+                            "es-object-atoms": "^1.0.0"
                           }
                         },
                         "gopd": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-                          "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-                          "requires": {
-                            "get-intrinsic": "^1.1.3"
-                          }
-                        },
-                        "has": {
-                          "version": "1.0.3",
-                          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-                          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-                          "requires": {
-                            "function-bind": "^1.1.1"
-                          }
+                          "version": "1.2.0",
+                          "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+                          "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
                         },
                         "has-property-descriptors": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-                          "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+                          "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
                           "requires": {
-                            "get-intrinsic": "^1.1.1"
+                            "es-define-property": "^1.0.0"
                           }
                         },
-                        "has-proto": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-                          "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg=="
-                        },
                         "has-symbols": {
-                          "version": "1.0.3",
-                          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-                          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+                          "version": "1.1.0",
+                          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+                          "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
                         },
                         "has-tostringtag": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-                          "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+                          "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
                           "requires": {
-                            "has-symbols": "^1.0.2"
+                            "has-symbols": "^1.0.3"
+                          }
+                        },
+                        "hasown": {
+                          "version": "2.0.2",
+                          "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+                          "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+                          "requires": {
+                            "function-bind": "^1.1.2"
                           }
                         },
                         "iconv-lite": {
@@ -1516,29 +1737,32 @@ output:
                           "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
                         },
                         "is-arguments": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-                          "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+                          "version": "1.2.0",
+                          "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+                          "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
                           "requires": {
-                            "call-bind": "^1.0.2",
-                            "has-tostringtag": "^1.0.0"
+                            "call-bound": "^1.0.2",
+                            "has-tostringtag": "^1.0.2"
                           }
                         },
                         "is-date-object": {
-                          "version": "1.0.5",
-                          "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-                          "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+                          "version": "1.1.0",
+                          "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+                          "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
                           "requires": {
-                            "has-tostringtag": "^1.0.0"
+                            "call-bound": "^1.0.2",
+                            "has-tostringtag": "^1.0.2"
                           }
                         },
                         "is-regex": {
-                          "version": "1.1.4",
-                          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-                          "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+                          "version": "1.2.1",
+                          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+                          "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
                           "requires": {
-                            "call-bind": "^1.0.2",
-                            "has-tostringtag": "^1.0.0"
+                            "call-bound": "^1.0.2",
+                            "gopd": "^1.2.0",
+                            "has-tostringtag": "^1.0.2",
+                            "hasown": "^2.0.2"
                           }
                         },
                         "is-stream": {
@@ -1559,6 +1783,11 @@ output:
                           "version": "4.17.15",
                           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
                           "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+                        },
+                        "math-intrinsics": {
+                          "version": "1.1.0",
+                          "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+                          "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
                         },
                         "mime-db": {
                           "version": "1.52.0",
@@ -1621,12 +1850,12 @@ output:
                           }
                         },
                         "object-is": {
-                          "version": "1.1.5",
-                          "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-                          "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+                          "version": "1.1.6",
+                          "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+                          "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
                           "requires": {
-                            "call-bind": "^1.0.2",
-                            "define-properties": "^1.1.3"
+                            "call-bind": "^1.0.7",
+                            "define-properties": "^1.2.1"
                           }
                         },
                         "object-keys": {
@@ -1648,23 +1877,40 @@ output:
                           }
                         },
                         "regexp.prototype.flags": {
-                          "version": "1.5.1",
-                          "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
-                          "integrity": "sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==",
+                          "version": "1.5.4",
+                          "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+                          "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
                           "requires": {
-                            "call-bind": "^1.0.2",
-                            "define-properties": "^1.2.0",
-                            "set-function-name": "^2.0.0"
+                            "call-bind": "^1.0.8",
+                            "define-properties": "^1.2.1",
+                            "es-errors": "^1.3.0",
+                            "get-proto": "^1.0.1",
+                            "gopd": "^1.2.0",
+                            "set-function-name": "^2.0.2"
+                          }
+                        },
+                        "set-function-length": {
+                          "version": "1.2.2",
+                          "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+                          "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+                          "requires": {
+                            "define-data-property": "^1.1.4",
+                            "es-errors": "^1.3.0",
+                            "function-bind": "^1.1.2",
+                            "get-intrinsic": "^1.2.4",
+                            "gopd": "^1.0.1",
+                            "has-property-descriptors": "^1.0.2"
                           }
                         },
                         "set-function-name": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
-                          "integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
+                          "version": "2.0.2",
+                          "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+                          "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
                           "requires": {
-                            "define-data-property": "^1.0.1",
+                            "define-data-property": "^1.1.4",
+                            "es-errors": "^1.3.0",
                             "functions-have-names": "^1.2.3",
-                            "has-property-descriptors": "^1.0.0"
+                            "has-property-descriptors": "^1.0.2"
                           }
                         },
                         "strict-uri-encode": {
@@ -1876,7 +2122,8 @@ output:
                         "node_modules/lodash": {
                           "version": "4.17.21",
                           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-                          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+                          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+                          "license": "MIT"
                         },
                         "node_modules/mime-db": {
                           "version": "1.52.0",
@@ -2178,6 +2425,7 @@ output:
                           "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
                           "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
                           "dev": true,
+                          "license": "MIT",
                           "engines": {
                             "node": ">= 0.6"
                           }


### PR DESCRIPTION
Smoke test logs updated after corepack is removed from npm update.

These file changes will fix the smoke test failures on [this PR](https://github.com/dependabot/dependabot-core/pull/11299)