### PR TITLE
Fixes smoke tests for Dependabot GEM release

### DIFF
--- a/tests/smoke-nuget-sdk-implicit-deps.yaml
+++ b/tests/smoke-nuget-sdk-implicit-deps.yaml
@@ -95,8 +95,7 @@ output:
                       </PropertyGroup>
 
                       <ItemGroup>
-                        <PackageReference Include="Mongo2Go" Version="3.1.3" />
-                        <PackageReference Include="System.Text.Json" Version="5.0.2" />
+                        <PackageReference Include="Mongo2Go" Version="4.0.0" />
                       </ItemGroup>
 
                     </Project>

--- a/tests/smoke-nuget-transitive-pinning.yaml
+++ b/tests/smoke-nuget-transitive-pinning.yaml
@@ -92,7 +92,7 @@ output:
                         <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
                       </PropertyGroup>
                       <ItemGroup>
-                        <PackageVersion Include="Mongo2Go" Version="3.1.3" />
+                        <PackageVersion Include="Mongo2Go" Version="4.0.0" />
                         <PackageVersion Include="System.Text.Json" Version="5.0.2" />
                       </ItemGroup>
                     </Project>


### PR DESCRIPTION
We are noticing some smoke test fails on latest gem release CI pipeline, This PR fixes the smoke tests so that CI pipeline can pass on for :dependabot: GEM release

https://github.com/dependabot/dependabot-core/actions/runs/13055910157/job/36430658539?pr=11443
https://github.com/dependabot/dependabot-core/actions/runs/13055910157/job/36430657083?pr=11443