### PR TITLE
Don't rely on Deivid's copy of the smoke tests

### DIFF
--- a/tests/smoke-bundler-security-subdep.yaml
+++ b/tests/smoke-bundler-security-subdep.yaml
@@ -35,7 +35,7 @@ input:
         security-updates-only: true
         source:
             provider: github
-            repo: deivid-rodriguez/smoke-tests
+            repo: dependabot/smoke-tests
             directory: /bundler/security-subdep
             commit: d68acbc60726e366810a710835479ae8165cd14a
 output:


### PR DESCRIPTION
I noticed this while looking at example security update... This should be pointing at our repo, not Deivid's personal copy of the repo.

Otherwise when he eventually deletes his copy, it'll break our tests.