### PR TITLE
Update Smoke Tests to Reflect Default Behavior After Feature Flag Removal

### DIFF
--- a/tests/smoke-npm-pnpm.yaml
+++ b/tests/smoke-npm-pnpm.yaml
@@ -485,16 +485,16 @@ output:
                           fastq: 1.15.0
                         dev: true
 
-                      /acorn-jsx@5.3.2(acorn@8.8.2):
+                      /acorn-jsx@5.3.2(acorn@8.11.3):
                         resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
                         peerDependencies:
                           acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
                         dependencies:
-                          acorn: 8.8.2
+                          acorn: 8.11.3
                         dev: true
 
-                      /acorn@8.8.2:
-                        resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
+                      /acorn@8.11.3:
+                        resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
                         engines: {node: '>=0.4.0'}
                         hasBin: true
                         dev: true
@@ -600,14 +600,14 @@ output:
                         engines: {node: '>=10'}
                         dev: true
 
-                      /eslint-plugin-yml@1.7.0(eslint@8.39.0):
+                      /eslint-plugin-yml@1.7.0(eslint@8.57.0):
                         resolution: {integrity: sha512-qq61FQJk+qIgWl0R06bec7UQQEIBrUH22jS+MroTbFUKu+3/iVlGRpZd8mjpOAm/+H/WEDFwy4x/+kKgVGbsWw==}
                         engines: {node: ^14.17.0 || >=16.0.0}
                         peerDependencies:
                           eslint: '>=6.0.0'
                         dependencies:
                           debug: 4.3.4
-                          eslint: 8.39.0
+                          eslint: 8.57.0
                           lodash: 4.17.21
                           natural-compare: 1.4.0
                           yaml-eslint-parser: 1.2.2
@@ -615,75 +615,73 @@ output:
                           - supports-color
                         dev: true
 
-                      /eslint-scope@7.2.0:
-                        resolution: {integrity: sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==}
+                      /eslint-scope@7.2.2:
+                        resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
                         engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
                         dependencies:
                           esrecurse: 4.3.0
                           estraverse: 5.3.0
                         dev: true
 
-                      /eslint-visitor-keys@3.4.0:
-                        resolution: {integrity: sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==}
+                      /eslint-visitor-keys@3.4.3:
+                        resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
                         engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
                         dev: true
 
-                      /eslint@8.39.0:
-                        resolution: {integrity: sha512-mwiok6cy7KTW7rBpo05k6+p4YVZByLNjAZ/ACB9DRCu4YDRwjXI01tWHp6KAUWelsBetTxKK/2sHB0vdS8Z2Og==}
+                      /eslint@8.57.0:
+                        resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
                         engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
                         hasBin: true
                         dependencies:
-                          '@eslint-community/eslint-utils': 4.4.0(eslint@8.39.0)
-                          '@eslint-community/regexpp': 4.5.0
-                          '@eslint/eslintrc': 2.0.2
-                          '@eslint/js': 8.39.0
-                          '@humanwhocodes/config-array': 0.11.8
+                          '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+                          '@eslint-community/regexpp': 4.10.0
+                          '@eslint/eslintrc': 2.1.4
+                          '@eslint/js': 8.57.0
+                          '@humanwhocodes/config-array': 0.11.14
                           '@humanwhocodes/module-importer': 1.0.1
                           '@nodelib/fs.walk': 1.2.8
+                          '@ungap/structured-clone': 1.2.0
                           ajv: 6.12.6
                           chalk: 4.1.2
                           cross-spawn: 7.0.3
                           debug: 4.3.4
                           doctrine: 3.0.0
                           escape-string-regexp: 4.0.0
-                          eslint-scope: 7.2.0
-                          eslint-visitor-keys: 3.4.0
-                          espree: 9.5.1
+                          eslint-scope: 7.2.2
+                          eslint-visitor-keys: 3.4.3
+                          espree: 9.6.1
                           esquery: 1.5.0
                           esutils: 2.0.3
                           fast-deep-equal: 3.1.3
                           file-entry-cache: 6.0.1
                           find-up: 5.0.0
                           glob-parent: 6.0.2
-                          globals: 13.20.0
-                          grapheme-splitter: 1.0.4
-                          ignore: 5.2.4
-                          import-fresh: 3.3.0
+                          globals: 13.24.0
+                          graphemer: 1.4.0
+                          ignore: 5.3.1
                           imurmurhash: 0.1.4
                           is-glob: 4.0.3
                           is-path-inside: 3.0.3
