### PR TITLE
sdk versions no longer reported by NuGet updater

### DIFF
--- a/tests/smoke-nuget-sdk-replacement-packages.yaml
+++ b/tests/smoke-nuget-sdk-replacement-packages.yaml
@@ -36,14 +36,6 @@ output:
       expect:
         data:
             dependencies:
-                - name: Microsoft.NET.Sdk
-                  requirements:
-                    - file: /nuget/sdk-replacement-packages/global.json
-                      groups:
-                        - dependencies
-                      requirement: 8.0.304
-                      source: null
-                  version: 8.0.304
                 - name: System.Text.Encodings.Web
                   requirements:
                     - file: /nuget/sdk-replacement-packages/project.csproj


### PR DESCRIPTION
Updates a smoke test to correspond to dependabot/dependabot-core#12638.