### PR TITLE
Updating the smoke test results to exclude changes related to support files

### DIFF
--- a/tests/smoke-devcontainers.yaml
+++ b/tests/smoke-devcontainers.yaml
@@ -62,6 +62,7 @@ output:
             dependency_files:
                 - /devcontainers/.devcontainer.json
                 - /devcontainers/.devcontainer/devcontainer.json
+                - /devcontainers/.devcontainer/devcontainer-lock.json
     - type: create_pull_request
       expect:
         data:

--- a/tests/smoke-devcontainers.yaml
+++ b/tests/smoke-devcontainers.yaml
@@ -150,7 +150,7 @@ output:
                   directory: /devcontainers
                   name: .devcontainer/devcontainer-lock.json
                   operation: update
-                  support_file: true
+                  support_file: false
                   type: file
             pr-title: Bump ghcr.io/codspace/versioning/foo from 1.1.0 to 2.11.1 in /devcontainers
             pr-body: |
@@ -222,7 +222,7 @@ output:
                   directory: /devcontainers
                   name: .devcontainer/devcontainer-lock.json
                   operation: update
-                  support_file: true
+                  support_file: false
                   type: file
             pr-title: Bump ghcr.io/codspace/versioning/baz from 1.0.0 to 2.0.0 in /devcontainers
             pr-body: |

--- a/tests/smoke-submodules.yaml
+++ b/tests/smoke-submodules.yaml
@@ -34,6 +34,7 @@ output:
                   version: 83e962f7f9fa27eaf62ecfb5da86f1eb0355b785
             dependency_files:
                 - /.gitmodules
+                - /dependabot-test
     - type: create_pull_request
       expect:
         data:

--- a/tests/smoke-submodules.yaml
+++ b/tests/smoke-submodules.yaml
@@ -68,7 +68,7 @@ output:
                   directory: /
                   name: dependabot-test
                   operation: update
-                  support_file: true
+                  support_file: false
                   type: submodule
             pr-title: Bump dependabot-test from `83e962f` to `5fc0a8c`
             pr-body: |


### PR DESCRIPTION
Updating the smoke test results to exclude changes related to support files. Related PR: https://github.com/dependabot/dependabot-core/pull/11888