-                          js-sdsl: 4.4.0
                           js-yaml: 4.1.0
                           json-stable-stringify-without-jsonify: 1.0.1
                           levn: 0.4.1
                           lodash.merge: 4.6.2
                           minimatch: 3.1.2
                           natural-compare: 1.4.0
-                          optionator: 0.9.1
+                          optionator: 0.9.3
                           strip-ansi: 6.0.1
-                          strip-json-comments: 3.1.1
                           text-table: 0.2.0
                         transitivePeerDependencies:
                           - supports-color
                         dev: true
 
-                      /espree@9.5.1:
-                        resolution: {integrity: sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==}
+                      /espree@9.6.1:
+                        resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
                         engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
                         dependencies:
-                          acorn: 8.8.2
-                          acorn-jsx: 5.3.2(acorn@8.8.2)
-                          eslint-visitor-keys: 3.4.0
+                          acorn: 8.11.3
+                          acorn-jsx: 5.3.2(acorn@8.11.3)
+                          eslint-visitor-keys: 3.4.3
                         dev: true
 
                       /esquery@1.5.0:
@@ -722,8 +720,8 @@ output:
                         resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
                         dev: true
 
-                      /fastq@1.15.0:
-                        resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
+                      /fastq@1.17.1:
+                        resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
                         dependencies:
                           reusify: 1.0.4
                         dev: true
@@ -732,7 +730,7 @@ output:
                         resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
                         engines: {node: ^10.12.0 || >=12.0.0}
                         dependencies:
-                          flat-cache: 3.0.4
+                          flat-cache: 3.2.0
                         dev: true
 
                       /find-up@5.0.0:
@@ -743,16 +741,17 @@ output:
                           path-exists: 4.0.0
                         dev: true
 
-                      /flat-cache@3.0.4:
-                        resolution: {integrity: sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==}
+                      /flat-cache@3.2.0:
+                        resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
                         engines: {node: ^10.12.0 || >=12.0.0}
                         dependencies:
-                          flatted: 3.2.7
+                          flatted: 3.3.1
+                          keyv: 4.5.4
                           rimraf: 3.0.2
                         dev: true
 
-                      /flatted@3.2.7:
-                        resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
+                      /flatted@3.3.1:
+                        resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
                         dev: true
 
                       /fs.realpath@1.0.0:
@@ -777,15 +776,11 @@ output:
                           path-is-absolute: 1.0.1
                         dev: true
 
-                      /globals@13.20.0:
-                        resolution: {integrity: sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==}
+                      /globals@13.24.0:
+                        resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
                         engines: {node: '>=8'}
                         dependencies:
                           type-fest: 0.20.2
-                        dev: true
-
-                      /grapheme-splitter@1.0.4:
-                        resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
                         dev: true
 
                       /graphemer@1.4.0:
@@ -1069,7 +1064,7 @@ output:
                         resolution: {integrity: sha512-pEwzfsKbTrB8G3xc/sN7aw1v6A6c/pKxLAkjclnAyo5g5qOh6eL9WGu0o3cSDQZKrTNk4KL4lQSwZW+nBkANEg==}
                         engines: {node: ^14.17.0 || >=16.0.0}
                         dependencies:
-                          eslint-visitor-keys: 3.4.0
+                          eslint-visitor-keys: 3.4.3
                           lodash: 4.17.21
                           yaml: 2.4.1
                         dev: true

--- a/tests/smoke-npm-pnpm.yaml
+++ b/tests/smoke-npm-pnpm.yaml
@@ -14,7 +14,11 @@ input:
             repo: dependabot/smoke-tests
             directory: /pnpm/
             commit: a2579c0ace294be0332276ea32db3da71fa253cc
+        credentials-metadata:
+            - host: github.com
+              type: git_source
     credentials:
+        - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN
           type: git_source
           username: x-access-token

--- a/tests/smoke-npm-pnpm.yaml
+++ b/tests/smoke-npm-pnpm.yaml
@@ -14,11 +14,7 @@ input:
             repo: dependabot/smoke-tests
             directory: /pnpm/
             commit: a2579c0ace294be0332276ea32db3da71fa253cc
-        credentials-metadata:
-            - host: github.com
-              type: git_source
     credentials:
-        - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN
           type: git_source
           username: x-access-token
