### PR TITLE
Update expected maintainer URL encoding in npm group semver smoke test

### DIFF
--- a/tests/smoke-npm-group-semver.yaml
+++ b/tests/smoke-npm-group-semver.yaml
@@ -1801,7 +1801,7 @@ output:
                 </details>
                 <details>
                 <summary>Maintainer changes</summary>
-                <p>This version was pushed to npm by [GitHub Actions](<a href="https://www.npmjs.com/~GitHub">https://www.npmjs.com/~GitHub</a> Actions), a new releaser for axios since your current version.</p>
+                <p>This version was pushed to npm by <a href="https://www.npmjs.com/~GitHub%20Actions">GitHub Actions</a>, a new releaser for axios since your current version.</p>
                 </details>
                 <details>
                 <summary>Install script changes</summary>


### PR DESCRIPTION
## What changed?

Updates the expected PR body HTML in `smoke-npm-group-semver.yaml` to match the new URL-encoded maintainer name format.

## Why?

[dependabot/dependabot-core#14638](https://github.com/dependabot/dependabot-core/pull/14638) fixes broken Markdown links in the Maintainer changes section when the npm releaser name contains spaces (e.g. `GitHub Actions`). The releaser name is now percent-encoded in the URL, producing valid links like `https://www.npmjs.com/~GitHub%20Actions` instead of the broken `https://www.npmjs.com/~GitHub Actions`.

This smoke test update aligns the expected HTML output with the corrected behavior.