### PR TITLE
update smoke test with release notes

### DIFF
--- a/tests/smoke-nuget-potential-downgrade.yaml
+++ b/tests/smoke-nuget-potential-downgrade.yaml
@@ -592,6 +592,23 @@ output:
             pr-body: |
                 Bumps [Microsoft.VisualStudio.Sdk.TestFramework.Xunit](https://github.com/microsoft/vssdktestfx) from 17.2.7 to 17.6.16.
                 <details>
+                <summary>Release notes</summary>
+                <p><em>Sourced from <a href="https://github.com/microsoft/vssdktestfx/releases">Microsoft.VisualStudio.Sdk.TestFramework.Xunit's releases</a>.</em></p>
+                <blockquote>
+                <h2>v17.6.16</h2>
+                <h2>What's Changed</h2>
+                <ul>
+                <li>Update Microsoft.ServiceHub.Framework to OSS version by <a href="https://github.com/AArnott"><code>@​AArnott</code></a> in <a href="https://redirect.github.com/microsoft/vssdktestfx/pull/85">microsoft/vssdktestfx#85</a></li>
+                <li>Remove MEF filtering out of MS.VS.Utilities by <a href="https://github.com/AArnott"><code>@​AArnott</code></a> in <a href="https://redirect.github.com/microsoft/vssdktestfx/pull/86">microsoft/vssdktestfx#86</a></li>
+                </ul>
+                <h2>New Contributors</h2>
+                <ul>
+                <li><a href="https://github.com/javierdlg"><code>@​javierdlg</code></a> made their first contribution in <a href="https://redirect.github.com/microsoft/vssdktestfx/pull/50">microsoft/vssdktestfx#50</a></li>
+                </ul>
+                <p><strong>Full Changelog</strong>: <a href="https://github.com/microsoft/vssdktestfx/compare/v17.2.7...v17.6.16">https://github.com/microsoft/vssdktestfx/compare/v17.2.7...v17.6.16</a></p>
+                </blockquote>
+                </details>
+                <details>
                 <summary>Commits</summary>
                 <ul>
                 <li><a href="https://github.com/microsoft/vssdktestfx/commit/fabda9e07d14ba6bb6b0f06cf3cb5aaaf8acc498"><code>fabda9e</code></a> Merge pull request <a href="https://redirect.github.com/microsoft/vssdktestfx/issues/105">#105</a> from microsoft/libtemplateUpdate</li>


### PR DESCRIPTION
Recent runs of this test (i.e., after a run of "Cache One") have been failing due to the missing "Release notes" section.