### PR TITLE
Remove broken ignore-conditions from nix smoke test

### DIFF
--- a/tests/smoke-nix.yaml
+++ b/tests/smoke-nix.yaml
@@ -6,10 +6,6 @@ input:
             - update-type: all
         experiments:
             enable_beta_ecosystems: true
-        ignore-conditions:
-            - dependency-name: flake-utils
-              source: result-nix.yaml
-              version-requirement: '>11707dc2f618dd54ca8739b309ec4fc024de578b'
         source:
             provider: github
             repo: dependabot/smoke-tests


### PR DESCRIPTION
The CLI auto-generates 'version-requirement: >SHA' ignore conditions, but nix uses git commit SHAs as versions which Ruby's Gem::Requirement cannot parse, causing test runs to fail. Without the ignore condition, the test relies on caching for stability.