### PR TITLE
fix: remove irrelevant changelog refs

### DIFF
--- a/tests/smoke-composer.yaml
+++ b/tests/smoke-composer.yaml
@@ -349,7 +349,6 @@ output:
 
                 Updates `phpstan/phpstan` from 1.10.23 to 1.10.25
                 - [Release notes](https://github.com/phpstan/phpstan/releases)
-                - [Changelog](https://github.com/phpstan/phpstan/blob/1.11.x/CHANGELOG.md)
                 - [Commits](https://github.com/phpstan/phpstan/compare/1.10.23...1.10.25)
 
                 Updates `phpstan/phpstan-strict-rules` from 1.5.0 to 1.5.1

--- a/tests/smoke-npm-yarn-berry.yaml
+++ b/tests/smoke-npm-yarn-berry.yaml
@@ -19659,7 +19659,6 @@ output:
 
                 Bumps [jquery](https://github.com/jquery/jquery) from 3.5.0 to 3.6.3.
                 - [Release notes](https://github.com/jquery/jquery/releases)
-                - [Changelog](https://github.com/jquery/jquery/blob/main/changelog.md)
                 - [Commits](https://github.com/jquery/jquery/compare/3.5.0...3.6.3)
     - type: mark_as_processed
       expect:

--- a/tests/smoke-nuget-compatible-version.yaml
+++ b/tests/smoke-nuget-compatible-version.yaml
@@ -180,7 +180,6 @@ output:
 
                 Bumps [Microsoft.AspNetCore.Authentication.JwtBearer](https://github.com/dotnet/aspnetcore) from 6.0.0 to 6.0.25.
                 - [Release notes](https://github.com/dotnet/aspnetcore/releases)
-                - [Changelog](https://github.com/dotnet/aspnetcore/blob/main/docs/ReleasePlanning.md)
                 - [Commits](https://github.com/dotnet/aspnetcore/compare/v6.0.0...v6.0.25)
     - type: mark_as_processed
       expect:

--- a/tests/smoke-nuget-props-and-targets.yaml
+++ b/tests/smoke-nuget-props-and-targets.yaml
@@ -176,7 +176,6 @@ output:
 
                 Bumps [Microsoft.CodeAnalysis.Analyzers](https://github.com/dotnet/roslyn-analyzers) from 3.3.0 to 3.3.4.
                 - [Release notes](https://github.com/dotnet/roslyn-analyzers/releases)
-                - [Changelog](https://github.com/dotnet/roslyn-analyzers/blob/main/PostReleaseActivities.md)
                 - [Commits](https://github.com/dotnet/roslyn-analyzers/compare/v3.3.0...v3.3.4)
     - type: create_pull_request
       expect:

--- a/tests/smoke-nuget-resolvability.yaml
+++ b/tests/smoke-nuget-resolvability.yaml
@@ -245,12 +245,10 @@ output:
 
                 Updates `AspNetCore.HealthChecks.Rabbitmq` from 5.0.2 to 7.0.0
                 - [Release notes](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/releases)
-                - [Changelog](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/blob/master/doc/ui-changelog.md)
                 - [Commits](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/commits/preview-all-7.0.0)
 
                 Updates `Microsoft.Extensions.Diagnostics.HealthChecks` from 5.0.17 to 7.0.9
                 - [Release notes](https://github.com/dotnet/aspnetcore/releases)
-                - [Changelog](https://github.com/dotnet/aspnetcore/blob/main/docs/ReleasePlanning.md)
                 - [Commits](https://github.com/dotnet/aspnetcore/compare/v5.0.17...v7.0.9)
     - type: mark_as_processed
       expect:

--- a/tests/smoke-python-group-multidir.yaml
+++ b/tests/smoke-python-group-multidir.yaml
@@ -249,7 +249,6 @@ output:
 
                 Updates `numpy` from 1.0 to 1.3.0
                 - [Release notes](https://github.com/numpy/numpy/releases)
-                - [Changelog](https://github.com/numpy/numpy/blob/main/doc/RELEASE_WALKTHROUGH.rst)
                 - [Commits](https://github.com/numpy/numpy/compare/v1.0...v1.3.0)
             dependency-group:
                 name: pip

--- a/tests/smoke-python-pip-compile.yaml
+++ b/tests/smoke-python-pip-compile.yaml
@@ -372,7 +372,6 @@ output:
 
                 Bumps [numpy](https://github.com/numpy/numpy) from 1.23.0 to 1.24.1.
                 - [Release notes](https://github.com/numpy/numpy/releases)
-                - [Changelog](https://github.com/numpy/numpy/blob/main/doc/RELEASE_WALKTHROUGH.rst)
                 - [Commits](https://github.com/numpy/numpy/compare/v1.23.0...v1.24.1)
     - type: create_pull_request
       expect:

--- a/tests/smoke-python-pip.yaml
+++ b/tests/smoke-python-pip.yaml
@@ -238,7 +238,6 @@ output:
 
                 Bumps [numpy](https://github.com/numpy/numpy) from 1.23.0 to 2.0.2.
                 - [Release notes](https://github.com/numpy/numpy/releases)
-                - [Changelog](https://github.com/numpy/numpy/blob/main/doc/RELEASE_WALKTHROUGH.rst)
                 - [Commits](https://github.com/numpy/numpy/compare/v1.23.0...v2.0.2)
     - type: mark_as_processed
       expect:

--- a/tests/smoke-python-pipenv.yaml
+++ b/tests/smoke-python-pipenv.yaml
@@ -226,7 +226,6 @@ output:
 
                 Bumps [numpy](https://github.com/numpy/numpy) from 1.25.0 to 1.26.2.
                 - [Release notes](https://github.com/numpy/numpy/releases)
-                - [Changelog](https://github.com/numpy/numpy/blob/main/doc/RELEASE_WALKTHROUGH.rst)
                 - [Commits](https://github.com/numpy/numpy/compare/v1.25.0...v1.26.2)
     - type: mark_as_processed
       expect:

--- a/tests/smoke-python-poetry.yaml
+++ b/tests/smoke-python-poetry.yaml
@@ -229,7 +229,6 @@ output:
                 Bump toml from 0.10.0 to 0.10.2 in /poetry
 
                 Bumps [toml](https://github.com/uiri/toml) from 0.10.0 to 0.10.2.
-                - [Changelog](https://github.com/uiri/toml/blob/master/RELEASE.rst)
                 - [Commits](https://github.com/uiri/toml/compare/0.10.0...0.10.2)
     - type: create_pull_request
       expect:
@@ -712,7 +711,6 @@ output:
 
                 Bumps [numpy](https://github.com/numpy/numpy) from 1.23.0 to 2.2.6.
                 - [Release notes](https://github.com/numpy/numpy/releases)
-                - [Changelog](https://github.com/numpy/numpy/blob/main/doc/RELEASE_WALKTHROUGH.rst)
                 - [Commits](https://github.com/numpy/numpy/compare/v1.23.0...v2.2.6)
     - type: mark_as_processed
       expect:

--- a/tests/smoke-python-version-multidir.yaml
+++ b/tests/smoke-python-version-multidir.yaml
@@ -638,7 +638,6 @@ output:
 
                 Updates `numpy` from 1.0 to 1.26.2
                 - [Release notes](https://github.com/numpy/numpy/releases)
-                - [Changelog](https://github.com/numpy/numpy/blob/main/doc/RELEASE_WALKTHROUGH.rst)
                 - [Commits](https://github.com/numpy/numpy/compare/v1.0...v1.26.2)
             dependency-group:
                 name: python_pkgs


### PR DESCRIPTION
This commit is part of a bug fix in the dependabot-core repository and is required to pass the smoke tests.

See: https://github.com/dependabot/dependabot-core/pull/12338