### PR TITLE
Revert "Update npm_and_yarn smoke tests after cooldown feature flag removal"

### DIFF
--- a/tests/smoke-npm-group-multidir.yaml
+++ b/tests/smoke-npm-group-multidir.yaml
@@ -134,12 +134,52 @@ output:
                         url: https://registry.npmjs.org
                   version: 1.1.0
                   directory: /npm/multi-dir/foo
+                - name: left-pad
+                  previous-requirements:
+                    - file: package.json
+                      groups:
+                        - dependencies
+                      requirement: ^1.0.0
+                      source:
+                        type: registry
+                        url: https://registry.npmjs.org
+                  previous-version: 1.0.0
+                  requirements:
+                    - file: package.json
+                      groups:
+                        - dependencies
+                      requirement: ^1.0.0
+                      source:
+                        type: registry
+                        url: https://registry.npmjs.org
+                  version: 1.3.0
+                  directory: /npm/multi-dir/foo
                 - name: '@dependabot/dummy-pkg-a'
                   previous-requirements: []
                   previous-version: 1.1.0
                   requirements: []
                   version: 2.0.0
                   directory: /npm/multi-dir/foo
+                - name: left-pad
+                  previous-requirements:
+                    - file: package.json
+                      groups:
+                        - dependencies
+                      requirement: ^1.0.0
+                      source:
+                        type: registry
+                        url: https://registry.npmjs.org
+                  previous-version: 1.0.0
+                  requirements:
+                    - file: package.json
+                      groups:
+                        - dependencies
+                      requirement: ^1.0.0
+                      source:
+                        type: registry
+                        url: https://registry.npmjs.org
+                  version: 1.3.0
+                  directory: /npm/multi-dir/bar
                 - name: '@dependabot/dummy-pkg-a'
                   previous-requirements:
                     - file: package.json
@@ -193,10 +233,11 @@ output:
                           }
                         },
                         "node_modules/left-pad": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.0.0.tgz",
-                          "integrity": "sha512-Xvly4CWfzT+7TGZRB2Qd7ub2dmJDomZCNf3BuT3XXfrNerQHtta82NNhbvToU4Qiz7IHrg21YB3UpL/6npCtmg==",
-                          "deprecated": "use String.prototype.padStart()"
+                          "version": "1.3.0",
+                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+                          "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+                          "deprecated": "use String.prototype.padStart()",
+                          "license": "WTFPL"
                         }
                       }
                     }
@@ -230,10 +271,11 @@ output:
                           "license": "MIT"
                         },
                         "node_modules/left-pad": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.0.0.tgz",
-                          "integrity": "sha512-Xvly4CWfzT+7TGZRB2Qd7ub2dmJDomZCNf3BuT3XXfrNerQHtta82NNhbvToU4Qiz7IHrg21YB3UpL/6npCtmg==",
-                          "deprecated": "use String.prototype.padStart()"
+                          "version": "1.3.0",
+                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+                          "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+                          "deprecated": "use String.prototype.padStart()",
+                          "license": "WTFPL"
                         }
                       }
                     }
@@ -244,26 +286,50 @@ output:
                   operation: update
                   support_file: false
                   type: file
-            pr-title: Bump the npm_and_yarn group across 2 directories with 2 updates
+            pr-title: Bump the npm_and_yarn group across 2 directories with 3 updates
             pr-body: |
