### PR TITLE
Add nix smoke test

### DIFF
--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1731603435,
+        "narHash": "sha256-CqCX4JG7UiHvkrBTpYC3wcEurvbtTADLbo3Ns2CEoL8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8b27c1239e5c421a2bbc2c65d52e4a6fbf2ff296",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -1,0 +1,5 @@
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+
+  outputs = { ... }: { };
+}

--- a/tests/smoke-nix.yaml
+++ b/tests/smoke-nix.yaml
@@ -1,0 +1,129 @@
+input:
+    job:
+        command: update
+        package-manager: nix
+        allowed-updates:
+            - update-type: all
+        experiments:
+            enable_beta_ecosystems: true
+        source:
+            provider: github
+            repo: dependabot/smoke-tests
+            directory: /nix
+            commit: 8d857a01c9c034aaf4bb100007479ab5f5a1c623
+    credentials:
+        - host: github.com
+          password: $LOCAL_GITHUB_ACCESS_TOKEN
+          type: git_source
+          username: x-access-token
+output:
+    - type: update_dependency_list
+      expect:
+        data:
+            dependencies:
+                - name: nixpkgs
+                  requirements:
+                    - file: flake.lock
+                      groups: []
+                      requirement: null
+                      source:
+                        branch: nixos-24.11
+                        ref: nixos-24.11
+                        type: git
+                        url: https://github.com/NixOS/nixpkgs
+                  version: 8b27c1239e5c421a2bbc2c65d52e4a6fbf2ff296
+            dependency_files:
+                - /nix/flake.nix
+                - /nix/flake.lock
+    - type: create_pull_request
+      expect:
+        data:
+            base-commit-sha: 8d857a01c9c034aaf4bb100007479ab5f5a1c623
+            dependencies:
+                - name: nixpkgs
+                  previous-requirements:
+                    - file: flake.lock
+                      groups: []
+                      requirement: null
+                      source:
+                        branch: nixos-24.11
+                        ref: nixos-24.11
+                        type: git
+                        url: https://github.com/NixOS/nixpkgs
+                  previous-version: 8b27c1239e5c421a2bbc2c65d52e4a6fbf2ff296
+                  requirements:
+                    - file: flake.lock
+                      groups: []
+                      requirement: null
+                      source:
+                        branch: nixos-24.11
+                        ref: nixos-24.11
+                        type: git
+                        url: https://github.com/NixOS/nixpkgs
+                  version: 50ab793786d9de88ee30ec4e4c24fb4236fc2674
+                  directory: /nix
+            updated-dependency-files:
+                - content: |
+                    {
+                      "nodes": {
+                        "nixpkgs": {
+                          "locked": {
+                            "lastModified": 1751274312,
+                            "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+                            "owner": "NixOS",
+                            "repo": "nixpkgs",
+                            "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+                            "type": "github"
+                          },
+                          "original": {
+                            "owner": "NixOS",
+                            "ref": "nixos-24.11",
+                            "repo": "nixpkgs",
+                            "type": "github"
+                          }
+                        },
+                        "root": {
+                          "inputs": {
+                            "nixpkgs": "nixpkgs"
+                          }
+                        }
+                      },
+                      "root": "root",
+                      "version": 7
+                    }
+                  content_encoding: utf-8
+                  deleted: false
+                  directory: /nix
+                  name: flake.lock
+                  operation: update
+                  support_file: false
+                  type: file
+            pr-title: Bump nixpkgs from `8b27c12` to `50ab793` in /nix
+            pr-body: |
+                Bumps [nixpkgs](https://github.com/NixOS/nixpkgs) from `8b27c12` to `50ab793`.
+                <details>
+                <summary>Commits</summary>
+                <ul>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/50ab793786d9de88ee30ec4e4c24fb4236fc2674"><code>50ab793</code></a> [24.11] Lix CVE-2025-46415 (critical) bug fixes (<a href="https://redirect.github.com/NixOS/nixpkgs/issues/421137">#421137</a>)</li>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/1d1ef5040b240dcee4769adc6943ba5af0adbb37"><code>1d1ef50</code></a> [Backport release-24.11] librewolf-unwrapped: 139.0.4-1 -&gt; 140.0.2-1 (<a href="https://redirect.github.com/NixOS/nixpkgs/issues/421086">#421086</a>)</li>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/b79ee9f063c5205184201cab03005036a8d466ec"><code>b79ee9f</code></a> lixVersions_2_91: patch for the critical correctness bug</li>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/dc92673fc043e800b76d12a80bfc0c27cfb7685c"><code>dc92673</code></a> [Backport release-24.11] ci/README.md: one sentence per line (<a href="https://redirect.github.com/NixOS/nixpkgs/issues/421097">#421097</a>)</li>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/3bcaebc6035750592b759f2ad3e8c009ba074520"><code>3bcaebc</code></a> .github/workflows/README.md: one sentence per line</li>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/11ccc438638e165b918d7a5f48748ec34086ba59"><code>11ccc43</code></a> ci/eval/README.md: one sentence per line</li>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/2e07c7808660e42ebfec4906ca9b76b88ed5e27b"><code>2e07c78</code></a> ci/README.md: one sentence per line</li>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/9ea8e31fefc452f94040d380974ac565b69c61e1"><code>9ea8e31</code></a> librewolf-unwrapped: 139.0.4-1 -&gt; 140.0.2-1</li>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/0ac77cd1ecb7504ee2ea66fa5bb40cf44eedf12d"><code>0ac77cd</code></a> [Backport release-24.11] nexus: mark as insecure and remove inactive maintain...</li>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/e062c07692562320c9625645b12bdd45e0b3cec0"><code>e062c07</code></a> nexus: mark as insecure and remove maintainers</li>
+                <li>Additional commits viewable in <a href="https://github.com/NixOS/nixpkgs/compare/8b27c1239e5c421a2bbc2c65d52e4a6fbf2ff296...50ab793786d9de88ee30ec4e4c24fb4236fc2674">compare view</a></li>
+                </ul>
+                </details>
+                <br />
+            commit-message: |-
+                Bump nixpkgs from `8b27c12` to `50ab793` in /nix
+
+                Bumps [nixpkgs](https://github.com/NixOS/nixpkgs) from `8b27c12` to `50ab793`.
+                - [Commits](https://github.com/NixOS/nixpkgs/compare/8b27c1239e5c421a2bbc2c65d52e4a6fbf2ff296...50ab793786d9de88ee30ec4e4c24fb4236fc2674)
+    - type: mark_as_processed
+      expect:
+        data:
+            base-commit-sha: 8d857a01c9c034aaf4bb100007479ab5f5a1c623


### PR DESCRIPTION
- Add nix/flake.nix and nix/flake.lock manifests pinned to nixos-24.11
- Add tests/smoke-nix.yaml with enable_beta_ecosystems experiment
- Pin flake.lock to 24.11 release tag (8b27c12) for stable test output