### PR TITLE
update smoke tests to include transitive packages with no active runtime components

### DIFF
--- a/tests/smoke-nuget-compatible-version.yaml
+++ b/tests/smoke-nuget-compatible-version.yaml
@@ -33,6 +33,9 @@ output:
                       requirement: 6.0.0
                       source: null
                   version: 6.0.0
+                - name: Microsoft.CSharp
+                  requirements: []
+                  version: 4.5.0
                 - name: Microsoft.IdentityModel.JsonWebTokens
                   requirements: []
                   version: 6.10.0
@@ -51,6 +54,9 @@ output:
                 - name: System.IdentityModel.Tokens.Jwt
                   requirements: []
                   version: 6.10.0
+                - name: System.Security.Cryptography.Cng
+                  requirements: []
+                  version: 4.5.0
             dependency_files:
                 - /nuget/compatible-version/project/project.csproj
     - type: create_pull_request

--- a/tests/smoke-nuget-lockfile.yaml
+++ b/tests/smoke-nuget-lockfile.yaml
@@ -25,6 +25,12 @@ output:
       expect:
         data:
             dependencies:
+                - name: Microsoft.CSharp
+                  requirements: []
+                  version: 4.3.0
+                - name: Microsoft.Win32.Primitives
+                  requirements: []
+                  version: 4.3.0
                 - name: Newtonsoft.Json
                   requirements: []
                   version: 10.0.1
@@ -36,6 +42,240 @@ output:
                       requirement: 1.0.1
                       source: null
                   version: 1.0.1
+                - name: runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.native.System
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.native.System.IO.Compression
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.native.System.Net.Http
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.native.System.Security.Cryptography.Apple
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.native.System.Security.Cryptography.OpenSsl
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl
+                  requirements: []
+                  version: 4.3.0
+                - name: System.AppContext
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Buffers
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Collections
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Collections.Concurrent
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Collections.NonGeneric
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Collections.Specialized
+                  requirements: []
+                  version: 4.3.0
+                - name: System.ComponentModel
+                  requirements: []
+                  version: 4.3.0
+                - name: System.ComponentModel.Primitives
+                  requirements: []
+                  version: 4.3.0
+                - name: System.ComponentModel.TypeConverter
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Console
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Diagnostics.Debug
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Diagnostics.DiagnosticSource
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Diagnostics.Tools
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Diagnostics.Tracing
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Dynamic.Runtime
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Globalization
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Globalization.Calendars
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Globalization.Extensions
+                  requirements: []
+                  version: 4.3.0
+                - name: System.IO
+                  requirements: []
+                  version: 4.3.0
+                - name: System.IO.Compression
+                  requirements: []
+                  version: 4.3.0
+                - name: System.IO.Compression.ZipFile
+                  requirements: []
+                  version: 4.3.0
+                - name: System.IO.FileSystem
+                  requirements: []
+                  version: 4.3.0
+                - name: System.IO.FileSystem.Primitives
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Linq
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Linq.Expressions
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Net.Http
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Net.Primitives
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Net.Sockets
+                  requirements: []
+                  version: 4.3.0
+                - name: System.ObjectModel
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Reflection
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Reflection.Emit
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Reflection.Emit.ILGeneration
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Reflection.Emit.Lightweight
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Reflection.Extensions
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Reflection.Primitives
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Reflection.TypeExtensions
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Resources.ResourceManager
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Runtime
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Runtime.Extensions
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Runtime.Handles
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Runtime.InteropServices
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Runtime.InteropServices.RuntimeInformation
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Runtime.Numerics
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Runtime.Serialization.Formatters
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Runtime.Serialization.Primitives
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Security.Cryptography.Algorithms
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Security.Cryptography.Cng
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Security.Cryptography.Csp
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Security.Cryptography.Encoding
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Security.Cryptography.OpenSsl
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Security.Cryptography.Primitives
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Security.Cryptography.X509Certificates
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Text.Encoding
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Text.Encoding.Extensions
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Text.RegularExpressions
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Threading
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Threading.Tasks
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Threading.Tasks.Extensions
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Threading.Timer
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Xml.ReaderWriter
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Xml.XDocument
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Xml.XmlDocument
+                  requirements: []
+                  version: 4.3.0
             dependency_files:
                 - /nuget/lock-file/packages.lock.json
                 - /nuget/lock-file/project.csproj

--- a/tests/smoke-nuget-peer-dependencies.yaml
+++ b/tests/smoke-nuget-peer-dependencies.yaml
@@ -68,6 +68,15 @@ output:
                 - name: Microsoft.Extensions.Primitives
                   requirements: []
                   version: 2.2.0
+                - name: System.ComponentModel.Annotations
+                  requirements: []
+                  version: 4.5.0
+                - name: System.Memory
+                  requirements: []
+                  version: 4.5.1
+                - name: System.Runtime.CompilerServices.Unsafe
+                  requirements: []
+                  version: 4.5.1
             dependency_files:
                 - /nuget/peer-dependencies/project.csproj
     - type: create_pull_request