-                Bumps the npm_and_yarn group with 1 update in the /npm/multi-dir/foo directory: @dependabot/dummy-pkg-b.
-                Bumps the npm_and_yarn group with 1 update in the /npm/multi-dir/bar directory: @dependabot/dummy-pkg-a.
+                Bumps the npm_and_yarn group with 2 updates in the /npm/multi-dir/foo directory: @dependabot/dummy-pkg-b and [left-pad](https://github.com/stevemao/left-pad).
+                Bumps the npm_and_yarn group with 2 updates in the /npm/multi-dir/bar directory: [left-pad](https://github.com/stevemao/left-pad) and @dependabot/dummy-pkg-a.
 
                 Updates `@dependabot/dummy-pkg-b` from 1.0.0 to 1.1.0
 
+                Updates `left-pad` from 1.0.0 to 1.3.0
+                <details>
+                <summary>Commits</summary>
+                <ul>
+                <li>See full diff in <a href="https://github.com/stevemao/left-pad/commits/v1.3.0">compare view</a></li>
+                </ul>
+                </details>
+                <br />
+
                 Updates `@dependabot/dummy-pkg-a` from 1.1.0 to 2.0.0
+
+                Updates `left-pad` from 1.0.0 to 1.3.0
+                <details>
+                <summary>Commits</summary>
+                <ul>
+                <li>See full diff in <a href="https://github.com/stevemao/left-pad/commits/v1.3.0">compare view</a></li>
+                </ul>
+                </details>
+                <br />
 
                 Updates `@dependabot/dummy-pkg-a` from 1.0.0 to 1.1.0
             commit-message: |-
-                Bump the npm_and_yarn group across 2 directories with 2 updates
+                Bump the npm_and_yarn group across 2 directories with 3 updates
 
-                Bumps the npm_and_yarn group with 1 update in the /npm/multi-dir/foo directory: @dependabot/dummy-pkg-b.
-                Bumps the npm_and_yarn group with 1 update in the /npm/multi-dir/bar directory: @dependabot/dummy-pkg-a.
+                Bumps the npm_and_yarn group with 2 updates in the /npm/multi-dir/foo directory: @dependabot/dummy-pkg-b and [left-pad](https://github.com/stevemao/left-pad).
+                Bumps the npm_and_yarn group with 2 updates in the /npm/multi-dir/bar directory: [left-pad](https://github.com/stevemao/left-pad) and @dependabot/dummy-pkg-a.
 
 
                 Updates `@dependabot/dummy-pkg-b` from 1.0.0 to 1.1.0
 
+                Updates `left-pad` from 1.0.0 to 1.3.0
+                - [Commits](https://github.com/stevemao/left-pad/commits/v1.3.0)
+
                 Updates `@dependabot/dummy-pkg-a` from 1.1.0 to 2.0.0
+
+                Updates `left-pad` from 1.0.0 to 1.3.0
+                - [Commits](https://github.com/stevemao/left-pad/commits/v1.3.0)
 
                 Updates `@dependabot/dummy-pkg-a` from 1.0.0 to 1.1.0
             dependency-group:

--- a/tests/smoke-npm-version-multidir.yaml
+++ b/tests/smoke-npm-version-multidir.yaml
@@ -111,12 +111,52 @@ output:
                         url: https://registry.npmjs.org
                   version: 1.2.0
                   directory: /npm/multi-dir/foo
+                - name: left-pad
+                  previous-requirements:
+                    - file: package.json
+                      groups:
+                        - dependencies
+                      requirement: ^1.0.0
+                      source:
+                        type: registry
+                        url: https://registry.npmjs.org
+                  previous-version: 1.0.0
+                  requirements:
+                    - file: package.json
+                      groups:
+                        - dependencies
+                      requirement: ^1.0.0
+                      source:
+                        type: registry
+                        url: https://registry.npmjs.org
+                  version: 1.3.0
+                  directory: /npm/multi-dir/foo
                 - name: '@dependabot/dummy-pkg-a'
                   previous-requirements: []
                   previous-version: 1.1.0
                   requirements: []
                   version: 2.0.0
                   directory: /npm/multi-dir/foo
+                - name: left-pad
+                  previous-requirements:
+                    - file: package.json
+                      groups:
+                        - dependencies
+                      requirement: ^1.0.0
+                      source:
+                        type: registry
+                        url: https://registry.npmjs.org
+                  previous-version: 1.0.0
+                  requirements:
+                    - file: package.json
+                      groups:
+                        - dependencies
+                      requirement: ^1.0.0
+                      source:
+                        type: registry
+                        url: https://registry.npmjs.org
+                  version: 1.3.0
+                  directory: /npm/multi-dir/bar
                 - name: '@dependabot/dummy-pkg-a'
                   previous-requirements:
                     - file: package.json
@@ -170,10 +210,11 @@ output:
                           }
                         },
                         "node_modules/left-pad": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.0.0.tgz",
-                          "integrity": "sha512-Xvly4CWfzT+7TGZRB2Qd7ub2dmJDomZCNf3BuT3XXfrNerQHtta82NNhbvToU4Qiz7IHrg21YB3UpL/6npCtmg==",
-                          "deprecated": "use String.prototype.padStart()"
+                          "version": "1.3.0",
+                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+                          "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+                          "deprecated": "use String.prototype.padStart()",
+                          "license": "WTFPL"
                         }
                       }
                     }
@@ -230,10 +271,11 @@ output:
                           "license": "MIT"
                         },
                         "node_modules/left-pad": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.0.0.tgz",
