### PR TITLE
Stabilize poetry smoke fixture by ignoring transitive certifi and idna releases

### DIFF
--- a/tests/smoke-python-poetry.yaml
+++ b/tests/smoke-python-poetry.yaml
@@ -17,6 +17,9 @@ input:
             - dependency-name: requests
               source: tests/smoke-python-poetry.yaml
               version-requirement: '>2.32.3'
+            - dependency-name: certifi
+              source: tests/smoke-python-poetry.yaml
+              version-requirement: '>2026.2.25'
         source:
             provider: github
             repo: dependabot/smoke-tests

--- a/tests/smoke-python-poetry.yaml
+++ b/tests/smoke-python-poetry.yaml
@@ -20,6 +20,9 @@ input:
             - dependency-name: certifi
               source: tests/smoke-python-poetry.yaml
               version-requirement: '>2026.2.25'
+            - dependency-name: idna
+              source: tests/smoke-python-poetry.yaml
+              version-requirement: '>3.12'
         source:
             provider: github
             repo: dependabot/smoke-tests


### PR DESCRIPTION
## Summary
Add a certifi ignore condition to `smoke-python-poetry.yaml` so the Poetry smoke test remains deterministic when `certifi` and `idna` publish a new release.

## Why this is needed
This came up for my [dependabot-core PR](https://github.com/dependabot/dependabot-core/pull/14689) - the [e2e smoke tests were failing](https://github.com/dependabot/dependabot-core/actions/runs/24794490348/job/72560733557?pr=14689) because of `certifi` and `idna`. The smoke-python-poetry fixture currently pins lockfile content that includes `certifi` and `idna` artifacts.
When a new `certifi` or `idna` release appears on PyPI, Poetry can update that transitive dependency during unrelated updates (for example `requests`), which causes fixture expectation drift and smoke failures.

This failure mode is:
1. External to dependabot-core behavior.
2. Time-dependent (depends on registry state at run time).
3. Unrelated to the change under test.

In other words, the smoke test becomes flaky due to upstream package churn, not due to a regression in Dependabot logic.

## What changed
In `smoke-python-poetry.yaml`, under `input.job.ignore-conditions`, add:

1. `dependency-name: certifi`
2. `source: tests/smoke-python-poetry.yaml`
3. `version-requirement: '>2026.2.25'`
4. Repeat for `idna`

## Effect
This keeps the fixture stable by preventing transitive `certifi` and `idna` updates beyond the fixture’s pinned baseline while preserving coverage for the intended top-level updates in this smoke scenario.

## Scope
This change is intentionally narrow:

1. Only affects `smoke-python-poetry`.
2. Does not alter smoke workflow logic.
3. Does not change Dependabot updater behavior, only fixture policy for deterministic expectations.

## Validation
1. Confirmed fixture edit is limited to a single new ignore condition in `smoke-python-poetry.yaml`.
2. No other smoke fixtures were modified.