### PR TITLE
Pin version of the rand to 0.8.5

### DIFF
--- a/tests/smoke-cargo-group-multidir.yaml
+++ b/tests/smoke-cargo-group-multidir.yaml
@@ -26,7 +26,7 @@ input:
               source: ../smoke-tests/tests/smoke-cargo-group-multidir.yaml
               version-requirement: '>0.3.0'
             - dependency-name: rand
-              source: tests/smoke-cargo-version-multidir.yaml
+              source: ../smoke-tests/tests/smoke-cargo-group-multidir.yaml
               version-requirement: '>0.8.5'
         security-advisories:
             - dependency-name: time

--- a/tests/smoke-cargo-group-multidir.yaml
+++ b/tests/smoke-cargo-group-multidir.yaml
@@ -25,6 +25,9 @@ input:
             - dependency-name: time
               source: ../smoke-tests/tests/smoke-cargo-group-multidir.yaml
               version-requirement: '>0.3.0'
+            - dependency-name: rand
+              source: tests/smoke-cargo-version-multidir.yaml
+              version-requirement: '>0.8.5'
         security-advisories:
             - dependency-name: time
               affected-versions:

--- a/tests/smoke-cargo-version-multidir.yaml
+++ b/tests/smoke-cargo-version-multidir.yaml
@@ -22,6 +22,9 @@ input:
             - dependency-name: time
               source: tests/smoke-cargo-version-multidir.yaml
               version-requirement: '>0.3.30'
+            - dependency-name: rand
+              source: tests/smoke-cargo-version-multidir.yaml
+              version-requirement: '>0.8.5'
         source:
             provider: github
             repo: dependabot/smoke-tests


### PR DESCRIPTION
Our cargo tests started failing when [rand 9.0.0 was released](https://github.com/rust-random/rand/releases/tag/0.9.0). This PR attempts to address this failure by making sure that we do not attempt to update rand to versions higher than the excepted one.