### PR TITLE
Update README to use `regen.sh` instead of `run-all.sh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ In this case we will need to regenerate the failing test locally with `dependabo
 
 Where possible try to add additional ignore_conditions and allowed_updates so even when uncached the tests will not fail.
 
-For convenience there's a `script/run-all.sh` which will regenerate all of the tests.
+For convenience there's a `script/regen.sh` which will regenerate all of the tests.
 
 ### How to add new tests
 


### PR DESCRIPTION
`run-all.sh` was renamed to `regen.sh` in #175. This PR updates the `README.md` to reflect that change.