### PR TITLE
Bumping get-intrinsic package

### DIFF
--- a/tests/smoke-npm-group-rules.yaml
+++ b/tests/smoke-npm-group-rules.yaml
@@ -570,17 +570,16 @@ output:
                           }
                         },
                         "node_modules/get-intrinsic": {
-                          "version": "1.2.7",
-                          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
-                          "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
-                          "license": "MIT",
+                          "version": "1.3.0",
+                          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+                          "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",                          "license": "MIT",
                           "dependencies": {
-                            "call-bind-apply-helpers": "^1.0.1",
+                            "call-bind-apply-helpers": "^1.0.2",
                             "es-define-property": "^1.0.1",
                             "es-errors": "^1.3.0",
-                            "es-object-atoms": "^1.0.0",
+                            "es-object-atoms": "^1.1.1",
                             "function-bind": "^1.1.2",
-                            "get-proto": "^1.0.0",
+                            "get-proto": "^1.0.1",
                             "gopd": "^1.2.0",
                             "has-symbols": "^1.1.0",
                             "hasown": "^2.0.2",
@@ -1198,22 +1197,21 @@ output:
                           "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
                           "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
                         },
-                        "get-intrinsic": {
-                          "version": "1.2.7",
-                          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
-                          "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
-                          "requires": {
-                            "call-bind-apply-helpers": "^1.0.1",
+                        "get-intrinsic": { 
+                          "version": "1.3.0",
+                          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+                          "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",                          "license": "MIT",
+                          "dependencies": {
+                            "call-bind-apply-helpers": "^1.0.2",
                             "es-define-property": "^1.0.1",
                             "es-errors": "^1.3.0",
-                            "es-object-atoms": "^1.0.0",
+                            "es-object-atoms": "^1.1.1",
                             "function-bind": "^1.1.2",
-                            "get-proto": "^1.0.0",
+                            "get-proto": "^1.0.1",
                             "gopd": "^1.2.0",
                             "has-symbols": "^1.1.0",
                             "hasown": "^2.0.2",
                             "math-intrinsics": "^1.1.0"
-                          }
                         },
                         "get-proto": {
                           "version": "1.0.1",

--- a/tests/smoke-npm-group-rules.yaml
+++ b/tests/smoke-npm-group-rules.yaml
@@ -25,6 +25,9 @@ input:
             - dependency-name: lodash
               source: tests/smoke-npm-group-rules.yaml
               version-requirement: '>4.17.21'
+            - dependency-name: get-intrinsic
+              source: tests/smoke-npm-group-rules.yaml
+              version-requirement: '>1.3.0'
         source:
             provider: github
             repo: dependabot/smoke-tests

--- a/tests/smoke-npm-group-semver.yaml
+++ b/tests/smoke-npm-group-semver.yaml
@@ -14,7 +14,9 @@ input:
             grouped-updates-prototype: true
             record-ecosystem-versions: true
         ignore-conditions:
-            - dependency-name: none
+             - dependency-name: get-intrinsic
+               source: tests/smoke-npm-group-semver.yaml
+               version-requirement: '>1.3.0'
         source:
             provider: github
             repo: dependabot/smoke-tests

--- a/tests/smoke-npm-group-semver.yaml
+++ b/tests/smoke-npm-group-semver.yaml
@@ -519,18 +519,17 @@ output:
                             "url": "https://github.com/sponsors/ljharb"
                           }
                         },
-                        "node_modules/get-intrinsic": {
-                          "version": "1.2.7",
-                          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
-                          "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
-                          "license": "MIT",
+                        "node_modules/get-intrinsic": { 
+                          "version": "1.3.0",
+                          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+                          "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",                          "license": "MIT",
                           "dependencies": {
-                            "call-bind-apply-helpers": "^1.0.1",
+                            "call-bind-apply-helpers": "^1.0.2",
                             "es-define-property": "^1.0.1",
                             "es-errors": "^1.3.0",
-                            "es-object-atoms": "^1.0.0",
+                            "es-object-atoms": "^1.1.1",
                             "function-bind": "^1.1.2",
-                            "get-proto": "^1.0.0",
+                            "get-proto": "^1.0.1",
                             "gopd": "^1.2.0",
                             "has-symbols": "^1.1.0",
                             "hasown": "^2.0.2",

--- a/tests/smoke-npm.yaml
+++ b/tests/smoke-npm.yaml
@@ -18,6 +18,9 @@ input:
             - dependency-name: lodash
               source: tests/smoke-npm.yaml
               version-requirement: '>4.17.21'
+            - dependency-name: get-intrinsic
+              source: tests/smoke-npm.yaml
+              version-requirement: '>1.3.0'
         source:
             provider: github
             repo: dependabot/smoke-tests

--- a/tests/smoke-npm.yaml
+++ b/tests/smoke-npm.yaml
@@ -1050,18 +1050,17 @@ output:
                             "url": "https://github.com/sponsors/ljharb"
                           }
                         },
-                        "node_modules/get-intrinsic": {
-                          "version": "1.2.7",
-                          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
-                          "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
-                          "license": "MIT",
+                        "node_modules/get-intrinsic": { 
+                          "version": "1.3.0",
+                          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+                          "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",                          "license": "MIT",
                           "dependencies": {
-                            "call-bind-apply-helpers": "^1.0.1",
+                            "call-bind-apply-helpers": "^1.0.2",
                             "es-define-property": "^1.0.1",
                             "es-errors": "^1.3.0",
-                            "es-object-atoms": "^1.0.0",
+                            "es-object-atoms": "^1.1.1",
                             "function-bind": "^1.1.2",
-                            "get-proto": "^1.0.0",
+                            "get-proto": "^1.0.1",
                             "gopd": "^1.2.0",
                             "has-symbols": "^1.1.0",
                             "hasown": "^2.0.2",
@@ -1671,22 +1670,21 @@ output:
                           "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
                           "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
                         },
-                        "get-intrinsic": {
-                          "version": "1.2.7",
-                          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
-                          "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
-                          "requires": {
-                            "call-bind-apply-helpers": "^1.0.1",
+                        "get-intrinsic": { 
+                          "version": "1.3.0",
+                          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+                          "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",                          "license": "MIT",
+                          "dependencies": {
+                            "call-bind-apply-helpers": "^1.0.2",
                             "es-define-property": "^1.0.1",
                             "es-errors": "^1.3.0",
-                            "es-object-atoms": "^1.0.0",
+                            "es-object-atoms": "^1.1.1",
                             "function-bind": "^1.1.2",
-                            "get-proto": "^1.0.0",
+                            "get-proto": "^1.0.1",
                             "gopd": "^1.2.0",
                             "has-symbols": "^1.1.0",
                             "hasown": "^2.0.2",
                             "math-intrinsics": "^1.1.0"
-                          }
                         },
                         "get-proto": {
                           "version": "1.0.1",


### PR DESCRIPTION
Our npm tests started failing when [get-intrinsic 1.3.0 was released](hhttps://www.npmjs.com/package/get-intrinsic/v/1.3.0). This PR attempts to address this failure by making sure that we do not attempt to update `get-intrinsic` to versions higher than `1.3.0`.