### PR TITLE
generate simple pr body while other refactorings are underway

### DIFF
--- a/tests/smoke-nuget-central-package-management.yaml
+++ b/tests/smoke-nuget-central-package-management.yaml
@@ -4,6 +4,7 @@ input:
         allowed-updates:
             - update-type: all
         experiments:
+            nuget_generate_simple_pr_body: true
             nuget_native_updater: true
             nuget_use_direct_discovery: true
             nuget_use_new_file_updater: true

--- a/tests/smoke-nuget-compatible-version.yaml
+++ b/tests/smoke-nuget-compatible-version.yaml
@@ -4,6 +4,7 @@ input:
         allowed-updates:
             - update-type: all
         experiments:
+            nuget_generate_simple_pr_body: true
             nuget_native_updater: true
             nuget_use_direct_discovery: true
             nuget_use_new_file_updater: true

--- a/tests/smoke-nuget-dirs-proj.yaml
+++ b/tests/smoke-nuget-dirs-proj.yaml
@@ -4,6 +4,7 @@ input:
         allowed-updates:
             - update-type: all
         experiments:
+            nuget_generate_simple_pr_body: true
             nuget_native_updater: true
             nuget_use_direct_discovery: true
             nuget_use_new_file_updater: true

--- a/tests/smoke-nuget-group-multidir.yaml
+++ b/tests/smoke-nuget-group-multidir.yaml
@@ -14,6 +14,7 @@ input:
             - NuGet.Versioning
             - NuGet.Versioning
         experiments:
+            nuget_generate_simple_pr_body: true
             nuget_native_updater: true
             nuget_use_direct_discovery: true
             nuget_use_new_file_updater: true

--- a/tests/smoke-nuget-lockfile.yaml
+++ b/tests/smoke-nuget-lockfile.yaml
@@ -4,6 +4,7 @@ input:
         allowed-updates:
             - update-type: all
         experiments:
+            nuget_generate_simple_pr_body: true
             nuget_native_updater: true
             nuget_use_direct_discovery: true
             nuget_use_new_file_updater: true

--- a/tests/smoke-nuget-peer-dependencies.yaml
+++ b/tests/smoke-nuget-peer-dependencies.yaml
@@ -4,6 +4,7 @@ input:
         allowed-updates:
             - update-type: all
         experiments:
+            nuget_generate_simple_pr_body: true
             nuget_native_updater: true
             nuget_use_direct_discovery: true
             nuget_use_new_file_updater: true

--- a/tests/smoke-nuget-potential-downgrade.yaml
+++ b/tests/smoke-nuget-potential-downgrade.yaml
@@ -6,6 +6,7 @@ input:
         dependencies:
             - Microsoft.VisualStudio.Sdk.TestFramework.Xunit
         experiments:
+            nuget_generate_simple_pr_body: true
             nuget_native_updater: true
             nuget_use_direct_discovery: true
             nuget_use_new_file_updater: true

--- a/tests/smoke-nuget-props-and-targets.yaml
+++ b/tests/smoke-nuget-props-and-targets.yaml
@@ -4,6 +4,7 @@ input:
         allowed-updates:
             - update-type: all
         experiments:
+            nuget_generate_simple_pr_body: true
             nuget_native_updater: true
             nuget_use_direct_discovery: true
             nuget_use_new_file_updater: true

--- a/tests/smoke-nuget-resolvability.yaml
+++ b/tests/smoke-nuget-resolvability.yaml
@@ -4,6 +4,7 @@ input:
         allowed-updates:
             - update-type: all
         experiments:
+            nuget_generate_simple_pr_body: true
             nuget_native_updater: true
             nuget_use_direct_discovery: true
             nuget_use_new_file_updater: true

--- a/tests/smoke-nuget-sdk-implicit-deps.yaml
+++ b/tests/smoke-nuget-sdk-implicit-deps.yaml
@@ -6,6 +6,7 @@ input:
         dependencies:
             - System.Text.Json
         experiments:
+            nuget_generate_simple_pr_body: true
             nuget_native_updater: true
             nuget_use_direct_discovery: true
             nuget_use_new_file_updater: true

--- a/tests/smoke-nuget-sdk-replacement-packages.yaml
+++ b/tests/smoke-nuget-sdk-replacement-packages.yaml
@@ -6,6 +6,7 @@ input:
         dependencies:
             - System.Text.Json
         experiments:
+            nuget_generate_simple_pr_body: true
             nuget_install_dotnet_sdks: true
             nuget_native_updater: true
             nuget_use_direct_discovery: true

--- a/tests/smoke-nuget-transitive-and-top-level-deps.yaml
+++ b/tests/smoke-nuget-transitive-and-top-level-deps.yaml
@@ -4,6 +4,7 @@ input:
         allowed-updates:
             - update-type: all
         experiments:
+            nuget_generate_simple_pr_body: true
             nuget_native_updater: true
             nuget_use_direct_discovery: true
             nuget_use_new_file_updater: true

--- a/tests/smoke-nuget-transitive-pinning.yaml
+++ b/tests/smoke-nuget-transitive-pinning.yaml
@@ -6,6 +6,7 @@ input:
         dependencies:
             - System.Text.Json
         experiments:
+            nuget_generate_simple_pr_body: true
             nuget_native_updater: true
             nuget_use_direct_discovery: true
             nuget_use_new_file_updater: true

--- a/tests/smoke-nuget-version-multidir.yaml
+++ b/tests/smoke-nuget-version-multidir.yaml
@@ -10,6 +10,7 @@ input:
                 patterns:
                     - '*'
         experiments:
+            nuget_generate_simple_pr_body: true
             nuget_native_updater: true
             nuget_use_direct_discovery: true
             nuget_use_new_file_updater: true

--- a/tests/smoke-nuget-version-property.yaml
+++ b/tests/smoke-nuget-version-property.yaml
@@ -4,6 +4,7 @@ input:
         allowed-updates:
             - update-type: all
         experiments:
+            nuget_generate_simple_pr_body: true
             nuget_native_updater: true
             nuget_use_direct_discovery: true
             nuget_use_new_file_updater: true

--- a/tests/smoke-nuget.yaml
+++ b/tests/smoke-nuget.yaml
@@ -4,6 +4,7 @@ input:
         allowed-updates:
             - update-type: all
         experiments:
+            nuget_generate_simple_pr_body: true
             nuget_native_updater: true
             nuget_use_direct_discovery: true
             nuget_use_new_file_updater: true


### PR DESCRIPTION
The NuGet updater will soon generate more details in the pull request body but while that work is happening, the smoke tests are being updated to force the simple version to avoid churn.

Once the detailed PR body work is done, the smoke tests will be updated to contain the full information.

The experiment flag used isn't registered with the dependabot service, it's purely a mechanism to force these short versions while work is ongoing.