### PR TITLE
Fix NPM Smoke Tests After `get-intrinsic` Dependency Update

### DIFF
--- a/tests/smoke-npm-group-rules.yaml
+++ b/tests/smoke-npm-group-rules.yaml
@@ -25,9 +25,6 @@ input:
             - dependency-name: lodash
               source: tests/smoke-npm-group-rules.yaml
               version-requirement: '>4.17.21'
-            - dependency-name: get-intrinsic
-              source: tests/smoke-npm-group-rules.yaml
-              version-requirement: '>1.3.0'
         source:
             provider: github
             repo: dependabot/smoke-tests
@@ -575,7 +572,8 @@ output:
                         "node_modules/get-intrinsic": {
                           "version": "1.3.0",
                           "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-                          "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",                          "license": "MIT",
+                          "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+                          "license": "MIT",
                           "dependencies": {
                             "call-bind-apply-helpers": "^1.0.2",
                             "es-define-property": "^1.0.1",
@@ -1200,11 +1198,11 @@ output:
                           "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
                           "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
                         },
-                        "get-intrinsic": { 
+                        "get-intrinsic": {
                           "version": "1.3.0",
                           "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-                          "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",                          "license": "MIT",
-                          "dependencies": {
+                          "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+                          "requires": {
                             "call-bind-apply-helpers": "^1.0.2",
                             "es-define-property": "^1.0.1",
                             "es-errors": "^1.3.0",
@@ -1215,6 +1213,7 @@ output:
                             "has-symbols": "^1.1.0",
                             "hasown": "^2.0.2",
                             "math-intrinsics": "^1.1.0"
+                          }
                         },
                         "get-proto": {
                           "version": "1.0.1",

--- a/tests/smoke-npm-group-semver.yaml
+++ b/tests/smoke-npm-group-semver.yaml
@@ -14,9 +14,7 @@ input:
             grouped-updates-prototype: true
             record-ecosystem-versions: true
         ignore-conditions:
-             - dependency-name: get-intrinsic
-               source: tests/smoke-npm-group-semver.yaml
-               version-requirement: '>1.3.0'
+            - dependency-name: none
         source:
             provider: github
             repo: dependabot/smoke-tests
@@ -521,10 +519,11 @@ output:
                             "url": "https://github.com/sponsors/ljharb"
                           }
                         },
-                        "node_modules/get-intrinsic": { 
+                        "node_modules/get-intrinsic": {
                           "version": "1.3.0",
                           "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-                          "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",                          "license": "MIT",
+                          "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+                          "license": "MIT",
                           "dependencies": {
                             "call-bind-apply-helpers": "^1.0.2",
                             "es-define-property": "^1.0.1",

--- a/tests/smoke-npm.yaml
+++ b/tests/smoke-npm.yaml
@@ -18,9 +18,6 @@ input:
             - dependency-name: lodash
               source: tests/smoke-npm.yaml
               version-requirement: '>4.17.21'
-            - dependency-name: get-intrinsic
-              source: tests/smoke-npm.yaml
-              version-requirement: '>1.3.0'
         source:
             provider: github
             repo: dependabot/smoke-tests
@@ -1053,10 +1050,11 @@ output:
                             "url": "https://github.com/sponsors/ljharb"
                           }
                         },
-                        "node_modules/get-intrinsic": { 
+                        "node_modules/get-intrinsic": {
                           "version": "1.3.0",
                           "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-                          "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",                          "license": "MIT",
+                          "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+                          "license": "MIT",
                           "dependencies": {
                             "call-bind-apply-helpers": "^1.0.2",
                             "es-define-property": "^1.0.1",
@@ -1673,11 +1671,11 @@ output:
                           "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
                           "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
                         },
-                        "get-intrinsic": { 
+                        "get-intrinsic": {
                           "version": "1.3.0",
                           "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-                          "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",                          "license": "MIT",
-                          "dependencies": {
+                          "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+                          "requires": {
                             "call-bind-apply-helpers": "^1.0.2",
                             "es-define-property": "^1.0.1",
                             "es-errors": "^1.3.0",
@@ -1688,6 +1686,7 @@ output:
                             "has-symbols": "^1.1.0",
                             "hasown": "^2.0.2",
                             "math-intrinsics": "^1.1.0"
+                          }
                         },
                         "get-proto": {
                           "version": "1.0.1",


### PR DESCRIPTION
This PR updates the NPM smoke tests to reflect the recent update of the `get-intrinsic` package from version **1.2.7** to **1.3.0**. The dependency changes affected the expected test output, requiring adjustments to maintain test accuracy. No functional changes were made—only test updates to align with the new dependency structure.