### PR TITLE
Add nix smoke tests for tag ref and versioned branch updates

### DIFF
--- a/nix-tag/flake.lock
+++ b/nix-tag/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1696267196,
+        "narHash": "sha256-AAQ/2sD+0D18bb8hKuEEVpHUYD1GmO2Uh/taFamn6XQ=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "4f910c9827911b1ec2bf26b5a062cd09f8d89f85",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "ref": "v1.0.0",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nix-tag/flake.nix
+++ b/nix-tag/flake.nix
@@ -1,0 +1,5 @@
+{
+  inputs.flake-compat.url = "github:edolstra/flake-compat/v1.0.0";
+
+  outputs = { ... }: { };
+}

--- a/nix-versioned-branch/flake.lock
+++ b/nix-versioned-branch/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1735563628,
+        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nix-versioned-branch/flake.lock
+++ b/nix-versioned-branch/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1735563628,
-        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
+        "lastModified": 1704290814,
+        "narHash": "sha256-LWvKHp7kGxk/GEtlrGYV68qIvPHkU9iToomNFGagixU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
+        "rev": "70bdadeb94ffc8806c0570eb5c2695ad29f0e421",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/nix-versioned-branch/flake.nix
+++ b/nix-versioned-branch/flake.nix
@@ -1,5 +1,5 @@
 {
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
 
   outputs = { ... }: { };
 }

