### PR TITLE
update test to reflect tool update

### DIFF
--- a/tests/smoke-composer.yaml
+++ b/tests/smoke-composer.yaml
@@ -26,9 +26,6 @@ input:
             repo: dependabot/smoke-tests
             directory: /composer
             commit: 509a98a45a6f933ffd49ca7f2c26815c693b3d76
-        credentials-metadata:
-          - host: github.com
-            type: git_source
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN
@@ -325,12 +322,12 @@ output:
                         ],
                         "aliases": [],
                         "minimum-stability": "stable",
-                        "stability-flags": [],
+                        "stability-flags": {},
                         "prefer-stable": false,
                         "prefer-lowest": false,
-                        "platform": [],
-                        "platform-dev": [],
-                        "plugin-api-version": "2.3.0"
+                        "platform": {},
+                        "platform-dev": {},
+                        "plugin-api-version": "2.6.0"
                     }
                   content_encoding: utf-8
                   deleted: false
@@ -611,12 +608,12 @@ output:
                         ],
                         "aliases": [],
                         "minimum-stability": "stable",
-                        "stability-flags": [],
+                        "stability-flags": {},
                         "prefer-stable": false,
                         "prefer-lowest": false,
-                        "platform": [],
-                        "platform-dev": [],
-                        "plugin-api-version": "2.3.0"
+                        "platform": {},
+                        "platform-dev": {},
+                        "plugin-api-version": "2.6.0"
                     }
                   content_encoding: utf-8
                   deleted: false


### PR DESCRIPTION
PR dependabot/dependabot-core#12570 updated composer from 2.7.7 to 2.8.9 and a [change](https://github.com/composer/composer/pull/12123) in composer 2.8.0 introduced a schema for the `composer.lock` file where `stability-flags`, `platform`, and `platform-dev` are now objects instead of arrays.

Swift failure is known and being tracked in dependabot/dependabot-core#12647