@@ -403,34 +399,39 @@ output:
                     devDependencies:
                       eslint-plugin-yml:
                         specifier: 1.7.0
-                        version: 1.7.0(eslint@8.39.0)
+                        version: 1.7.0(eslint@8.57.0)
 
                     packages:
 
-                      /@eslint-community/eslint-utils@4.4.0(eslint@8.39.0):
+                      /@aashutoshrathi/word-wrap@1.2.6:
+                        resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
+                        engines: {node: '>=0.10.0'}
+                        dev: true
+
+                      /@eslint-community/eslint-utils@4.4.0(eslint@8.57.0):
                         resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
                         engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
                         peerDependencies:
                           eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
                         dependencies:
-                          eslint: 8.39.0
+                          eslint: 8.57.0
                           eslint-visitor-keys: 3.4.3
                         dev: true
 
-                      /@eslint-community/regexpp@4.5.0:
-                        resolution: {integrity: sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==}
+                      /@eslint-community/regexpp@4.10.0:
+                        resolution: {integrity: sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==}
                         engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
                         dev: true
 
-                      /@eslint/eslintrc@2.0.2:
-                        resolution: {integrity: sha512-3W4f5tDUra+pA+FzgugqL2pRimUTDJWKr7BINqOpkZrC0uYI0NIc0/JFgBROCU07HR6GieA5m3/rsPIhDmCXTQ==}
+                      /@eslint/eslintrc@2.1.4:
+                        resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
                         engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
                         dependencies:
                           ajv: 6.12.6
                           debug: 4.3.4
-                          espree: 9.5.1
-                          globals: 13.20.0
-                          ignore: 5.2.4
+                          espree: 9.6.1
+                          globals: 13.24.0
+                          ignore: 5.3.1
                           import-fresh: 3.3.0
                           js-yaml: 4.1.0
                           minimatch: 3.1.2
@@ -439,16 +440,16 @@ output:
                           - supports-color
                         dev: true
 
-                      /@eslint/js@8.39.0:
-                        resolution: {integrity: sha512-kf9RB0Fg7NZfap83B3QOqOGg9QmD9yBudqQXzzOtn3i4y7ZUXe5ONeW34Gwi+TxhH4mvj72R1Zc300KUMa9Bng==}
+                      /@eslint/js@8.57.0:
+                        resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
                         engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
                         dev: true
 
-                      /@humanwhocodes/config-array@0.11.8:
-                        resolution: {integrity: sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==}
+                      /@humanwhocodes/config-array@0.11.14:
+                        resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
                         engines: {node: '>=10.10.0'}
                         dependencies:
-                          '@humanwhocodes/object-schema': 1.2.1
+                          '@humanwhocodes/object-schema': 2.0.2
                           debug: 4.3.4
                           minimatch: 3.1.2
                         transitivePeerDependencies:
@@ -460,8 +461,8 @@ output:
                         engines: {node: '>=12.22'}
                         dev: true
 
-                      /@humanwhocodes/object-schema@1.2.1:
-                        resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
+                      /@humanwhocodes/object-schema@2.0.2:
+                        resolution: {integrity: sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==}
                         dev: true
 
                       /@nodelib/fs.scandir@2.1.5:
@@ -482,7 +483,11 @@ output:
                         engines: {node: '>= 8'}
                         dependencies:
                           '@nodelib/fs.scandir': 2.1.5
-                          fastq: 1.15.0
+                          fastq: 1.17.1
+                        dev: true
+
+                      /@ungap/structured-clone@1.2.0:
+                        resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
                         dev: true
 
                       /acorn-jsx@5.3.2(acorn@8.11.3):

--- a/tests/smoke-npm-pnpm.yaml
+++ b/tests/smoke-npm-pnpm.yaml
@@ -414,7 +414,7 @@ output:
                           eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
                         dependencies:
                           eslint: 8.39.0
-                          eslint-visitor-keys: 3.4.0
+                          eslint-visitor-keys: 3.4.3
                         dev: true
 
                       /@eslint-community/regexpp@4.5.0:
@@ -788,13 +788,17 @@ output:
                         resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
                         dev: true
 
+                      /graphemer@1.4.0:
+                        resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+                        dev: true
+
                       /has-flag@4.0.0:
                         resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
                         engines: {node: '>=8'}
                         dev: true
 