-                          "integrity": "sha512-Xvly4CWfzT+7TGZRB2Qd7ub2dmJDomZCNf3BuT3XXfrNerQHtta82NNhbvToU4Qiz7IHrg21YB3UpL/6npCtmg==",
-                          "deprecated": "use String.prototype.padStart()"
+                          "version": "1.3.0",
+                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+                          "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+                          "deprecated": "use String.prototype.padStart()",
+                          "license": "WTFPL"
                         }
                       }
                     }
@@ -244,26 +286,50 @@ output:
                   operation: update
                   support_file: false
                   type: file
-            pr-title: Bump the npm_pkgs group across 2 directories with 2 updates
+            pr-title: Bump the npm_pkgs group across 2 directories with 3 updates
             pr-body: |
-                Bumps the npm_pkgs group with 1 update in the /npm/multi-dir/foo directory: @dependabot/dummy-pkg-b.
-                Bumps the npm_pkgs group with 1 update in the /npm/multi-dir/bar directory: @dependabot/dummy-pkg-a.
+                Bumps the npm_pkgs group with 2 updates in the /npm/multi-dir/foo directory: @dependabot/dummy-pkg-b and [left-pad](https://github.com/stevemao/left-pad).
+                Bumps the npm_pkgs group with 2 updates in the /npm/multi-dir/bar directory: [left-pad](https://github.com/stevemao/left-pad) and @dependabot/dummy-pkg-a.
 
                 Updates `@dependabot/dummy-pkg-b` from 1.0.0 to 1.2.0
 
+                Updates `left-pad` from 1.0.0 to 1.3.0
+                <details>
+                <summary>Commits</summary>
+                <ul>
+                <li>See full diff in <a href="https://github.com/stevemao/left-pad/commits/v1.3.0">compare view</a></li>
+                </ul>
+                </details>
+                <br />
+
                 Updates `@dependabot/dummy-pkg-a` from 1.1.0 to 2.0.0
+
+                Updates `left-pad` from 1.0.0 to 1.3.0
+                <details>
+                <summary>Commits</summary>
+                <ul>
+                <li>See full diff in <a href="https://github.com/stevemao/left-pad/commits/v1.3.0">compare view</a></li>
+                </ul>
+                </details>
+                <br />
 
                 Updates `@dependabot/dummy-pkg-a` from 1.0.0 to 2.0.0
             commit-message: |-
-                Bump the npm_pkgs group across 2 directories with 2 updates
+                Bump the npm_pkgs group across 2 directories with 3 updates
 
-                Bumps the npm_pkgs group with 1 update in the /npm/multi-dir/foo directory: @dependabot/dummy-pkg-b.
-                Bumps the npm_pkgs group with 1 update in the /npm/multi-dir/bar directory: @dependabot/dummy-pkg-a.
+                Bumps the npm_pkgs group with 2 updates in the /npm/multi-dir/foo directory: @dependabot/dummy-pkg-b and [left-pad](https://github.com/stevemao/left-pad).
+                Bumps the npm_pkgs group with 2 updates in the /npm/multi-dir/bar directory: [left-pad](https://github.com/stevemao/left-pad) and @dependabot/dummy-pkg-a.
 
 
                 Updates `@dependabot/dummy-pkg-b` from 1.0.0 to 1.2.0
 
+                Updates `left-pad` from 1.0.0 to 1.3.0
+                - [Commits](https://github.com/stevemao/left-pad/commits/v1.3.0)
+
                 Updates `@dependabot/dummy-pkg-a` from 1.1.0 to 2.0.0
+
+                Updates `left-pad` from 1.0.0 to 1.3.0
+                - [Commits](https://github.com/stevemao/left-pad/commits/v1.3.0)
 
                 Updates `@dependabot/dummy-pkg-a` from 1.0.0 to 2.0.0
             dependency-group:


### PR DESCRIPTION
We are reverting the update because that problem was causing for deprecated version (not yanked) and when we don't have feature flag smoke tests was hitting the logic where we are ignoring deprecated version. So we are reverting smoke test back and going to fix the logic properly

Reverts dependabot/smoke-tests#304