### PR TITLE
update smoke tests for grouping fix

### DIFF
--- a/tests/smoke-nuget-peer-dependencies.yaml
+++ b/tests/smoke-nuget-peer-dependencies.yaml
@@ -205,6 +205,57 @@ output:
 
                 Bumps Microsoft.Extensions.Http from 2.2.0 to 8.0.0
                 Bumps Microsoft.Extensions.Logging from 2.2.0 to 8.0.0
+    - type: create_pull_request
+      expect:
+        data:
+            base-commit-sha: 7dbbef7b02f40ddfa7d32fc3099caf19f370bb9b
+            dependencies:
+                - name: Microsoft.Extensions.Logging
+                  previous-requirements:
+                    - file: /nuget/peer-dependencies/project.csproj
+                      groups:
+                        - dependencies
+                      requirement: 2.2.0
+                      source: null
+                  previous-version: 2.2.0
+                  requirements:
+                    - file: /nuget/peer-dependencies/project.csproj
+                      groups:
+                        - dependencies
+                      requirement: 8.0.0
+                      source:
+                        source_url: https://github.com/dotnet/runtime
+                        type: nuget_repo
+                  version: 8.0.0
+            updated-dependency-files:
+                - content: |-
+                    <Project Sdk="Microsoft.NET.Sdk">
+
+                      <PropertyGroup>
+                        <OutputType>Exe</OutputType>
+                        <TargetFramework>net6.0</TargetFramework>
+                        <ImplicitUsings>enable</ImplicitUsings>
+                        <Nullable>enable</Nullable>
+                      </PropertyGroup>
+
+                      <ItemGroup>
+                        <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
+                        <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+                      </ItemGroup>
+
+                    </Project>
+                  content_encoding: utf-8
+                  deleted: false
+                  directory: /nuget/peer-dependencies
+                  name: project.csproj
+                  operation: update
+                  support_file: false
+                  type: file
+            pr-title: Bump Microsoft.Extensions.Logging from 2.2.0 to 8.0.0
+            pr-body: |-
+                Performed the following updates:
+                - Updated Microsoft.Extensions.Logging from 2.2.0 to 8.0.0
+            commit-message: Bump Microsoft.Extensions.Logging from 2.2.0 to 8.0.0
     - type: mark_as_processed
       expect:
         data:

--- a/tests/smoke-nuget-props-and-targets.yaml
+++ b/tests/smoke-nuget-props-and-targets.yaml
@@ -72,6 +72,40 @@ output:
                         source_url: https://github.com/dotnet/roslyn-analyzers
                         type: nuget_repo
                   version: 3.3.4
+            updated-dependency-files:
+                - content: |-
+                    <!--
+                    This build configuration file will be automatically imported by MSBuild in all projects in the
+                    solution, because it's placed in the root directory.
+                    See https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2019
+                    -->
+                    <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+                      <ItemGroup>
+                        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
+                          <PrivateAssets>all</PrivateAssets>
+                          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+                        </PackageReference>
+                      </ItemGroup>
+
+                    </Project>
+                  content_encoding: utf-8
+                  deleted: false
+                  directory: /nuget/props-and-targets
+                  name: Directory.Build.targets
+                  operation: update
+                  support_file: false
+                  type: file
+            pr-title: Bump Microsoft.CodeAnalysis.Analyzers from 3.3.0 to 3.3.4
+            pr-body: |-
+                Performed the following updates:
+                - Updated Microsoft.CodeAnalysis.Analyzers from 3.3.0 to 3.3.4
+            commit-message: Bump Microsoft.CodeAnalysis.Analyzers from 3.3.0 to 3.3.4
+    - type: create_pull_request
+      expect:
+        data:
+            base-commit-sha: 7dbbef7b02f40ddfa7d32fc3099caf19f370bb9b
+            dependencies:
                 - name: NuGet.Versioning
                   previous-requirements:
                     - file: /nuget/props-and-targets/project.csproj
@@ -110,39 +144,11 @@ output:
                   operation: update
                   support_file: false
                   type: file
-                - content: |-
-                    <!--
-                    This build configuration file will be automatically imported by MSBuild in all projects in the
-                    solution, because it's placed in the root directory.
-                    See https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2019
-                    -->
-                    <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-                      <ItemGroup>
-                        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
-                          <PrivateAssets>all</PrivateAssets>
-                          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-                        </PackageReference>
-                      </ItemGroup>
-
-                    </Project>
-                  content_encoding: utf-8
-                  deleted: false
-                  directory: /nuget/props-and-targets
-                  name: Directory.Build.targets
-                  operation: update
-                  support_file: false
-                  type: file
-            pr-title: Bump Microsoft.CodeAnalysis.Analyzers and NuGet.Versioning
+            pr-title: Bump NuGet.Versioning from 6.1.0 to 6.8.0
             pr-body: |-
                 Performed the following updates:
-                - Updated Microsoft.CodeAnalysis.Analyzers from 3.3.0 to 3.3.4
                 - Updated NuGet.Versioning from 6.1.0 to 6.8.0
-            commit-message: |-
-                Bump Microsoft.CodeAnalysis.Analyzers and NuGet.Versioning
-
-                Bumps Microsoft.CodeAnalysis.Analyzers from 3.3.0 to 3.3.4
-                Bumps NuGet.Versioning from 6.1.0 to 6.8.0
+            commit-message: Bump NuGet.Versioning from 6.1.0 to 6.8.0
     - type: mark_as_processed
       expect:
         data:

--- a/tests/smoke-nuget-resolvability.yaml
+++ b/tests/smoke-nuget-resolvability.yaml
@@ -265,6 +265,35 @@ output:
                         source_url: https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks
                         type: nuget_repo
                   version: 7.0.0
+            updated-dependency-files:
+                - content: |-
+                    <Project>
+                      <!--https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management-->
+                      <PropertyGroup>
+                        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageVersion Include="AspNetCore.HealthChecks.Rabbitmq" Version="7.0.0" />
+                        <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="5.0.17" />
+                      </ItemGroup>
+                    </Project>
+                  content_encoding: utf-8
+                  deleted: false
+                  directory: /nuget/resolvability
+                  name: Directory.Packages.props
+                  operation: update
+                  support_file: false
+                  type: file
+            pr-title: Bump AspNetCore.HealthChecks.Rabbitmq from 5.0.2 to 7.0.0
+            pr-body: |-
+                Performed the following updates:
+                - Updated AspNetCore.HealthChecks.Rabbitmq from 5.0.2 to 7.0.0
+            commit-message: Bump AspNetCore.HealthChecks.Rabbitmq from 5.0.2 to 7.0.0
+    - type: create_pull_request
+      expect:
+        data:
+            base-commit-sha: 1204ab6852a4872bbb0ba4fff1343fefb39663d6
+            dependencies:
                 - name: Microsoft.Extensions.Diagnostics.HealthChecks
                   previous-requirements:
                     - file: /nuget/resolvability/B/B.csproj
@@ -290,7 +319,7 @@ output:
                         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
                       </PropertyGroup>
                       <ItemGroup>
-                        <PackageVersion Include="AspNetCore.HealthChecks.Rabbitmq" Version="7.0.0" />
+                        <PackageVersion Include="AspNetCore.HealthChecks.Rabbitmq" Version="5.0.2" />
                         <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="7.0.9" />
                       </ItemGroup>
                     </Project>
@@ -301,16 +330,11 @@ output:
                   operation: update
                   support_file: false
                   type: file
-            pr-title: Bump AspNetCore.HealthChecks.Rabbitmq and Microsoft.Extensions.Diagnostics.HealthChecks
+            pr-title: Bump Microsoft.Extensions.Diagnostics.HealthChecks from 5.0.17 to 7.0.9
             pr-body: |-
                 Performed the following updates:
-                - Updated AspNetCore.HealthChecks.Rabbitmq from 5.0.2 to 7.0.0
                 - Updated Microsoft.Extensions.Diagnostics.HealthChecks from 5.0.17 to 7.0.9
-            commit-message: |-
-                Bump AspNetCore.HealthChecks.Rabbitmq and Microsoft.Extensions.Diagnostics.HealthChecks
-
-                Bumps AspNetCore.HealthChecks.Rabbitmq from 5.0.2 to 7.0.0
-                Bumps Microsoft.Extensions.Diagnostics.HealthChecks from 5.0.17 to 7.0.9
+            commit-message: Bump Microsoft.Extensions.Diagnostics.HealthChecks from 5.0.17 to 7.0.9
     - type: mark_as_processed
       expect:
         data:


### PR DESCRIPTION
This PR is expected to fail here until dependabot/dependabot-core#12762 has been merged.

The above mentioned PR ungroups NuGet updates for separate packages.  The end result is, e.g., 2 separate PRs created, one for each dependency, instead of one PR total.