-                      /ignore@5.2.4:
-                        resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
+                      /ignore@5.3.1:
+                        resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
                         engines: {node: '>= 4'}
                         dev: true
 
@@ -843,15 +847,15 @@ output:
                         resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
                         dev: true
 
-                      /js-sdsl@4.4.0:
-                        resolution: {integrity: sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==}
-                        dev: true
-
                       /js-yaml@4.1.0:
                         resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
                         hasBin: true
                         dependencies:
                           argparse: 2.0.1
+                        dev: true
+
+                      /json-buffer@3.0.1:
+                        resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
                         dev: true
 
                       /json-schema-traverse@0.4.1:
@@ -860,6 +864,12 @@ output:
 
                       /json-stable-stringify-without-jsonify@1.0.1:
                         resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+                        dev: true
+
+                      /keyv@4.5.4:
+                        resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+                        dependencies:
+                          json-buffer: 3.0.1
                         dev: true
 
                       /levn@0.4.1:
@@ -905,16 +915,16 @@ output:
                           wrappy: 1.0.2
                         dev: true
 
-                      /optionator@0.9.1:
-                        resolution: {integrity: sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==}
+                      /optionator@0.9.3:
+                        resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
                         engines: {node: '>= 0.8.0'}
                         dependencies:
+                          '@aashutoshrathi/word-wrap': 1.2.6
                           deep-is: 0.1.4
                           fast-levenshtein: 2.0.6
                           levn: 0.4.1
                           prelude-ls: 1.2.1
                           type-check: 0.4.0
-                          word-wrap: 1.2.3
                         dev: true
 
                       /p-limit@3.1.0:
@@ -958,8 +968,8 @@ output:
                         engines: {node: '>= 0.8.0'}
                         dev: true
 
-                      /punycode@2.3.0:
-                        resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
+                      /punycode@2.3.1:
+                        resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
                         engines: {node: '>=6'}
                         dev: true
 
@@ -1040,7 +1050,7 @@ output:
                       /uri-js@4.4.1:
                         resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
                         dependencies:
-                          punycode: 2.3.0
+                          punycode: 2.3.1
                         dev: true
 
                       /which@2.0.2:
@@ -1049,11 +1059,6 @@ output:
                         hasBin: true
                         dependencies:
                           isexe: 2.0.0
-                        dev: true
-
-                      /word-wrap@1.2.3:
-                        resolution: {integrity: sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==}
-                        engines: {node: '>=0.10.0'}
                         dev: true
 
                       /wrappy@1.0.2:
@@ -1066,12 +1071,13 @@ output:
                         dependencies:
                           eslint-visitor-keys: 3.4.0
                           lodash: 4.17.21
-                          yaml: 2.2.2
+                          yaml: 2.4.1
                         dev: true
 
-                      /yaml@2.2.2:
-                        resolution: {integrity: sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==}
+                      /yaml@2.4.1:
+                        resolution: {integrity: sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==}
                         engines: {node: '>= 14'}
+                        hasBin: true
                         dev: true
 
                       /yocto-queue@0.1.0:


### PR DESCRIPTION
### Summary of Changes  
This PR updates the smoke tests to align with the behavior after the removal of the `enable_fix_for_pnpm_no_change_error` feature flag.  

Although the feature flag had been enabled for the past two weeks, the smoke tests were still running without it. Now that the feature flag has been removed, the previously gated logic is the default behavior, and the smoke tests are now executing this code for the first time. As a result, adjustments were required to adapt the smoke tests to the new expected outputs.  

Related PRs: 
- https://github.com/dependabot/dependabot-core/pull/11592
- https://github.com/github/dependabot-api/pull/6267

### Why This Change?  
- The `enable_fix_for_pnpm_no_change_error` feature flag was removed from **dependabot-core** and **dependabot-api**, making its logic the new default.  
- Smoke tests were not previously running with this flag enabled, meaning they are now interacting with this code for the first time.  
- Updates were needed to ensure that the test expectations reflect the new behavior.  

### Key Updates  
- **Modified test expectations to match the now-default behavior that was previously behind the feature flag.**  
- **Verified that all test cases align with the latest Dependabot behavior without requiring feature flag conditionals.**  

### Validation & Testing  
- Smoke tests now pass with the updated expectations.  
- Confirmed that the changes align with the behavior enforced by the recent feature flag removal.  
- No unintended test failures or discrepancies in recorded outputs.  