--- a/nix-versioned-branch/flake.nix
+++ b/nix-versioned-branch/flake.nix
@@ -1,0 +1,5 @@
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+
+  outputs = { ... }: { };
+}

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -1,24 +1,41 @@
 {
   "nodes": {
-    "nixpkgs": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1731603435,
-        "narHash": "sha256-CqCX4JG7UiHvkrBTpYC3wcEurvbtTADLbo3Ns2CEoL8=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "8b27c1239e5c421a2bbc2c65d52e4a6fbf2ff296",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.11",
-        "repo": "nixpkgs",
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "flake-utils": "flake-utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -1,5 +1,5 @@
 {
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
 
   outputs = { ... }: { };
 }

--- a/tests/smoke-nix-tag.yaml
+++ b/tests/smoke-nix-tag.yaml
@@ -1,0 +1,137 @@
+input:
+    job:
+        package-manager: nix
+        allowed-updates:
+            - update-type: all
+        experiments:
+            enable_beta_ecosystems: true
+        ignore-conditions:
+            - dependency-name: flake-compat
+              source: tests/smoke-nix-tag.yaml
+              version-requirement: '>1.0.1'
+        source:
+            provider: github
+            repo: dependabot/smoke-tests
+            directory: /nix-tag
+            commit: b23be6858f96a0d210331ef540f7c184d41a2ba8
+    credentials:
+        - host: github.com
+          password: $LOCAL_GITHUB_ACCESS_TOKEN
+          type: git_source
+          username: x-access-token
+output:
+    - type: update_dependency_list
+      expect:
+        data:
+            dependencies:
+                - name: flake-compat
+                  requirements:
+                    - file: flake.lock
+                      groups: []
+                      requirement: null
+                      source:
+                        branch: null
+                        ref: v1.0.0
+                        type: git
+                        url: https://github.com/edolstra/flake-compat
+                  version: 4f910c9827911b1ec2bf26b5a062cd09f8d89f85
+            dependency_files:
+                - /nix-tag/flake.nix
+                - /nix-tag/flake.lock
+    - type: create_pull_request
+      expect:
+        data:
+            base-commit-sha: b23be6858f96a0d210331ef540f7c184d41a2ba8
+            dependencies:
+                - name: flake-compat
+                  previous-requirements:
+                    - file: flake.lock
+                      groups: []
+                      requirement: null
+                      source:
+                        branch: null
+                        ref: v1.0.0
+                        type: git
+                        url: https://github.com/edolstra/flake-compat
+                  previous-version: 4f910c9827911b1ec2bf26b5a062cd09f8d89f85
+                  requirements:
+                    - file: flake.lock
+                      groups: []
+                      requirement: null
+                      source:
+                        branch: null
+                        ref: v1.0.1
+                        type: git
+                        url: https://github.com/edolstra/flake-compat
+                  version: 0f9255e01c2351cc7d116c072cb317785dd33b33
+                  directory: /nix-tag
+            updated-dependency-files:
+                - content: |
+                    {
+                      inputs.flake-compat.url = "github:edolstra/flake-compat/v1.0.1";
+
+                      outputs = { ... }: { };
+                    }
+                  content_encoding: utf-8
+                  deleted: false
+                  directory: /nix-tag
+                  name: flake.nix
+                  operation: update
+                  support_file: false
+                  type: file
+                - content: |
+                    {
+                      "nodes": {
+                        "flake-compat": {
+                          "locked": {
+                            "lastModified": 1696426674,
+                            "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+                            "owner": "edolstra",
+                            "repo": "flake-compat",
+                            "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+                            "type": "github"
+                          },
+                          "original": {
+                            "owner": "edolstra",
+                            "ref": "v1.0.1",
+                            "repo": "flake-compat",
+                            "type": "github"
+                          }
+                        },
+                        "root": {
+                          "inputs": {
+                            "flake-compat": "flake-compat"
+                          }
+                        }
+                      },
+                      "root": "root",
+                      "version": 7
+                    }
+                  content_encoding: utf-8
+                  deleted: false
+                  directory: /nix-tag
+                  name: flake.lock
+                  operation: update
+                  support_file: false
+                  type: file
+            pr-title: Bump flake-compat from v1.0.0 to v1.0.1 in /nix-tag
+            pr-body: |
+                Bumps [flake-compat](https://github.com/edolstra/flake-compat) from v1.0.0 to v1.0.1.
+                <details>
+                <summary>Commits</summary>
+                <ul>
+                <li><a href="https://github.com/NixOS/flake-compat/commit/0f9255e01c2351cc7d116c072cb317785dd33b33"><code>0f9255e</code></a> Force root sources like &quot;./.&quot; into the Nix store</li>
+                <li><a href="https://github.com/NixOS/flake-compat/commit/5a16547d46553d7bdd1dfc2cf418f5f7d236f6ad"><code>5a16547</code></a> Prevent double copying and work around an apparent Nix bug</li>
+                <li>See full diff in <a href="https://github.com/edolstra/flake-compat/compare/4f910c9827911b1ec2bf26b5a062cd09f8d89f85...0f9255e01c2351cc7d116c072cb317785dd33b33">compare view</a></li>
+                </ul>
+                </details>
+                <br />
+            commit-message: |-
+                Bump flake-compat from v1.0.0 to v1.0.1 in /nix-tag
+
+                Bumps [flake-compat](https://github.com/edolstra/flake-compat) from v1.0.0 to v1.0.1.
+                - [Commits](https://github.com/edolstra/flake-compat/compare/4f910c9827911b1ec2bf26b5a062cd09f8d89f85...0f9255e01c2351cc7d116c072cb317785dd33b33)
+    - type: mark_as_processed
+      expect:
+        data:
+            base-commit-sha: b23be6858f96a0d210331ef540f7c184d41a2ba8

--- a/tests/smoke-nix-versioned-branch.yaml
+++ b/tests/smoke-nix-versioned-branch.yaml
@@ -8,12 +8,12 @@ input:
         ignore-conditions:
             - dependency-name: nixpkgs
               source: tests/smoke-nix-versioned-branch.yaml
-              version-requirement: '>0.0.0-0.1'
+              version-requirement: '>= 24'
         source:
             provider: github
             repo: dependabot/smoke-tests
             directory: /nix-versioned-branch
-            commit: b23be6858f96a0d210331ef540f7c184d41a2ba8
+            commit: ecda8782c19c1a493a39a1e5bc51e4092f738c04
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN
@@ -31,17 +31,17 @@ output:
                       requirement: null
                       source:
                         branch: null
-                        ref: nixos-24.05
+                        ref: nixos-23.05
                         type: git
                         url: https://github.com/NixOS/nixpkgs
-                  version: b134951a4c9f3c995fd7be05f3243f8ecd65d798
+                  version: 70bdadeb94ffc8806c0570eb5c2695ad29f0e421
             dependency_files:
                 - /nix-versioned-branch/flake.nix
                 - /nix-versioned-branch/flake.lock
     - type: create_pull_request
       expect:
         data:
-            base-commit-sha: b23be6858f96a0d210331ef540f7c184d41a2ba8
+            base-commit-sha: ecda8782c19c1a493a39a1e5bc51e4092f738c04
             dependencies:
                 - name: nixpkgs
                   previous-requirements:
@@ -50,25 +50,25 @@ output:
                       requirement: null
                       source:
                         branch: null
-                        ref: nixos-24.05
+                        ref: nixos-23.05
                         type: git
                         url: https://github.com/NixOS/nixpkgs
-                  previous-version: b134951a4c9f3c995fd7be05f3243f8ecd65d798
+                  previous-version: 70bdadeb94ffc8806c0570eb5c2695ad29f0e421
                   requirements:
                     - file: flake.lock
                       groups: []
                       requirement: null
                       source:
                         branch: null
-                        ref: nixos-25.11
+                        ref: nixos-23.11
                         type: git
                         url: https://github.com/NixOS/nixpkgs
-                  version: 54170c54449ea4d6725efd30d719c5e505f1c10e
+                  version: 205fd4226592cc83fd4c0885a3e4c9c400efabb5
                   directory: /nix-versioned-branch
             updated-dependency-files:
                 - content: |
                     {
-                      inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+                      inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
 
                       outputs = { ... }: { };
                     }
@@ -84,16 +84,16 @@ output:
                       "nodes": {
                         "nixpkgs": {
                           "locked": {
-                            "lastModified": 1775811116,
-                            "narHash": "sha256-t+HZK42pB6N+i5RGbuy7Xluez/VvWbembBdvzsc23Ss=",
+                            "lastModified": 1720535198,
+                            "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
                             "owner": "NixOS",
                             "repo": "nixpkgs",
-                            "rev": "54170c54449ea4d6725efd30d719c5e505f1c10e",
+                            "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
                             "type": "github"
                           },
                           "original": {
                             "owner": "NixOS",
-                            "ref": "nixos-25.11",
+                            "ref": "nixos-23.11",
                             "repo": "nixpkgs",
                             "type": "github"
                           }
@@ -114,32 +114,32 @@ output:
                   operation: update
                   support_file: false
                   type: file
-            pr-title: Bump nixpkgs from nixos-24.05 to nixos-25.11 in /nix-versioned-branch
+            pr-title: Bump nixpkgs from nixos-23.05 to nixos-23.11 in /nix-versioned-branch
             pr-body: |
-                Bumps [nixpkgs](https://github.com/NixOS/nixpkgs) from nixos-24.05 to nixos-25.11.
+                Bumps [nixpkgs](https://github.com/NixOS/nixpkgs) from nixos-23.05 to nixos-23.11.
                 <details>
                 <summary>Commits</summary>
                 <ul>
-                <li><a href="https://github.com/NixOS/nixpkgs/commit/54170c54449ea4d6725efd30d719c5e505f1c10e"><code>54170c5</code></a> [Backport release-25.11] matrix-authentication-service: 1.14.0 -&gt; 1.15.0 (<a href="https://redirect.github.com/NixOS/nixpkgs/issues/50">#50</a>...</li>
-                <li><a href="https://github.com/NixOS/nixpkgs/commit/863c462d78dd3e9de7ca3516b28764ef0346a763"><code>863c462</code></a> [Backport release-25.11] batman-adv: 2026.0 -&gt; 2026.1 (<a href="https://redirect.github.com/NixOS/nixpkgs/issues/508128">#508128</a>)</li>
-                <li><a href="https://github.com/NixOS/nixpkgs/commit/11cda251ebadef1877a8adad04d175cc54fae7d3"><code>11cda25</code></a> [Backport release-25.11] gitlab: 18.10.1 -&gt; 18.10.3 (<a href="https://redirect.github.com/NixOS/nixpkgs/issues/508293">#508293</a>)</li>
-                <li><a href="https://github.com/NixOS/nixpkgs/commit/ecf622c2d15709b03a43f31c29665b52a49b1293"><code>ecf622c</code></a> matrix-authentication-service: 1.14.0 -&gt; 1.15.0</li>
-                <li><a href="https://github.com/NixOS/nixpkgs/commit/74b87959b2d16f59f54d8559cf3cf26b9d907949"><code>74b8795</code></a> [Backport release-25.11] dn42-registry-wizard: 0.4.19 -&gt; 0.4.20 (<a href="https://redirect.github.com/NixOS/nixpkgs/issues/508346">#508346</a>)</li>
-                <li><a href="https://github.com/NixOS/nixpkgs/commit/b7f6edc092a35a0ba645fcc2e8699c8fb5baac90"><code>b7f6edc</code></a> dn42-registry-wizard: 0.4.19 -&gt; 0.4.20</li>
-                <li><a href="https://github.com/NixOS/nixpkgs/commit/2b40e62526b4ceebc63e66a8752c3057a2420ed3"><code>2b40e62</code></a> gitlab: 18.10.1 -&gt; 18.10.3</li>
-                <li><a href="https://github.com/NixOS/nixpkgs/commit/0d5a853f7004a5fc57b61a97ccb02832f8e7ed9d"><code>0d5a853</code></a> [25.11] zammad: 7.0.0 -&gt; 7.0.1 (<a href="https://redirect.github.com/NixOS/nixpkgs/issues/508275">#508275</a>)</li>
-                <li><a href="https://github.com/NixOS/nixpkgs/commit/6bd442f9189fff2726ee7a847860d8cc4e46664f"><code>6bd442f</code></a> zammad: 7.0.0 -&gt; 7.0.1</li>
-                <li><a href="https://github.com/NixOS/nixpkgs/commit/ba005e7fb54f635a5507fcc197210b0da20de5ab"><code>ba005e7</code></a> [Backport release-25.11] signal-cli: 0.13.24 -&gt; 0.14.2 (<a href="https://redirect.github.com/NixOS/nixpkgs/issues/507524">#507524</a>)</li>
-                <li>Additional commits viewable in <a href="https://github.com/NixOS/nixpkgs/compare/b134951a4c9f3c995fd7be05f3243f8ecd65d798...54170c54449ea4d6725efd30d719c5e505f1c10e">compare view</a></li>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/205fd4226592cc83fd4c0885a3e4c9c400efabb5"><code>205fd42</code></a> Merge #325769: staging-next-23.11 iteration 10</li>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/72f84695f83e0cd56a270890cd1eb06bfe6f2f5b"><code>72f8469</code></a> Merge branch 'release-23.11' into staging-next-23.11</li>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/f6ee1e79691a5c7ee284830c2ca3daf9b7e50e06"><code>f6ee1e7</code></a> Merge branch 'staging-23.11' into staging-next-23.11</li>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/7144d6241f02d171d25fba3edeaf15e0f2592105"><code>7144d62</code></a> python3Packages.clustershell: remove blocking test</li>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/28f8f3531ebdbea069995c20bd946a295699f275"><code>28f8f35</code></a> openssh_{hpn,gssapi}: add backported security fix patches</li>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/763fc33f3612bc404d24d8333f4ab314cc79f90b"><code>763fc33</code></a> Merge pull request <a href="https://redirect.github.com/NixOS/nixpkgs/issues/323765">#323765</a> from emilazy/openssh-security-backport-23.11</li>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/c21c340818954576c6401ad460a9d42bab030bc4"><code>c21c340</code></a> openssh: add backported security fix patches</li>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/50f6d728651282b8c57effb49c8e6d4df94e1d9a"><code>50f6d72</code></a> Merge staging-next-23.11 into staging-23.11</li>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/5ef86cf835ce0956cc5563724dce216af0e035e3"><code>5ef86cf</code></a> Merge release-23.11 into staging-next-23.11</li>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/83725a49ebd58a56ffc865ae5c59ce7977351b6b"><code>83725a4</code></a> Merge pull request <a href="https://redirect.github.com/NixOS/nixpkgs/issues/323649">#323649</a> from NixOS/backport-322037-to-release-23.11</li>
+                <li>Additional commits viewable in <a href="https://github.com/NixOS/nixpkgs/compare/70bdadeb94ffc8806c0570eb5c2695ad29f0e421...205fd4226592cc83fd4c0885a3e4c9c400efabb5">compare view</a></li>
                 </ul>
                 </details>
                 <br />
             commit-message: |-
-                Bump nixpkgs from nixos-24.05 to nixos-25.11 in /nix-versioned-branch
+                Bump nixpkgs from nixos-23.05 to nixos-23.11 in /nix-versioned-branch
 
-                Bumps [nixpkgs](https://github.com/NixOS/nixpkgs) from nixos-24.05 to nixos-25.11.
-                - [Commits](https://github.com/NixOS/nixpkgs/compare/b134951a4c9f3c995fd7be05f3243f8ecd65d798...54170c54449ea4d6725efd30d719c5e505f1c10e)
+                Bumps [nixpkgs](https://github.com/NixOS/nixpkgs) from nixos-23.05 to nixos-23.11.
+                - [Commits](https://github.com/NixOS/nixpkgs/compare/70bdadeb94ffc8806c0570eb5c2695ad29f0e421...205fd4226592cc83fd4c0885a3e4c9c400efabb5)
     - type: mark_as_processed
       expect:
         data:
-            base-commit-sha: b23be6858f96a0d210331ef540f7c184d41a2ba8
+            base-commit-sha: ecda8782c19c1a493a39a1e5bc51e4092f738c04

--- a/tests/smoke-nix-versioned-branch.yaml
+++ b/tests/smoke-nix-versioned-branch.yaml
@@ -120,7 +120,7 @@ output:
                 <details>
                 <summary>Commits</summary>
                 <ul>
-                <li><a href="https://github.com/NixOS/nixpkgs/commit/205fd4226592cc83fd4c0885a3e4c9c400efabb5"><code>205fd42</code></a> Merge #325769: staging-next-23.11 iteration 10</li>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/205fd4226592cc83fd4c0885a3e4c9c400efabb5"><code>205fd42</code></a> Merge <a href="https://redirect.github.com/NixOS/nixpkgs/issues/325769">#325769</a>: staging-next-23.11 iteration 10</li>
                 <li><a href="https://github.com/NixOS/nixpkgs/commit/72f84695f83e0cd56a270890cd1eb06bfe6f2f5b"><code>72f8469</code></a> Merge branch 'release-23.11' into staging-next-23.11</li>
                 <li><a href="https://github.com/NixOS/nixpkgs/commit/f6ee1e79691a5c7ee284830c2ca3daf9b7e50e06"><code>f6ee1e7</code></a> Merge branch 'staging-23.11' into staging-next-23.11</li>
                 <li><a href="https://github.com/NixOS/nixpkgs/commit/7144d6241f02d171d25fba3edeaf15e0f2592105"><code>7144d62</code></a> python3Packages.clustershell: remove blocking test</li>

--- a/tests/smoke-nix-versioned-branch.yaml
+++ b/tests/smoke-nix-versioned-branch.yaml
@@ -1,0 +1,145 @@
+input:
+    job:
+        package-manager: nix
+        allowed-updates:
+            - update-type: all
+        experiments:
+            enable_beta_ecosystems: true
+        ignore-conditions:
+            - dependency-name: nixpkgs
+              source: tests/smoke-nix-versioned-branch.yaml
+              version-requirement: '>0.0.0-0.1'
+        source:
+            provider: github
+            repo: dependabot/smoke-tests
+            directory: /nix-versioned-branch
+            commit: b23be6858f96a0d210331ef540f7c184d41a2ba8
+    credentials:
+        - host: github.com
+          password: $LOCAL_GITHUB_ACCESS_TOKEN
+          type: git_source
+          username: x-access-token
+output:
+    - type: update_dependency_list
+      expect:
+        data:
+            dependencies:
+                - name: nixpkgs
+                  requirements:
+                    - file: flake.lock
+                      groups: []
+                      requirement: null
+                      source:
+                        branch: null
+                        ref: nixos-24.05
+                        type: git
+                        url: https://github.com/NixOS/nixpkgs
+                  version: b134951a4c9f3c995fd7be05f3243f8ecd65d798
+            dependency_files:
+                - /nix-versioned-branch/flake.nix
+                - /nix-versioned-branch/flake.lock
+    - type: create_pull_request
+      expect:
+        data:
+            base-commit-sha: b23be6858f96a0d210331ef540f7c184d41a2ba8
+            dependencies:
+                - name: nixpkgs
+                  previous-requirements:
+                    - file: flake.lock
+                      groups: []
+                      requirement: null
+                      source:
+                        branch: null
+                        ref: nixos-24.05
+                        type: git
+                        url: https://github.com/NixOS/nixpkgs
+                  previous-version: b134951a4c9f3c995fd7be05f3243f8ecd65d798
+                  requirements:
+                    - file: flake.lock
+                      groups: []
+                      requirement: null
+                      source:
+                        branch: null
+                        ref: nixos-25.11
+                        type: git
+                        url: https://github.com/NixOS/nixpkgs
+                  version: 54170c54449ea4d6725efd30d719c5e505f1c10e
+                  directory: /nix-versioned-branch
+            updated-dependency-files:
+                - content: |
+                    {
+                      inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+
+                      outputs = { ... }: { };
+                    }
+                  content_encoding: utf-8
+                  deleted: false
+                  directory: /nix-versioned-branch
+                  name: flake.nix
+                  operation: update
+                  support_file: false
+                  type: file
+                - content: |
+                    {
+                      "nodes": {
+                        "nixpkgs": {
+                          "locked": {
+                            "lastModified": 1775811116,
+                            "narHash": "sha256-t+HZK42pB6N+i5RGbuy7Xluez/VvWbembBdvzsc23Ss=",
+                            "owner": "NixOS",
+                            "repo": "nixpkgs",
+                            "rev": "54170c54449ea4d6725efd30d719c5e505f1c10e",
+                            "type": "github"
+                          },
+                          "original": {
+                            "owner": "NixOS",
+                            "ref": "nixos-25.11",
+                            "repo": "nixpkgs",
+                            "type": "github"
+                          }
+                        },
+                        "root": {
+                          "inputs": {
+                            "nixpkgs": "nixpkgs"
+                          }
+                        }
+                      },
+                      "root": "root",
+                      "version": 7
+                    }
+                  content_encoding: utf-8
+                  deleted: false
+                  directory: /nix-versioned-branch
+                  name: flake.lock
+                  operation: update
+                  support_file: false
+                  type: file
+            pr-title: Bump nixpkgs from nixos-24.05 to nixos-25.11 in /nix-versioned-branch
+            pr-body: |
+                Bumps [nixpkgs](https://github.com/NixOS/nixpkgs) from nixos-24.05 to nixos-25.11.
+                <details>
+                <summary>Commits</summary>
+                <ul>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/54170c54449ea4d6725efd30d719c5e505f1c10e"><code>54170c5</code></a> [Backport release-25.11] matrix-authentication-service: 1.14.0 -&gt; 1.15.0 (<a href="https://redirect.github.com/NixOS/nixpkgs/issues/50">#50</a>...</li>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/863c462d78dd3e9de7ca3516b28764ef0346a763"><code>863c462</code></a> [Backport release-25.11] batman-adv: 2026.0 -&gt; 2026.1 (<a href="https://redirect.github.com/NixOS/nixpkgs/issues/508128">#508128</a>)</li>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/11cda251ebadef1877a8adad04d175cc54fae7d3"><code>11cda25</code></a> [Backport release-25.11] gitlab: 18.10.1 -&gt; 18.10.3 (<a href="https://redirect.github.com/NixOS/nixpkgs/issues/508293">#508293</a>)</li>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/ecf622c2d15709b03a43f31c29665b52a49b1293"><code>ecf622c</code></a> matrix-authentication-service: 1.14.0 -&gt; 1.15.0</li>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/74b87959b2d16f59f54d8559cf3cf26b9d907949"><code>74b8795</code></a> [Backport release-25.11] dn42-registry-wizard: 0.4.19 -&gt; 0.4.20 (<a href="https://redirect.github.com/NixOS/nixpkgs/issues/508346">#508346</a>)</li>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/b7f6edc092a35a0ba645fcc2e8699c8fb5baac90"><code>b7f6edc</code></a> dn42-registry-wizard: 0.4.19 -&gt; 0.4.20</li>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/2b40e62526b4ceebc63e66a8752c3057a2420ed3"><code>2b40e62</code></a> gitlab: 18.10.1 -&gt; 18.10.3</li>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/0d5a853f7004a5fc57b61a97ccb02832f8e7ed9d"><code>0d5a853</code></a> [25.11] zammad: 7.0.0 -&gt; 7.0.1 (<a href="https://redirect.github.com/NixOS/nixpkgs/issues/508275">#508275</a>)</li>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/6bd442f9189fff2726ee7a847860d8cc4e46664f"><code>6bd442f</code></a> zammad: 7.0.0 -&gt; 7.0.1</li>
+                <li><a href="https://github.com/NixOS/nixpkgs/commit/ba005e7fb54f635a5507fcc197210b0da20de5ab"><code>ba005e7</code></a> [Backport release-25.11] signal-cli: 0.13.24 -&gt; 0.14.2 (<a href="https://redirect.github.com/NixOS/nixpkgs/issues/507524">#507524</a>)</li>
+                <li>Additional commits viewable in <a href="https://github.com/NixOS/nixpkgs/compare/b134951a4c9f3c995fd7be05f3243f8ecd65d798...54170c54449ea4d6725efd30d719c5e505f1c10e">compare view</a></li>
+                </ul>
+                </details>
+                <br />
+            commit-message: |-
+                Bump nixpkgs from nixos-24.05 to nixos-25.11 in /nix-versioned-branch
+
+                Bumps [nixpkgs](https://github.com/NixOS/nixpkgs) from nixos-24.05 to nixos-25.11.
+                - [Commits](https://github.com/NixOS/nixpkgs/compare/b134951a4c9f3c995fd7be05f3243f8ecd65d798...54170c54449ea4d6725efd30d719c5e505f1c10e)
+    - type: mark_as_processed
+      expect:
+        data:
+            base-commit-sha: b23be6858f96a0d210331ef540f7c184d41a2ba8

--- a/tests/smoke-nix.yaml
+++ b/tests/smoke-nix.yaml
@@ -5,10 +5,6 @@ input:
             - update-type: all
         experiments:
             enable_beta_ecosystems: true
-        ignore-conditions:
-            - dependency-name: flake-utils
-              source: tests/smoke-nix.yaml
-              version-requirement: '>11707dc2f618dd54ca8739b309ec4fc024de578b'
         source:
             provider: github
             repo: dependabot/smoke-tests

--- a/tests/smoke-nix.yaml
+++ b/tests/smoke-nix.yaml
@@ -1,16 +1,19 @@
 input:
     job:
-        command: update
         package-manager: nix
         allowed-updates:
             - update-type: all
         experiments:
             enable_beta_ecosystems: true
+        ignore-conditions:
+            - dependency-name: flake-utils
+              source: tests/smoke-nix.yaml
+              version-requirement: '>11707dc2f618dd54ca8739b309ec4fc024de578b'
         source:
             provider: github
             repo: dependabot/smoke-tests
             directory: /nix
-            commit: 8d857a01c9c034aaf4bb100007479ab5f5a1c623
+            commit: b23be6858f96a0d210331ef540f7c184d41a2ba8
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN
@@ -21,70 +24,87 @@ output:
       expect:
         data:
             dependencies:
-                - name: nixpkgs
+                - name: flake-utils
                   requirements:
                     - file: flake.lock
                       groups: []
                       requirement: null
                       source:
-                        branch: nixos-24.11
-                        ref: nixos-24.11
+                        branch: null
+                        ref: null
                         type: git
-                        url: https://github.com/NixOS/nixpkgs
-                  version: 8b27c1239e5c421a2bbc2c65d52e4a6fbf2ff296
+                        url: https://github.com/numtide/flake-utils
+                  version: c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a
             dependency_files:
                 - /nix/flake.nix
                 - /nix/flake.lock
     - type: create_pull_request
       expect:
         data:
-            base-commit-sha: 8d857a01c9c034aaf4bb100007479ab5f5a1c623
+            base-commit-sha: b23be6858f96a0d210331ef540f7c184d41a2ba8
             dependencies:
-                - name: nixpkgs
+                - name: flake-utils
                   previous-requirements:
                     - file: flake.lock
                       groups: []
                       requirement: null
                       source:
-                        branch: nixos-24.11
-                        ref: nixos-24.11
+                        branch: null
+                        ref: null
                         type: git
-                        url: https://github.com/NixOS/nixpkgs
-                  previous-version: 8b27c1239e5c421a2bbc2c65d52e4a6fbf2ff296
+                        url: https://github.com/numtide/flake-utils
+                  previous-version: c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a
                   requirements:
                     - file: flake.lock
                       groups: []
                       requirement: null
                       source:
-                        branch: nixos-24.11
-                        ref: nixos-24.11
+                        branch: null
+                        ref: null
                         type: git
-                        url: https://github.com/NixOS/nixpkgs
-                  version: 50ab793786d9de88ee30ec4e4c24fb4236fc2674
+                        url: https://github.com/numtide/flake-utils
+                  version: 11707dc2f618dd54ca8739b309ec4fc024de578b
                   directory: /nix
             updated-dependency-files:
                 - content: |
                     {
                       "nodes": {
-                        "nixpkgs": {
+                        "flake-utils": {
+                          "inputs": {
+                            "systems": "systems"
+                          },
                           "locked": {
-                            "lastModified": 1751274312,
-                            "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
-                            "owner": "NixOS",
-                            "repo": "nixpkgs",
-                            "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+                            "lastModified": 1731533236,
+                            "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+                            "owner": "numtide",
+                            "repo": "flake-utils",
+                            "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
                             "type": "github"
                           },
                           "original": {
-                            "owner": "NixOS",
-                            "ref": "nixos-24.11",
-                            "repo": "nixpkgs",
+                            "owner": "numtide",
+                            "repo": "flake-utils",
                             "type": "github"
                           }
                         },
                         "root": {
                           "inputs": {
-                            "nixpkgs": "nixpkgs"
+                            "flake-utils": "flake-utils"
+                          }
+                        },
+                        "systems": {
+                          "locked": {
+                            "lastModified": 1681028828,
+                            "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+                            "owner": "nix-systems",
+                            "repo": "default",
+                            "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+                            "type": "github"
+                          },
+                          "original": {
+                            "owner": "nix-systems",
+                            "repo": "default",
+                            "type": "github"
                           }
                         }
                       },
@@ -98,32 +118,24 @@ output:
                   operation: update
                   support_file: false
                   type: file
-            pr-title: Bump nixpkgs from `8b27c12` to `50ab793` in /nix
+            pr-title: Bump flake-utils from `c1dfcf0` to `11707dc` in /nix
             pr-body: |
-                Bumps [nixpkgs](https://github.com/NixOS/nixpkgs) from `8b27c12` to `50ab793`.
+                Bumps [flake-utils](https://github.com/numtide/flake-utils) from `c1dfcf0` to `11707dc`.
                 <details>
                 <summary>Commits</summary>
                 <ul>
-                <li><a href="https://github.com/NixOS/nixpkgs/commit/50ab793786d9de88ee30ec4e4c24fb4236fc2674"><code>50ab793</code></a> [24.11] Lix CVE-2025-46415 (critical) bug fixes (<a href="https://redirect.github.com/NixOS/nixpkgs/issues/421137">#421137</a>)</li>
-                <li><a href="https://github.com/NixOS/nixpkgs/commit/1d1ef5040b240dcee4769adc6943ba5af0adbb37"><code>1d1ef50</code></a> [Backport release-24.11] librewolf-unwrapped: 139.0.4-1 -&gt; 140.0.2-1 (<a href="https://redirect.github.com/NixOS/nixpkgs/issues/421086">#421086</a>)</li>
-                <li><a href="https://github.com/NixOS/nixpkgs/commit/b79ee9f063c5205184201cab03005036a8d466ec"><code>b79ee9f</code></a> lixVersions_2_91: patch for the critical correctness bug</li>
-                <li><a href="https://github.com/NixOS/nixpkgs/commit/dc92673fc043e800b76d12a80bfc0c27cfb7685c"><code>dc92673</code></a> [Backport release-24.11] ci/README.md: one sentence per line (<a href="https://redirect.github.com/NixOS/nixpkgs/issues/421097">#421097</a>)</li>
-                <li><a href="https://github.com/NixOS/nixpkgs/commit/3bcaebc6035750592b759f2ad3e8c009ba074520"><code>3bcaebc</code></a> .github/workflows/README.md: one sentence per line</li>
-                <li><a href="https://github.com/NixOS/nixpkgs/commit/11ccc438638e165b918d7a5f48748ec34086ba59"><code>11ccc43</code></a> ci/eval/README.md: one sentence per line</li>
-                <li><a href="https://github.com/NixOS/nixpkgs/commit/2e07c7808660e42ebfec4906ca9b76b88ed5e27b"><code>2e07c78</code></a> ci/README.md: one sentence per line</li>
-                <li><a href="https://github.com/NixOS/nixpkgs/commit/9ea8e31fefc452f94040d380974ac565b69c61e1"><code>9ea8e31</code></a> librewolf-unwrapped: 139.0.4-1 -&gt; 140.0.2-1</li>
-                <li><a href="https://github.com/NixOS/nixpkgs/commit/0ac77cd1ecb7504ee2ea66fa5bb40cf44eedf12d"><code>0ac77cd</code></a> [Backport release-24.11] nexus: mark as insecure and remove inactive maintain...</li>
-                <li><a href="https://github.com/NixOS/nixpkgs/commit/e062c07692562320c9625645b12bdd45e0b3cec0"><code>e062c07</code></a> nexus: mark as insecure and remove maintainers</li>
-                <li>Additional commits viewable in <a href="https://github.com/NixOS/nixpkgs/compare/8b27c1239e5c421a2bbc2c65d52e4a6fbf2ff296...50ab793786d9de88ee30ec4e4c24fb4236fc2674">compare view</a></li>
+                <li><a href="https://github.com/numtide/flake-utils/commit/11707dc2f618dd54ca8739b309ec4fc024de578b"><code>11707dc</code></a> README: add new logo (<a href="https://redirect.github.com/numtide/flake-utils/issues/120">#120</a>)</li>
+                <li>See full diff in <a href="https://github.com/numtide/flake-utils/compare/c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a...11707dc2f618dd54ca8739b309ec4fc024de578b">compare view</a></li>
                 </ul>
                 </details>
                 <br />
             commit-message: |-
-                Bump nixpkgs from `8b27c12` to `50ab793` in /nix
+                Bump flake-utils from `c1dfcf0` to `11707dc` in /nix
 
-                Bumps [nixpkgs](https://github.com/NixOS/nixpkgs) from `8b27c12` to `50ab793`.
-                - [Commits](https://github.com/NixOS/nixpkgs/compare/8b27c1239e5c421a2bbc2c65d52e4a6fbf2ff296...50ab793786d9de88ee30ec4e4c24fb4236fc2674)
+                Bumps [flake-utils](https://github.com/numtide/flake-utils) from `c1dfcf0` to `11707dc`.
+                - [Release notes](https://github.com/numtide/flake-utils/releases)
+                - [Commits](https://github.com/numtide/flake-utils/compare/c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a...11707dc2f618dd54ca8739b309ec4fc024de578b)
     - type: mark_as_processed
       expect:
         data:
-            base-commit-sha: 8d857a01c9c034aaf4bb100007479ab5f5a1c623
+            base-commit-sha: b23be6858f96a0d210331ef540f7c184d41a2ba8


### PR DESCRIPTION
Adds smoke test coverage for the two new nix update modes from dependabot/dependabot-core#14670 and dependabot/dependabot-core#14671.

Three tests, each covering a distinct scenario:
- `smoke-nix.yaml`: commit tracking (`numtide/flake-utils`, no ref). Only `flake.lock` changes.
- `smoke-nix-tag.yaml`: tag-pinned ref (`edolstra/flake-compat` v1.0.0 -> v1.0.1). Rewrites `flake.nix` and regenerates `flake.lock`.
- `smoke-nix-versioned-branch.yaml`: versioned branch (`NixOS/nixpkgs` nixos-24.05 -> nixos-25.11). Rewrites `flake.nix` and regenerates `flake.lock`.

The existing `smoke-nix.yaml` was pointing at `NixOS/nixpkgs` on `nixos-24.11`, which is now detected as a versioned branch (and was high churn). Swapped to `numtide/flake-utils` on `main` for a stable commit-tracking test.