--- a/tests/smoke-nuget-potential-downgrade.yaml
+++ b/tests/smoke-nuget-potential-downgrade.yaml
@@ -56,6 +56,9 @@ output:
                 - name: Microsoft.CodeCoverage
                   requirements: []
                   version: 17.6.3
+                - name: Microsoft.CSharp
+                  requirements: []
+                  version: 4.7.0
                 - name: Microsoft.IO.Redist
                   requirements: []
                   version: 6.0.0
@@ -80,6 +83,9 @@ output:
                   requirements: []
                   version: 4.2.8
                 - name: Microsoft.TestPlatform.ObjectModel
+                  requirements: []
+                  version: 17.6.3
+                - name: Microsoft.TestPlatform.TestHost
                   requirements: []
                   version: 17.6.3
                 - name: Microsoft.VisualStudio.ComponentModelHost
@@ -164,6 +170,12 @@ output:
                 - name: Microsoft.VisualStudio.Validation
                   requirements: []
                   version: 17.6.11
+                - name: Microsoft.Win32.Primitives
+                  requirements: []
+                  version: 4.3.0
+                - name: Microsoft.Win32.Registry
+                  requirements: []
+                  version: 5.0.0
                 - name: Microsoft.Win32.SystemEvents
                   requirements: []
                   version: 7.0.0
@@ -184,13 +196,79 @@ output:
                 - name: NuGet.Frameworks
                   requirements: []
                   version: 6.5.0
+                - name: runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.native.System
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.native.System.IO.Compression
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.native.System.Net.Http
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.native.System.Security.Cryptography.Apple
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.native.System.Security.Cryptography.OpenSsl
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl
+                  requirements: []
+                  version: 4.3.0
+                - name: runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl
+                  requirements: []
+                  version: 4.3.0
                 - name: StreamJsonRpc
                   requirements: []
                   version: 2.15.29
+                - name: System.AppContext
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Buffers
+                  requirements: []
+                  version: 4.5.1
                 - name: System.CodeDom
                   requirements: []
                   version: 5.0.0
+                - name: System.Collections
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Collections.Concurrent
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Collections.Immutable
+                  requirements: []
+                  version: 7.0.0
                 - name: System.ComponentModel.Composition
+                  requirements: []
+                  version: 7.0.0
+                - name: System.Composition
                   requirements: []
                   version: 7.0.0
                 - name: System.Composition.AttributedModel
@@ -211,33 +289,213 @@ output:
                 - name: System.Configuration.ConfigurationManager
                   requirements: []
                   version: 7.0.0
+                - name: System.Console
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Diagnostics.Debug
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Diagnostics.DiagnosticSource
+                  requirements: []
+                  version: 7.0.1
                 - name: System.Diagnostics.EventLog
                   requirements: []
                   version: 7.0.0
                 - name: System.Diagnostics.PerformanceCounter
                   requirements: []
                   version: 7.0.0
+                - name: System.Diagnostics.Tools
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Diagnostics.Tracing
+                  requirements: []
+                  version: 4.3.0
                 - name: System.Drawing.Common
                   requirements: []
                   version: 7.0.0
+                - name: System.Globalization
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Globalization.Calendars
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Globalization.Extensions
+                  requirements: []
+                  version: 4.3.0
+                - name: System.IO
+                  requirements: []
+                  version: 4.3.0
+                - name: System.IO.Compression
+                  requirements: []
+                  version: 4.3.0
+                - name: System.IO.Compression.ZipFile
+                  requirements: []
+                  version: 4.3.0
+                - name: System.IO.FileSystem
+                  requirements: []
+                  version: 4.3.0
+                - name: System.IO.FileSystem.AccessControl
+                  requirements: []
+                  version: 5.0.0
+                - name: System.IO.FileSystem.Primitives
+                  requirements: []
+                  version: 4.3.0
                 - name: System.IO.Pipelines
                   requirements: []
                   version: 7.0.0
+                - name: System.Linq
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Linq.Expressions
+                  requirements: []
+                  version: 4.3.0
                 - name: System.Management
                   requirements: []
                   version: 5.0.0
