### PR TITLE
fix: Outdated bundler dependency

### DIFF
--- a/tests/smoke-bundler-security-subdep.yaml
+++ b/tests/smoke-bundler-security-subdep.yaml
@@ -311,7 +311,7 @@ output:
                         sass-listen (4.0.0)
                           rb-fsevent (~> 0.9, >= 0.9.4)
                           rb-inotify (~> 0.9, >= 0.9.7)
-                        strscan (3.1.0)
+                        strscan (3.1.2)
                         terminal-table (3.0.2)
                           unicode-display_width (>= 1.1.1, < 3)
                         unicode-display_width (2.5.0)


### PR DESCRIPTION
A smoke test for bundler is failing in https://github.com/dependabot/dependabot-core/pull/11681 because strscan is out of date.  This bumps strscan which at least fixes the issue locally, but would need to be merged after the corresponding PR is merged to pass.