### PR TITLE
Update follow-redirects to 1.15.11 in npm smoke tests

### DIFF
--- a/tests/smoke-npm-group-rules.yaml
+++ b/tests/smoke-npm-group-rules.yaml
@@ -2029,7 +2029,7 @@ output:
                   previous-requirements: []
                   previous-version: 1.15.2
                   requirements: []
-                  version: 1.15.9
+                  version: 1.15.11
                   directory: /npm
             updated-dependency-files:
                 - content: |
@@ -2120,9 +2120,9 @@ output:
                           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
                         },
                         "node_modules/follow-redirects": {
-                          "version": "1.15.9",
-                          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-                          "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+                          "version": "1.15.11",
+                          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+                          "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
                           "funding": [
                             {
                               "type": "individual",
@@ -2281,9 +2281,9 @@ output:
                           }
                         },
                         "follow-redirects": {
-                          "version": "1.15.9",
-                          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-                          "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="
+                          "version": "1.15.11",
+                          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+                          "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="
                         },
                         "form-data": {
                           "version": "4.0.0",
@@ -2355,32 +2355,22 @@ output:
                   operation: update
                   support_file: false
                   type: file
-            pr-title: Bump follow-redirects from 1.15.2 to 1.15.9 in /npm
+            pr-title: Bump follow-redirects from 1.15.2 to 1.15.11 in /npm
             pr-body: |
-                Bumps [follow-redirects](https://github.com/follow-redirects/follow-redirects) from 1.15.2 to 1.15.9.
+                Bumps [follow-redirects](https://github.com/follow-redirects/follow-redirects) from 1.15.2 to 1.15.11.
                 <details>
                 <summary>Commits</summary>
                 <ul>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/e4e55c77b2d849280d105943f49f42e0c735d05d"><code>e4e55c7</code></a> Release version 1.15.9 of the npm package.</li>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/31a1abf2d659ac1c8fcbe7e614a8c8914d80e1e3"><code>31a1abf</code></a> Attempt much more gentle detection.</li>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/d2aaa97439e8a7e4a9cd02513ec7b12f23c17638"><code>d2aaa97</code></a> Fix url field.</li>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/62558f0cd106195f4c17ece3ad255eb93487d37f"><code>62558f0</code></a> Release version 1.15.8 of the npm package.</li>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/a8d1ceed257d46758f913ff555b4f7e1cd758627"><code>a8d1cee</code></a> Return subtlety.</li>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/458ca8e19fd80897e97746e476d7389cdf9b6494"><code>458ca8e</code></a> Fix native URL test for Node 20.</li>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/ca49e4462651b07eb10452116235c1269cb79e1e"><code>ca49e44</code></a> Handle KeepAlive connections in tests.</li>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/f3711d7e78b24695eae8d348a4e695d288bd450f"><code>f3711d7</code></a> Test on Node 20 and 22.</li>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/fda0fafa0c8d197cbcd232d98c68445ed323c337"><code>fda0faf</code></a> Fix typo.</li>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/760757f7b75cce429604492d91649cbbd473c8d4"><code>760757f</code></a> Release version 1.15.7 of the npm package.</li>
-                <li>Additional commits viewable in <a href="https://github.com/follow-redirects/follow-redirects/compare/v1.15.2...v1.15.9">compare view</a></li>
+                <li>See full diff in <a href="https://github.com/follow-redirects/follow-redirects/commits">compare view</a></li>
                 </ul>
                 </details>
                 <br />
             commit-message: |-
-                Bump follow-redirects from 1.15.2 to 1.15.9 in /npm
+                Bump follow-redirects from 1.15.2 to 1.15.11 in /npm
 
-                Bumps [follow-redirects](https://github.com/follow-redirects/follow-redirects) from 1.15.2 to 1.15.9.
+                Bumps [follow-redirects](https://github.com/follow-redirects/follow-redirects) from 1.15.2 to 1.15.11.
                 - [Release notes](https://github.com/follow-redirects/follow-redirects/releases)
-                - [Commits](https://github.com/follow-redirects/follow-redirects/compare/v1.15.2...v1.15.9)
+                - [Commits](https://github.com/follow-redirects/follow-redirects/commits)
     - type: create_pull_request
       expect:
         data:

--- a/tests/smoke-npm-group-semver.yaml
+++ b/tests/smoke-npm-group-semver.yaml
@@ -169,7 +169,7 @@ output:
                   previous-requirements: []
                   previous-version: 1.15.2
                   requirements: []
-                  version: 1.15.9
+                  version: 1.15.11
                   directory: /npm/semver
                 - name: form-data
                   previous-requirements: []
@@ -509,9 +509,9 @@ output:
                           "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ=="
                         },
                         "node_modules/follow-redirects": {
-                          "version": "1.15.9",
-                          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-                          "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+                          "version": "1.15.11",
+                          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+                          "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
                           "funding": [
                             {
                               "type": "individual",
@@ -989,7 +989,7 @@ output:
                 | --- | --- | --- |
                 | fetch-factory | `0.0.1` | `0.2.1` |
                 | [lodash](https://github.com/lodash/lodash) | `4.16.6` | `4.17.21` |
-                | [follow-redirects](https://github.com/follow-redirects/follow-redirects) | `1.15.2` | `1.15.9` |
+                | [follow-redirects](https://github.com/follow-redirects/follow-redirects) | `1.15.2` | `1.15.11` |
                 | [form-data](https://github.com/form-data/form-data) | `4.0.0` | `4.0.4` |
                 | [whatwg-fetch](https://github.com/github/fetch) | `3.6.17` | `3.6.20` |
 
@@ -1018,21 +1018,11 @@ output:
                 </details>
                 <br />
 
-                Updates `follow-redirects` from 1.15.2 to 1.15.9
+                Updates `follow-redirects` from 1.15.2 to 1.15.11
                 <details>
                 <summary>Commits</summary>
                 <ul>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/e4e55c77b2d849280d105943f49f42e0c735d05d"><code>e4e55c7</code></a> Release version 1.15.9 of the npm package.</li>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/31a1abf2d659ac1c8fcbe7e614a8c8914d80e1e3"><code>31a1abf</code></a> Attempt much more gentle detection.</li>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/d2aaa97439e8a7e4a9cd02513ec7b12f23c17638"><code>d2aaa97</code></a> Fix url field.</li>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/62558f0cd106195f4c17ece3ad255eb93487d37f"><code>62558f0</code></a> Release version 1.15.8 of the npm package.</li>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/a8d1ceed257d46758f913ff555b4f7e1cd758627"><code>a8d1cee</code></a> Return subtlety.</li>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/458ca8e19fd80897e97746e476d7389cdf9b6494"><code>458ca8e</code></a> Fix native URL test for Node 20.</li>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/ca49e4462651b07eb10452116235c1269cb79e1e"><code>ca49e44</code></a> Handle KeepAlive connections in tests.</li>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/f3711d7e78b24695eae8d348a4e695d288bd450f"><code>f3711d7</code></a> Test on Node 20 and 22.</li>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/fda0fafa0c8d197cbcd232d98c68445ed323c337"><code>fda0faf</code></a> Fix typo.</li>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/760757f7b75cce429604492d91649cbbd473c8d4"><code>760757f</code></a> Release version 1.15.7 of the npm package.</li>
-                <li>Additional commits viewable in <a href="https://github.com/follow-redirects/follow-redirects/compare/v1.15.2...v1.15.9">compare view</a></li>
+                <li>See full diff in <a href="https://github.com/follow-redirects/follow-redirects/commits">compare view</a></li>
                 </ul>
                 </details>
                 <br />
@@ -1139,7 +1129,7 @@ output:
                 | --- | --- | --- |
                 | fetch-factory | `0.0.1` | `0.2.1` |
                 | [lodash](https://github.com/lodash/lodash) | `4.16.6` | `4.17.21` |
-                | [follow-redirects](https://github.com/follow-redirects/follow-redirects) | `1.15.2` | `1.15.9` |
+                | [follow-redirects](https://github.com/follow-redirects/follow-redirects) | `1.15.2` | `1.15.11` |
                 | [form-data](https://github.com/form-data/form-data) | `4.0.0` | `4.0.4` |
                 | [whatwg-fetch](https://github.com/github/fetch) | `3.6.17` | `3.6.20` |
 
@@ -1150,9 +1140,9 @@ output:
                 - [Release notes](https://github.com/lodash/lodash/releases)
                 - [Commits](https://github.com/lodash/lodash/compare/4.16.6...4.17.21)
 
-                Updates `follow-redirects` from 1.15.2 to 1.15.9
+                Updates `follow-redirects` from 1.15.2 to 1.15.11
                 - [Release notes](https://github.com/follow-redirects/follow-redirects/releases)
-                - [Commits](https://github.com/follow-redirects/follow-redirects/compare/v1.15.2...v1.15.9)
+                - [Commits](https://github.com/follow-redirects/follow-redirects/commits)
 
                 Updates `form-data` from 4.0.0 to 4.0.4
                 - [Release notes](https://github.com/form-data/form-data/releases)
@@ -1300,9 +1290,9 @@ output:
                           "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ=="
                         },
                         "node_modules/follow-redirects": {
-                          "version": "1.15.9",
-                          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-                          "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+                          "version": "1.15.11",
+                          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+                          "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
                           "funding": [
                             {
                               "type": "individual",

--- a/tests/smoke-npm.yaml
+++ b/tests/smoke-npm.yaml
@@ -2733,7 +2733,7 @@ output:
                   previous-requirements: []
                   previous-version: 1.15.2
                   requirements: []
-                  version: 1.15.9
+                  version: 1.15.11
                   directory: /npm
             updated-dependency-files:
                 - content: |
@@ -2824,9 +2824,9 @@ output:
                           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
                         },
                         "node_modules/follow-redirects": {
-                          "version": "1.15.9",
-                          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-                          "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+                          "version": "1.15.11",
+                          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+                          "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
                           "funding": [
                             {
                               "type": "individual",
@@ -2985,9 +2985,9 @@ output:
                           }
                         },
                         "follow-redirects": {
-                          "version": "1.15.9",
-                          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-                          "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="
+                          "version": "1.15.11",
+                          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+                          "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="
                         },
                         "form-data": {
                           "version": "4.0.0",
@@ -3059,32 +3059,22 @@ output:
                   operation: update
                   support_file: false
                   type: file
-            pr-title: Bump follow-redirects from 1.15.2 to 1.15.9 in /npm
+            pr-title: Bump follow-redirects from 1.15.2 to 1.15.11 in /npm
             pr-body: |
-                Bumps [follow-redirects](https://github.com/follow-redirects/follow-redirects) from 1.15.2 to 1.15.9.
+                Bumps [follow-redirects](https://github.com/follow-redirects/follow-redirects) from 1.15.2 to 1.15.11.
                 <details>
                 <summary>Commits</summary>
                 <ul>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/e4e55c77b2d849280d105943f49f42e0c735d05d"><code>e4e55c7</code></a> Release version 1.15.9 of the npm package.</li>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/31a1abf2d659ac1c8fcbe7e614a8c8914d80e1e3"><code>31a1abf</code></a> Attempt much more gentle detection.</li>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/d2aaa97439e8a7e4a9cd02513ec7b12f23c17638"><code>d2aaa97</code></a> Fix url field.</li>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/62558f0cd106195f4c17ece3ad255eb93487d37f"><code>62558f0</code></a> Release version 1.15.8 of the npm package.</li>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/a8d1ceed257d46758f913ff555b4f7e1cd758627"><code>a8d1cee</code></a> Return subtlety.</li>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/458ca8e19fd80897e97746e476d7389cdf9b6494"><code>458ca8e</code></a> Fix native URL test for Node 20.</li>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/ca49e4462651b07eb10452116235c1269cb79e1e"><code>ca49e44</code></a> Handle KeepAlive connections in tests.</li>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/f3711d7e78b24695eae8d348a4e695d288bd450f"><code>f3711d7</code></a> Test on Node 20 and 22.</li>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/fda0fafa0c8d197cbcd232d98c68445ed323c337"><code>fda0faf</code></a> Fix typo.</li>
-                <li><a href="https://github.com/follow-redirects/follow-redirects/commit/760757f7b75cce429604492d91649cbbd473c8d4"><code>760757f</code></a> Release version 1.15.7 of the npm package.</li>
-                <li>Additional commits viewable in <a href="https://github.com/follow-redirects/follow-redirects/compare/v1.15.2...v1.15.9">compare view</a></li>
+                <li>See full diff in <a href="https://github.com/follow-redirects/follow-redirects/commits">compare view</a></li>
                 </ul>
                 </details>
                 <br />
             commit-message: |-
-                Bump follow-redirects from 1.15.2 to 1.15.9 in /npm
+                Bump follow-redirects from 1.15.2 to 1.15.11 in /npm
 
-                Bumps [follow-redirects](https://github.com/follow-redirects/follow-redirects) from 1.15.2 to 1.15.9.
+                Bumps [follow-redirects](https://github.com/follow-redirects/follow-redirects) from 1.15.2 to 1.15.11.
                 - [Release notes](https://github.com/follow-redirects/follow-redirects/releases)
-                - [Commits](https://github.com/follow-redirects/follow-redirects/compare/v1.15.2...v1.15.9)
+                - [Commits](https://github.com/follow-redirects/follow-redirects/commits)
     - type: create_pull_request
       expect:
         data:


### PR DESCRIPTION
Updates the expected test results in npm smoke tests to reflect follow-redirects dependency updates from version 1.15.9 to 1.15.11.

### Changes Made:
- Updated expected version numbers from `1.15.9` to `1.15.11`
- Updated resolved package URLs and integrity hashes for the new version
- Simplified commit details in PR body descriptions to use generic "See full diff in compare view" format
- Updated PR titles and commit messages to reflect the new version

### Files Modified:
- `tests/smoke-npm.yaml`
- `tests/smoke-npm-group-rules.yaml` 
- `tests/smoke-npm-group-semver.yaml`

This ensures the smoke tests accurately reflect the expected behavior when follow-redirects is updated to the latest version 1.15.11.