+                - name: System.Memory
+                  requirements: []
+                  version: 4.5.5
+                - name: System.Net.Http
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Net.Primitives
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Net.Sockets
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Numerics.Vectors
+                  requirements: []
+                  version: 4.5.0
+                - name: System.ObjectModel
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Reflection
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Reflection.Emit
+                  requirements: []
+                  version: 4.7.0
+                - name: System.Reflection.Emit.ILGeneration
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Reflection.Emit.Lightweight
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Reflection.Extensions
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Reflection.Metadata
+                  requirements: []
+                  version: 7.0.0
+                - name: System.Reflection.Primitives
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Reflection.TypeExtensions
+                  requirements: []
+                  version: 4.7.0
+                - name: System.Resources.ResourceManager
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Runtime
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Runtime.CompilerServices.Unsafe
+                  requirements: []
+                  version: 6.0.0
+                - name: System.Runtime.Extensions
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Runtime.Handles
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Runtime.InteropServices
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Runtime.InteropServices.RuntimeInformation
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Runtime.Numerics
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Security.AccessControl
+                  requirements: []
+                  version: 6.0.0
+                - name: System.Security.Cryptography.Algorithms
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Security.Cryptography.Cng
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Security.Cryptography.Csp
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Security.Cryptography.Encoding
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Security.Cryptography.OpenSsl
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Security.Cryptography.Primitives
+                  requirements: []
+                  version: 4.3.0
                 - name: System.Security.Cryptography.ProtectedData
                   requirements: []
                   version: 7.0.0
+                - name: System.Security.Cryptography.X509Certificates
+                  requirements: []
+                  version: 4.3.0
                 - name: System.Security.Permissions
                   requirements: []
                   version: 7.0.0
+                - name: System.Security.Principal.Windows
+                  requirements: []
+                  version: 5.0.0
+                - name: System.Text.Encoding
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Text.Encoding.Extensions
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Text.Encodings.Web
+                  requirements: []
+                  version: 7.0.0
+                - name: System.Text.Json
+                  requirements: []
+                  version: 7.0.0
+                - name: System.Text.RegularExpressions
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Threading
+                  requirements: []
+                  version: 4.3.0
                 - name: System.Threading.AccessControl
                   requirements: []
                   version: 7.0.0
+                - name: System.Threading.Tasks
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Threading.Tasks.Dataflow
+                  requirements: []
+                  version: 7.0.0
+                - name: System.Threading.Tasks.Extensions
+                  requirements: []
+                  version: 4.5.4
+                - name: System.Threading.Timer
+                  requirements: []
+                  version: 4.3.0
+                - name: System.ValueTuple
+                  requirements: []
+                  version: 4.5.0
                 - name: System.Windows.Extensions
                   requirements: []
                   version: 7.0.0
+                - name: System.Xml.ReaderWriter
+                  requirements: []
+                  version: 4.3.0
+                - name: System.Xml.XDocument
+                  requirements: []
+                  version: 4.3.0
                 - name: Validation
                   requirements: []
                   version: 2.4.18
@@ -256,6 +514,9 @@ output:
                   requirements: []
                   version: 1.2.0
                 - name: xunit.assert
+                  requirements: []
+                  version: 2.5.0
+                - name: xunit.core
                   requirements: []
                   version: 2.5.0
                 - name: xunit.extensibility.core

--- a/tests/smoke-nuget-resolvability.yaml
+++ b/tests/smoke-nuget-resolvability.yaml
@@ -76,6 +76,12 @@ output:
                 - name: RabbitMQ.Client
                   requirements: []
                   version: 6.2.1
+                - name: System.Memory
+                  requirements: []
+                  version: 4.5.4
+                - name: System.Threading.Channels
+                  requirements: []
+                  version: 4.7.1
             dependency_files:
                 - /nuget/resolvability/A/A.csproj
                 - /nuget/resolvability/B/B.csproj

--- a/tests/smoke-nuget-version-multidir.yaml
+++ b/tests/smoke-nuget-version-multidir.yaml
@@ -76,6 +76,15 @@ output:
                       requirement: 6.1.0
                       source: null
                   version: 6.1.0
+                - name: System.ComponentModel.Annotations
+                  requirements: []
+                  version: 4.5.0
+                - name: System.Memory
+                  requirements: []
+                  version: 4.5.1
+                - name: System.Runtime.CompilerServices.Unsafe
+                  requirements: []
+                  version: 4.5.1
                 - name: Microsoft.Extensions.Configuration
                   requirements: []
                   version: 2.2.0
@@ -116,6 +125,15 @@ output:
                       requirement: 6.2.2
                       source: null
                   version: 6.2.2
+                - name: System.ComponentModel.Annotations
+                  requirements: []
+                  version: 4.5.0
+                - name: System.Memory
+                  requirements: []
+                  version: 4.5.1
+                - name: System.Runtime.CompilerServices.Unsafe
+                  requirements: []
+                  version: 4.5.1
             dependency_files:
                 - /nuget/multi-dir/foo/project.csproj
                 - /nuget/multi-dir/bar/project.csproj


### PR DESCRIPTION
# This PR corresponds to dependabot/dependabot-core#12219 and they must be merged simultaneously.

## This PR is expected to fail until the corresponding `dependabot-core` PR is merged.

All changes are reporting packages that weren't reported before because they are transitive dependencies with no runtime components like a `.dll` but the NuGet updater has been fixed to now report these packages.