### PR TITLE
Pin  to `rand-core` to `0.6.4`

### DIFF
--- a/tests/smoke-cargo-group-multidir.yaml
+++ b/tests/smoke-cargo-group-multidir.yaml
@@ -28,6 +28,9 @@ input:
             - dependency-name: rand
               source: ../smoke-tests/tests/smoke-cargo-group-multidir.yaml
               version-requirement: '>0.8.5'
+            - dependency-name: rand-core
+              source: ../smoke-tests/tests/smoke-cargo-group-multidir.yaml
+              version-requirement: '>0.6.4'
         security-advisories:
             - dependency-name: time
               affected-versions:

--- a/tests/smoke-cargo-version-multidir.yaml
+++ b/tests/smoke-cargo-version-multidir.yaml
@@ -25,6 +25,9 @@ input:
             - dependency-name: rand
               source: tests/smoke-cargo-version-multidir.yaml
               version-requirement: '>0.8.5'
+            - dependency-name: rand-core
+              source: tests/smoke-cargo-version-multidir.yaml
+              version-requirement: '>0.6.4'
         source:
             provider: github
             repo: dependabot/smoke-tests


### PR DESCRIPTION
Our cargo tests started failing when [rand 9.0.0 was released](https://github.com/rust-random/rand/releases/tag/0.9.0). This PR attempts to address this failure by making sure that we do not attempt to update `rand-core` to versions higher than the excepted one.

Thanks to @eggplants https://github.com/dependabot/smoke-tests/pull/265#issuecomment-2676219896 for suggesting this change