### PR TITLE
Regenerate failing pip smoke tests

### DIFF
--- a/tests/smoke-python-pip-compile.yaml
+++ b/tests/smoke-python-pip-compile.yaml
@@ -186,13 +186,13 @@ output:
                     - file: requirements.in
                       groups:
                         - dependencies
-                      requirement: '>=3.1,<5.0'
+                      requirement: '>=4.0.6,<5.0'
                       source: null
                   version: 4.0.6
                   directory: /pip-compile
             updated-dependency-files:
                 - content: |
-                    django[argon2]>=3.1,<5.0
+                    django[argon2]>=4.0.6,<5.0
                     numpy==1.23.0
                   content_encoding: utf-8
                   deleted: false

--- a/tests/smoke-python-pip.yaml
+++ b/tests/smoke-python-pip.yaml
@@ -88,13 +88,13 @@ output:
                     - file: requirements.txt
                       groups:
                         - dependencies
-                      requirement: '>=3.1,<5.0'
+                      requirement: '>=4.0.6,<5.0'
                       source: null
                   version: 4.0.6
                   directory: /pip
             updated-dependency-files:
                 - content: |
-                    Django>=3.1,<5.0
+                    Django>=4.0.6,<5.0
                     requests[socks]==2.28.0
                     pyyaml
                     pytest
@@ -106,7 +106,7 @@ output:
                   operation: update
                   support_file: false
                   type: file
-            pr-title: Update django requirement from <4.0,>=3.1 to >=3.1,<5.0 in /pip
+            pr-title: Update django requirement from <4.0,>=3.1 to >=4.0.6,<5.0 in /pip
             pr-body: |
                 Updates the requirements on [django](https://github.com/django/django) to permit the latest version.
                 <details>
@@ -127,7 +127,7 @@ output:
                 </details>
                 <br />
             commit-message: |-
-                Update django requirement from <4.0,>=3.1 to >=3.1,<5.0 in /pip
+                Update django requirement from <4.0,>=3.1 to >=4.0.6,<5.0 in /pip
 
                 Updates the requirements on [django](https://github.com/django/django) to permit the latest version.
                 - [Commits](https://github.com/django/django/compare/3.1...4.0.6)

--- a/tests/smoke-python-poetry.yaml
+++ b/tests/smoke-python-poetry.yaml
@@ -148,18 +148,18 @@ output:
 
                     [[package]]
                     name = "idna"
-                    version = "3.11"
+                    version = "3.12"
                     description = "Internationalized Domain Names in Applications (IDNA)"
                     optional = false
                     python-versions = ">=3.8"
                     groups = ["main"]
                     files = [
-                        {file = "idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea"},
-                        {file = "idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"},
+                        {file = "idna-3.12-py3-none-any.whl", hash = "sha256:60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67"},
+                        {file = "idna-3.12.tar.gz", hash = "sha256:724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254"},
                     ]
 
                     [package.extras]
-                    all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
+                    all = ["mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
                     [[package]]
                     name = "numpy"
@@ -399,18 +399,18 @@ output:
 
                     [[package]]
                     name = "idna"
-                    version = "3.11"
+                    version = "3.12"
                     description = "Internationalized Domain Names in Applications (IDNA)"
                     optional = false
                     python-versions = ">=3.8"
                     groups = ["main"]
                     files = [
-                        {file = "idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea"},
-                        {file = "idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"},
+                        {file = "idna-3.12-py3-none-any.whl", hash = "sha256:60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67"},
+                        {file = "idna-3.12.tar.gz", hash = "sha256:724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254"},
                     ]
 
                     [package.extras]
-                    all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
+                    all = ["mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
                     [[package]]
                     name = "numpy"
@@ -751,18 +751,18 @@ output:
 
                     [[package]]
                     name = "idna"
-                    version = "3.11"
+                    version = "3.12"
                     description = "Internationalized Domain Names in Applications (IDNA)"
                     optional = false
                     python-versions = ">=3.8"
                     groups = ["main"]
                     files = [
-                        {file = "idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea"},
-                        {file = "idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"},
+                        {file = "idna-3.12-py3-none-any.whl", hash = "sha256:60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67"},
+                        {file = "idna-3.12.tar.gz", hash = "sha256:724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254"},
                     ]
 
                     [package.extras]
-                    all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
+                    all = ["mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
                     [[package]]
                     name = "numpy"
@@ -1168,18 +1168,18 @@ output:
 
                     [[package]]
                     name = "idna"
-                    version = "3.11"
+                    version = "3.12"
                     description = "Internationalized Domain Names in Applications (IDNA)"
                     optional = false
                     python-versions = ">=3.8"
                     groups = ["main"]
                     files = [
-                        {file = "idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea"},
-                        {file = "idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"},
+                        {file = "idna-3.12-py3-none-any.whl", hash = "sha256:60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67"},
+                        {file = "idna-3.12.tar.gz", hash = "sha256:724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254"},
                     ]
 
                     [package.extras]
-                    all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
+                    all = ["mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
                     [[package]]
                     name = "numpy"


### PR DESCRIPTION
This PR regenrates the following `pip` smoke tests which are failing on https://github.com/dependabot/dependabot-core/pull/14785.
 - smoke-python-pip-compile
 - smoke-python-pip
 - smoke-python-poetry