### PR TITLE
Add opentofu smoke test

### DIFF
--- a/opentofu/main.tf
+++ b/opentofu/main.tf
@@ -1,0 +1,143 @@
+module "origin_label" {
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.7"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  name       = "${var.name}"
+  delimiter  = "${var.delimiter}"
+  attributes = ["${compact(concat(var.attributes, list("origin")))}"]
+  tags       = "${var.tags}"
+}
+
+resource "aws_cloudfront_origin_access_identity" "default" {
+  comment = "${module.distribution_label.id}"
+}
+
+module "logs" {
+  source                   = "github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.2.2"
+  namespace                = "${var.namespace}"
+  stage                    = "${var.stage}"
+  name                     = "${var.name}"
+  delimiter                = "${var.delimiter}"
+  attributes               = ["${compact(concat(var.attributes, list("origin", "logs")))}"]
+  tags                     = "${var.tags}"
+  prefix                   = "${var.log_prefix}"
+  standard_transition_days = "${var.log_standard_transition_days}"
+  glacier_transition_days  = "${var.log_glacier_transition_days}"
+  expiration_days          = "${var.log_expiration_days}"
+}
+
+module "distribution_label" {
+  source     = "github.com/cloudposse/terraform-null-label.git"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  name       = "${var.name}"
+  attributes = "${var.attributes}"
+  delimiter  = "${var.delimiter}"
+  tags       = "${var.tags}"
+}
+
+resource "aws_cloudfront_distribution" "default" {
+  enabled             = "${var.enabled}"
+  is_ipv6_enabled     = "${var.is_ipv6_enabled}"
+  comment             = "${var.comment}"
+  default_root_object = "${var.default_root_object}"
+  price_class         = "${var.price_class}"
+
+  logging_config = {
+    include_cookies = "${var.log_include_cookies}"
+    bucket          = "${module.logs.bucket_domain_name}"
+    prefix          = "${var.log_prefix}"
+  }
+
+  aliases = ["${var.aliases}"]
+
+  custom_error_response = ["${var.custom_error_response}"]
+
+  origin {
+    domain_name = "${var.origin_domain_name}"
+    origin_id   = "${module.distribution_label.id}"
+    origin_path = "${var.origin_path}"
+
+    custom_origin_config {
+      http_port                = "${var.origin_http_port}"
+      https_port               = "${var.origin_https_port}"
+      origin_protocol_policy   = "${var.origin_protocol_policy}"
+      origin_ssl_protocols     = "${var.origin_ssl_protocols}"
+      origin_keepalive_timeout = "${var.origin_keepalive_timeout}"
+      origin_read_timeout      = "${var.origin_read_timeout}"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn            = "${var.acm_certificate_arn}"
+    ssl_support_method             = "sni-only"
+    minimum_protocol_version       = "${var.viewer_minimum_protocol_version}"
+    cloudfront_default_certificate = "${var.acm_certificate_arn == "" ? true : false}"
+  }
+
+  default_cache_behavior {
+    allowed_methods  = "${var.allowed_methods}"
+    cached_methods   = "${var.cached_methods}"
+    target_origin_id = "${module.distribution_label.id}"
+    compress         = "${var.compress}"
+
+    forwarded_values {
+      headers = ["${var.forward_headers}"]
+
+      query_string = "${var.forward_query_string}"
+
+      cookies {
+        forward           = "${var.forward_cookies}"
+        whitelisted_names = ["${var.forward_cookies_whitelisted_names}"]
+      }
+    }
+
+    viewer_protocol_policy = "${var.viewer_protocol_policy}"
+    default_ttl            = "${var.default_ttl}"
+    min_ttl                = "${var.min_ttl}"
+    max_ttl                = "${var.max_ttl}"
+  }
+
+  cache_behavior = "${var.cache_behavior}"
+
+  web_acl_id = "${var.web_acl_id}"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "${var.geo_restriction_type}"
+      locations        = "${var.geo_restriction_locations}"
+    }
+  }
+
+  tags = "${module.distribution_label.tags}"
+}
+
+module "dns" {
+  source           = "git::https://github.com/cloudposse/terraform-cloudflare-zone.git//some/dir?ref=tags/0.2.5"
+  enabled          = "${var.dns_aliases_enabled}"
+  aliases          = "${var.aliases}"
+  parent_zone_id   = "${var.parent_zone_id}"
+  parent_zone_name = "${var.parent_zone_name}"
+  target_dns_name  = "${aws_cloudfront_distribution.default.domain_name}"
+  target_zone_id   = "${aws_cloudfront_distribution.default.hosted_zone_id}"
+}
+
+module "duplicate_label" {
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.7"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  name       = "${var.name}"
+  delimiter  = "${var.delimiter}"
+  attributes = ["${compact(concat(var.attributes, list("origin")))}"]
+  tags       = "${var.tags}"
+}
+
+module "github_ssh_without_protocol" {
+  source     = "git@github.com:cloudposse/terraform-aws-jenkins.git?ref=tags/0.4.0//some/dir"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  name       = "${var.name}"
+  delimiter  = "${var.delimiter}"
+  attributes = ["${compact(concat(var.attributes, list("origin")))}"]
+  tags       = "${var.tags}"
+}

--- a/tests/smoke-opentofu.yaml
+++ b/tests/smoke-opentofu.yaml
@@ -1,0 +1,1187 @@
+input:
+    job:
+        command: update
+        package-manager: opentofu
+        allowed-updates:
+            - update-type: all
+        ignore-conditions:
+            - dependency-name: duplicate_label::github::cloudposse/terraform-null-label::tags/0.3.7
+              source: tests/smoke-opentofu.yaml
+              version-requirement: '>0.25.0'
+            - dependency-name: github_ssh_without_protocol::github::cloudposse/terraform-aws-jenkins::tags/0.4.0
+              source: tests/smoke-opentofu.yaml
+              version-requirement: '>0.10.6'
+            - dependency-name: logs::github::cloudposse/terraform-aws-s3-log-storage::tags/0.2.2
+              source: tests/smoke-opentofu.yaml
+              version-requirement: '>0.28.0'
+            - dependency-name: origin_label::github::cloudposse/terraform-null-label::tags/0.3.7
+              source: tests/smoke-opentofu.yaml
+              version-requirement: '>0.25.0'
+        source:
+            provider: github
+            repo: dependabot/smoke-tests
+            directory: /opentofu
+            commit: adcc01bd94c8f9c6a9774b79782f02ef27bf8927
+    credentials:
+        - host: github.com
+          password: $LOCAL_GITHUB_ACCESS_TOKEN
+          type: git_source
+          username: x-access-token
+output:
+    - type: update_dependency_list
+      expect:
+        data:
+            dependencies:
+                - name: distribution_label::github::cloudposse/terraform-null-label
+                  requirements:
+                    - file: main.tf
+                      groups: []
+                      requirement: null
+                      source:
+                        branch: null
+                        ref: null
+                        type: git
+                        url: https://github.com/cloudposse/terraform-null-label.git
+                  version: null
+                - name: dns::github::cloudposse/terraform-cloudflare-zone::tags/0.2.5
+                  requirements:
+                    - file: main.tf
+                      groups: []
+                      requirement: null
+                      source:
+                        branch: null
+                        ref: tags/0.2.5
+                        type: git
+                        url: https://github.com/cloudposse/terraform-cloudflare-zone.git
+                  version: 0.2.5
+                - name: duplicate_label::github::cloudposse/terraform-null-label::tags/0.3.7
+                  requirements:
+                    - file: main.tf
+                      groups: []
+                      requirement: null
+                      source:
+                        branch: null
+                        ref: tags/0.3.7
+                        type: git
+                        url: https://github.com/cloudposse/terraform-null-label.git
+                  version: 0.3.7
+                - name: github_ssh_without_protocol::github::cloudposse/terraform-aws-jenkins::tags/0.4.0
+                  requirements:
+                    - file: main.tf
+                      groups: []
+                      requirement: null
+                      source:
+                        branch: null
+                        ref: tags/0.4.0
+                        type: git
+                        url: git@github.com:cloudposse/terraform-aws-jenkins.git
+                  version: 0.4.0
+                - name: logs::github::cloudposse/terraform-aws-s3-log-storage::tags/0.2.2
+                  requirements:
+                    - file: main.tf
+                      groups: []
+                      requirement: null
+                      source:
+                        branch: null
+                        ref: tags/0.2.2
+                        type: git
+                        url: https://github.com/cloudposse/terraform-aws-s3-log-storage.git
+                  version: 0.2.2
+                - name: origin_label::github::cloudposse/terraform-null-label::tags/0.3.7
+                  requirements:
+                    - file: main.tf
+                      groups: []
+                      requirement: null
+                      source:
+                        branch: null
+                        ref: tags/0.3.7
+                        type: git
+                        url: https://github.com/cloudposse/terraform-null-label.git
+                  version: 0.3.7
+            dependency_files:
+                - /opentofu/main.tf
+    - type: create_pull_request
+      expect:
+        data:
+            base-commit-sha: e97f61f9fd7b34f24e246c13b64621e71f7a390e
+            dependencies:
+                - name: dns::github::cloudposse/terraform-cloudflare-zone::tags/0.2.5
+                  previous-requirements:
+                    - file: main.tf
+                      groups: []
+                      requirement: null
+                      source:
+                        branch: null
+                        ref: tags/0.2.5
+                        type: git
+                        url: https://github.com/cloudposse/terraform-cloudflare-zone.git
+                  previous-version: 0.2.5
+                  requirements:
+                    - file: main.tf
+                      groups: []
+                      requirement: null
+                      source:
+                        branch: null
+                        ref: tags/v1.0.1
+                        type: git
+                        url: https://github.com/cloudposse/terraform-cloudflare-zone.git
+                  version: 1.0.1
+                  directory: /opentofu
+            updated-dependency-files:
+                - content: |
+                    module "origin_label" {
+                      source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.7"
+                      namespace  = "${var.namespace}"
+                      stage      = "${var.stage}"
+                      name       = "${var.name}"
+                      delimiter  = "${var.delimiter}"
+                      attributes = ["${compact(concat(var.attributes, list("origin")))}"]
+                      tags       = "${var.tags}"
+                    }
+
+                    resource "aws_cloudfront_origin_access_identity" "default" {
+                      comment = "${module.distribution_label.id}"
+                    }
+
+                    module "logs" {
+                      source                   = "github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.2.2"
+                      namespace                = "${var.namespace}"
+                      stage                    = "${var.stage}"
+                      name                     = "${var.name}"
+                      delimiter                = "${var.delimiter}"
+                      attributes               = ["${compact(concat(var.attributes, list("origin", "logs")))}"]
+                      tags                     = "${var.tags}"
+                      prefix                   = "${var.log_prefix}"
+                      standard_transition_days = "${var.log_standard_transition_days}"
+                      glacier_transition_days  = "${var.log_glacier_transition_days}"
+                      expiration_days          = "${var.log_expiration_days}"
+                    }
+
+                    module "distribution_label" {
+                      source     = "github.com/cloudposse/terraform-null-label.git"
+                      namespace  = "${var.namespace}"
+                      stage      = "${var.stage}"
+                      name       = "${var.name}"
+                      attributes = "${var.attributes}"
+                      delimiter  = "${var.delimiter}"
+                      tags       = "${var.tags}"
+                    }
+
+                    resource "aws_cloudfront_distribution" "default" {
+                      enabled             = "${var.enabled}"
+                      is_ipv6_enabled     = "${var.is_ipv6_enabled}"
+                      comment             = "${var.comment}"
+                      default_root_object = "${var.default_root_object}"
+                      price_class         = "${var.price_class}"
+
+                      logging_config = {
+                        include_cookies = "${var.log_include_cookies}"
+                        bucket          = "${module.logs.bucket_domain_name}"
+                        prefix          = "${var.log_prefix}"
+                      }
+
+                      aliases = ["${var.aliases}"]
+
+                      custom_error_response = ["${var.custom_error_response}"]
+
+                      origin {
+                        domain_name = "${var.origin_domain_name}"
+                        origin_id   = "${module.distribution_label.id}"
+                        origin_path = "${var.origin_path}"
+
+                        custom_origin_config {
+                          http_port                = "${var.origin_http_port}"
+                          https_port               = "${var.origin_https_port}"
+                          origin_protocol_policy   = "${var.origin_protocol_policy}"
+                          origin_ssl_protocols     = "${var.origin_ssl_protocols}"
+                          origin_keepalive_timeout = "${var.origin_keepalive_timeout}"
+                          origin_read_timeout      = "${var.origin_read_timeout}"
+                        }
+                      }
+
+                      viewer_certificate {
+                        acm_certificate_arn            = "${var.acm_certificate_arn}"
+                        ssl_support_method             = "sni-only"
+                        minimum_protocol_version       = "${var.viewer_minimum_protocol_version}"
+                        cloudfront_default_certificate = "${var.acm_certificate_arn == "" ? true : false}"
+                      }
+
+                      default_cache_behavior {
+                        allowed_methods  = "${var.allowed_methods}"
+                        cached_methods   = "${var.cached_methods}"
+                        target_origin_id = "${module.distribution_label.id}"
+                        compress         = "${var.compress}"
+
+                        forwarded_values {
+                          headers = ["${var.forward_headers}"]
+
+                          query_string = "${var.forward_query_string}"
+
+                          cookies {
+                            forward           = "${var.forward_cookies}"
+                            whitelisted_names = ["${var.forward_cookies_whitelisted_names}"]
+                          }
+                        }
+
+                        viewer_protocol_policy = "${var.viewer_protocol_policy}"
+                        default_ttl            = "${var.default_ttl}"
+                        min_ttl                = "${var.min_ttl}"
+                        max_ttl                = "${var.max_ttl}"
+                      }
+
+                      cache_behavior = "${var.cache_behavior}"
+
+                      web_acl_id = "${var.web_acl_id}"
+
+                      restrictions {
+                        geo_restriction {
+                          restriction_type = "${var.geo_restriction_type}"
+                          locations        = "${var.geo_restriction_locations}"
+                        }
+                      }
+
+                      tags = "${module.distribution_label.tags}"
+                    }
+
+                    module "dns" {
+                      source           = "git::https://github.com/cloudposse/terraform-cloudflare-zone.git//some/dir?ref=tags/v1.0.1"
+                      enabled          = "${var.dns_aliases_enabled}"
+                      aliases          = "${var.aliases}"
+                      parent_zone_id   = "${var.parent_zone_id}"
+                      parent_zone_name = "${var.parent_zone_name}"
+                      target_dns_name  = "${aws_cloudfront_distribution.default.domain_name}"
+                      target_zone_id   = "${aws_cloudfront_distribution.default.hosted_zone_id}"
+                    }
+
+                    module "duplicate_label" {
+                      source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.7"
+                      namespace  = "${var.namespace}"
+                      stage      = "${var.stage}"
+                      name       = "${var.name}"
+                      delimiter  = "${var.delimiter}"
+                      attributes = ["${compact(concat(var.attributes, list("origin")))}"]
+                      tags       = "${var.tags}"
+                    }
+
+                    module "github_ssh_without_protocol" {
+                      source     = "git@github.com:cloudposse/terraform-aws-jenkins.git?ref=tags/0.4.0//some/dir"
+                      namespace  = "${var.namespace}"
+                      stage      = "${var.stage}"
+                      name       = "${var.name}"
+                      delimiter  = "${var.delimiter}"
+                      attributes = ["${compact(concat(var.attributes, list("origin")))}"]
+                      tags       = "${var.tags}"
+                    }
+                  content_encoding: utf-8
+                  deleted: false
+                  directory: /opentofu
+                  name: main.tf
+                  operation: update
+                  support_file: false
+                  type: file
+            pr-title: Bump dns::terraform-cloudflare-zone from 0.2.5 to 1.0.1 in /opentofu
+            pr-body: "Bumps [dns::terraform-cloudflare-zone](https://github.com/cloudposse/terraform-cloudflare-zone) from 0.2.5 to 1.0.1.\n<details>\n<summary>Release notes</summary>\n<p><em>Sourced from <a href=\"https://github.com/cloudposse/terraform-cloudflare-zone/releases\">dns::terraform-cloudflare-zone's releases</a>.</em></p>\n<blockquote>\n<h2>v1.0.1</h2>\n<!-- raw HTML omitted -->\n<h2>\U0001F916 Automatic Updates</h2>\n<!-- raw HTML omitted -->\n<h2>why</h2>\n<ul>\n<li>Re-apply <code>.github/settings.yml</code> from org level</li>\n<li>Use organization level auto-release settings</li>\n</ul>\n<h2>references</h2>\n<ul>\n<li>DEV-1242 Add protected tags with Repository Rulesets on GitHub</li>\n</ul>\n<!-- raw HTML omitted -->\n<h2>v1.0.0</h2>\n<!-- raw HTML omitted -->\n<h2>Remove deprecated filter and firewall resources</h2>\n<h2>what</h2>\n<p>Support for the following resources, which are deprecated, are removed from this module.</p>\n<ul>\n<li>cloudflare_firewall_rule</li>\n<li>cloudflare_filter</li>\n</ul>\n<h2>why</h2>\n<p>Cloudflare converted existing <a href=\"https://developers.cloudflare.com/firewall/\">firewall rules</a> into <a href=\"https://developers.cloudflare.com/waf/custom-rules/\">WAF custom rules</a></p>\n<blockquote>\n<p>The <a href=\"https://developers.cloudflare.com/firewall/api/cf-firewall-rules/\">Firewall Rules API</a> and the associated <a href=\"https://developers.cloudflare.com/firewall/api/cf-filters/\">Cloudflare Filters API</a> are now deprecated. These APIs will stop working on 2024-07-01</p>\n</blockquote>\n<blockquote>\n<h4><a href=\"https://developers.cloudflare.com/waf/reference/migration-guides/firewall-rules-to-custom-rules/#relevant-changes-for-terraform-users\">Relevant changes for Terraform users</a></h4>\n<p>The following Terraform resources from the Cloudflare provider are now deprecated:\n* cloudflare_firewall_rule\n* cloudflare_filter</p>\n</blockquote>\n<!-- raw HTML omitted -->\n</blockquote>\n<p>... (truncated)</p>\n</details>\n<details>\n<summary>Commits</summary>\n<ul>\n<li>See full diff in <a href=\"https://github.com/cloudposse/terraform-cloudflare-zone/compare/tags/0.2.5...tags/v1.0.1\">compare view</a></li>\n</ul>\n</details>\n<br />\n"
+            commit-message: |-
+                Bump dns::terraform-cloudflare-zone from 0.2.5 to 1.0.1 in /opentofu
+
+                Bumps [dns::terraform-cloudflare-zone](https://github.com/cloudposse/terraform-cloudflare-zone) from 0.2.5 to 1.0.1.
+                - [Release notes](https://github.com/cloudposse/terraform-cloudflare-zone/releases)
+                - [Commits](https://github.com/cloudposse/terraform-cloudflare-zone/compare/tags/0.2.5...tags/v1.0.1)
+    - type: create_pull_request
+      expect:
+        data:
+            base-commit-sha: e97f61f9fd7b34f24e246c13b64621e71f7a390e
+            dependencies:
+                - name: duplicate_label::github::cloudposse/terraform-null-label::tags/0.3.7
+                  previous-requirements:
+                    - file: main.tf
+                      groups: []
+                      requirement: null
+                      source:
+                        branch: null
+                        ref: tags/0.3.7
+                        type: git
+                        url: https://github.com/cloudposse/terraform-null-label.git
+                  previous-version: 0.3.7
+                  requirements:
+                    - file: main.tf
+                      groups: []
+                      requirement: null
+                      source:
+                        branch: null
+                        ref: tags/0.25.0
+                        type: git
+                        url: https://github.com/cloudposse/terraform-null-label.git
+                  version: 0.25.0
+                  directory: /opentofu
+            updated-dependency-files:
+                - content: |
+                    module "origin_label" {
+                      source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.7"
+                      namespace  = "${var.namespace}"
+                      stage      = "${var.stage}"
+                      name       = "${var.name}"
+                      delimiter  = "${var.delimiter}"
+                      attributes = ["${compact(concat(var.attributes, list("origin")))}"]
+                      tags       = "${var.tags}"
+                    }
+
+                    resource "aws_cloudfront_origin_access_identity" "default" {
+                      comment = "${module.distribution_label.id}"
+                    }
+
+                    module "logs" {
+                      source                   = "github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.2.2"
+                      namespace                = "${var.namespace}"
+                      stage                    = "${var.stage}"
+                      name                     = "${var.name}"
+                      delimiter                = "${var.delimiter}"
+                      attributes               = ["${compact(concat(var.attributes, list("origin", "logs")))}"]
+                      tags                     = "${var.tags}"
+                      prefix                   = "${var.log_prefix}"
+                      standard_transition_days = "${var.log_standard_transition_days}"
+                      glacier_transition_days  = "${var.log_glacier_transition_days}"
+                      expiration_days          = "${var.log_expiration_days}"
+                    }
+
+                    module "distribution_label" {
+                      source     = "github.com/cloudposse/terraform-null-label.git"
+                      namespace  = "${var.namespace}"
+                      stage      = "${var.stage}"
+                      name       = "${var.name}"
+                      attributes = "${var.attributes}"
+                      delimiter  = "${var.delimiter}"
+                      tags       = "${var.tags}"
+                    }
+
+                    resource "aws_cloudfront_distribution" "default" {
+                      enabled             = "${var.enabled}"
+                      is_ipv6_enabled     = "${var.is_ipv6_enabled}"
+                      comment             = "${var.comment}"
+                      default_root_object = "${var.default_root_object}"
+                      price_class         = "${var.price_class}"
+
+                      logging_config = {
+                        include_cookies = "${var.log_include_cookies}"
+                        bucket          = "${module.logs.bucket_domain_name}"
+                        prefix          = "${var.log_prefix}"
+                      }
+
+                      aliases = ["${var.aliases}"]
+
+                      custom_error_response = ["${var.custom_error_response}"]
+
+                      origin {
+                        domain_name = "${var.origin_domain_name}"
+                        origin_id   = "${module.distribution_label.id}"
+                        origin_path = "${var.origin_path}"
+
+                        custom_origin_config {
+                          http_port                = "${var.origin_http_port}"
+                          https_port               = "${var.origin_https_port}"
+                          origin_protocol_policy   = "${var.origin_protocol_policy}"
+                          origin_ssl_protocols     = "${var.origin_ssl_protocols}"
+                          origin_keepalive_timeout = "${var.origin_keepalive_timeout}"
+                          origin_read_timeout      = "${var.origin_read_timeout}"
+                        }
+                      }
+
+                      viewer_certificate {
+                        acm_certificate_arn            = "${var.acm_certificate_arn}"
+                        ssl_support_method             = "sni-only"
+                        minimum_protocol_version       = "${var.viewer_minimum_protocol_version}"
+                        cloudfront_default_certificate = "${var.acm_certificate_arn == "" ? true : false}"
+                      }
+
+                      default_cache_behavior {
+                        allowed_methods  = "${var.allowed_methods}"
+                        cached_methods   = "${var.cached_methods}"
+                        target_origin_id = "${module.distribution_label.id}"
+                        compress         = "${var.compress}"
+
+                        forwarded_values {
+                          headers = ["${var.forward_headers}"]
+
+                          query_string = "${var.forward_query_string}"
+
+                          cookies {
+                            forward           = "${var.forward_cookies}"
+                            whitelisted_names = ["${var.forward_cookies_whitelisted_names}"]
+                          }
+                        }
+
+                        viewer_protocol_policy = "${var.viewer_protocol_policy}"
+                        default_ttl            = "${var.default_ttl}"
+                        min_ttl                = "${var.min_ttl}"
+                        max_ttl                = "${var.max_ttl}"
+                      }
+
+                      cache_behavior = "${var.cache_behavior}"
+
+                      web_acl_id = "${var.web_acl_id}"
+
+                      restrictions {
+                        geo_restriction {
+                          restriction_type = "${var.geo_restriction_type}"
+                          locations        = "${var.geo_restriction_locations}"
+                        }
+                      }
+
+                      tags = "${module.distribution_label.tags}"
+                    }
+
+                    module "dns" {
+                      source           = "git::https://github.com/cloudposse/terraform-cloudflare-zone.git//some/dir?ref=tags/0.2.5"
+                      enabled          = "${var.dns_aliases_enabled}"
+                      aliases          = "${var.aliases}"
+                      parent_zone_id   = "${var.parent_zone_id}"
+                      parent_zone_name = "${var.parent_zone_name}"
+                      target_dns_name  = "${aws_cloudfront_distribution.default.domain_name}"
+                      target_zone_id   = "${aws_cloudfront_distribution.default.hosted_zone_id}"
+                    }
+
+                    module "duplicate_label" {
+                      source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.25.0"
+                      namespace  = "${var.namespace}"
+                      stage      = "${var.stage}"
+                      name       = "${var.name}"
+                      delimiter  = "${var.delimiter}"
+                      attributes = ["${compact(concat(var.attributes, list("origin")))}"]
+                      tags       = "${var.tags}"
+                    }
+
+                    module "github_ssh_without_protocol" {
+                      source     = "git@github.com:cloudposse/terraform-aws-jenkins.git?ref=tags/0.4.0//some/dir"
+                      namespace  = "${var.namespace}"
+                      stage      = "${var.stage}"
+                      name       = "${var.name}"
+                      delimiter  = "${var.delimiter}"
+                      attributes = ["${compact(concat(var.attributes, list("origin")))}"]
+                      tags       = "${var.tags}"
+                    }
+                  content_encoding: utf-8
+                  deleted: false
+                  directory: /opentofu
+                  name: main.tf
+                  operation: update
+                  support_file: false
+                  type: file
+            pr-title: Bump duplicate_label::terraform-null-label from 0.3.7 to 0.25.0 in /opentofu
+            pr-body: |
+                Bumps [duplicate_label::terraform-null-label](https://github.com/cloudposse/terraform-null-label) from 0.3.7 to 0.25.0.
+                <details>
+                <summary>Release notes</summary>
+                <p><em>Sourced from <a href="https://github.com/cloudposse/terraform-null-label/releases">duplicate_label::terraform-null-label's releases</a>.</em></p>
+                <blockquote>
+                <h2>v0.25.0</h2>
+                <!-- raw HTML omitted -->
+                <h2>what</h2>
+                <ul>
+                <li>Add additional label and <code>id</code> component: <code>tenant</code></li>
+                <li>New input <code>labels_as_tags</code> controls which labels are exported as tags</li>
+                <li>New input <code>descriptor_formats</code> generates new output <code>descriptors</code></li>
+                <li>Update README, remove link to obsolete <code>terraform-terraform-label</code></li>
+                </ul>
+                <h2>why</h2>
+                <ul>
+                <li>Support users that host resources on behalf of and/or dedicated to single customers</li>
+                <li>Supersedes and closes <a href="https://redirect.github.com/cloudposse/terraform-null-label/issues/131">#131</a>, giving people control over which tags the module generates</li>
+                <li>Simple mechanism for creating multiple identifiers from the same inputs, reducing the need to create multiple instances of <code>null-label</code></li>
+                <li>Document <code>tenant</code>, <code>labels_as_tags</code>, <code>descriptor_formats</code>, add additional clarification, stop promoting obsolete module</li>
+                </ul>
+                <!-- raw HTML omitted -->
+                <!-- raw HTML omitted -->
+                <h2>what</h2>
+                <ul>
+                <li>Update README snippets to reflect use of Terraform Registry.</li>
+                </ul>
+                <h2>why</h2>
+                <ul>
+                <li>Including snippets that reflect use of the Terraform Registry make it easier for users to quickly instantiate a null_label module.</li>
+                <li>README is out of date and does not include snippets that reflect use of the Terraform Registry.</li>
+                </ul>
+                <h2>references</h2>
+                <ul>
+                <li>N/A</li>
+                </ul>
+                <!-- raw HTML omitted -->
+                <!-- raw HTML omitted -->
+                <h2>what</h2>
+                <ul>
+                <li>Resolve Bridgecrew compliance complaint about example Autoscaling Group (BC_AWS_GENERAL_31)</li>
+                <li>Fix typo in README</li>
+                <li>Include Terraform lock file in <code>.gitignore</code></li>
+                </ul>
+                <h2>why</h2>
+                <ul>
+                <li>Get clean Bridgecrew badge</li>
+                <li>Correct confusing error</li>
+                <li>Ensure lock files are not checked into GitHub</li>
+                </ul>
+                <h2>note</h2>
+                <p>The PR can and should be merged into <code>master</code> to update README and Bridgecrew without triggering a new release/version. These changes have no effect on the actual module in use and a release will create unnecessary ripple effects. However, merging to <code>master</code> will update the README and badges, so is worthwhile, and the changes will move forward into the next release.</p>
+                <!-- raw HTML omitted -->
+                </blockquote>
+                <p>... (truncated)</p>
+                </details>
+                <details>
+                <summary>Commits</summary>
+                <ul>
+                <li><a href="https://github.com/cloudposse/terraform-null-label/commit/488ab91e34a24a86957e397d9f7262ec5925586a"><code>488ab91</code></a> Properly output descriptors of chained modules (<a href="https://redirect.github.com/cloudposse/terraform-null-label/issues/133">#133</a>)</li>
+                <li><a href="https://github.com/cloudposse/terraform-null-label/commit/503f50c2fbf6974eee8091220ee3c246ba035931"><code>503f50c</code></a> Add &quot;tenant&quot;, &quot;labels_as_tags&quot;, and &quot;descriptors&quot; (<a href="https://redirect.github.com/cloudposse/terraform-null-label/issues/132">#132</a>)</li>
+                <li><a href="https://github.com/cloudposse/terraform-null-label/commit/2428b46ab57e4a93de5b942eb6a279ac89ec9b85"><code>2428b46</code></a> Fix: Update README Snippets (<a href="https://redirect.github.com/cloudposse/terraform-null-label/issues/130">#130</a>)</li>
+                <li><a href="https://github.com/cloudposse/terraform-null-label/commit/cf38625a5dde227db04c9cfedc1327d610229fec"><code>cf38625</code></a> Bridgecrew compliance (<a href="https://redirect.github.com/cloudposse/terraform-null-label/issues/125">#125</a>)</li>
+                <li><a href="https://github.com/cloudposse/terraform-null-label/commit/dc699992922b452ccc521c3dfe9c9c5c1f8376af"><code>dc69999</code></a> Copy validation to exports/context.tf (<a href="https://redirect.github.com/cloudposse/terraform-null-label/issues/123">#123</a>)</li>
+                <li><a href="https://github.com/cloudposse/terraform-null-label/commit/3a7014c622571cbbbe0daf270d1d8c9d1f2cbb3f"><code>3a7014c</code></a> Include updates to exports/context.tf (<a href="https://redirect.github.com/cloudposse/terraform-null-label/issues/122">#122</a>)</li>
+                <li><a href="https://github.com/cloudposse/terraform-null-label/commit/2de8bb4edf38c5ccc17969774cc853e2dfc36df7"><code>2de8bb4</code></a> Restore backward compatibility with v0.22.1 and earlier (<a href="https://redirect.github.com/cloudposse/terraform-null-label/issues/121">#121</a>)</li>
+                <li><a href="https://github.com/cloudposse/terraform-null-label/commit/6a7c42ef2105764b96d97e7d9ab9578dd1d83dd5"><code>6a7c42e</code></a> feat: add support for choosing letter case of context tags (<a href="https://redirect.github.com/cloudposse/terraform-null-label/issues/107">#107</a>)</li>
+                <li><a href="https://github.com/cloudposse/terraform-null-label/commit/f145d2a07da722f988ba6845737c3f2c1d55e476"><code>f145d2a</code></a> Add var.attributes to end of context.attributes, not vice versa (<a href="https://redirect.github.com/cloudposse/terraform-null-label/issues/114">#114</a>)</li>
+                <li><a href="https://github.com/cloudposse/terraform-null-label/commit/3861091c159d77115703b43cb88a47f6ee6a6191"><code>3861091</code></a> Restore &quot;this&quot; name (<a href="https://redirect.github.com/cloudposse/terraform-null-label/issues/111">#111</a>)</li>
+                <li>Additional commits viewable in <a href="https://github.com/cloudposse/terraform-null-label/compare/tags/0.3.7...tags/0.25.0">compare view</a></li>
+                </ul>
+                </details>
+                <br />
+            commit-message: |-
+                Bump duplicate_label::terraform-null-label in /opentofu
+
+                Bumps [duplicate_label::terraform-null-label](https://github.com/cloudposse/terraform-null-label) from 0.3.7 to 0.25.0.
+                - [Release notes](https://github.com/cloudposse/terraform-null-label/releases)
+                - [Commits](https://github.com/cloudposse/terraform-null-label/compare/tags/0.3.7...tags/0.25.0)
+    - type: create_pull_request
+      expect:
+        data:
+            base-commit-sha: e97f61f9fd7b34f24e246c13b64621e71f7a390e
+            dependencies:
+                - name: github_ssh_without_protocol::github::cloudposse/terraform-aws-jenkins::tags/0.4.0
+                  previous-requirements:
+                    - file: main.tf
+                      groups: []
+                      requirement: null
+                      source:
+                        branch: null
+                        ref: tags/0.4.0
+                        type: git
+                        url: git@github.com:cloudposse/terraform-aws-jenkins.git
+                  previous-version: 0.4.0
+                  requirements:
+                    - file: main.tf
+                      groups: []
+                      requirement: null
+                      source:
+                        branch: null
+                        ref: tags/0.10.6
+                        type: git
+                        url: git@github.com:cloudposse/terraform-aws-jenkins.git
+                  version: 0.10.6
+                  directory: /opentofu
+            updated-dependency-files:
+                - content: |
+                    module "origin_label" {
+                      source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.7"
+                      namespace  = "${var.namespace}"
+                      stage      = "${var.stage}"
+                      name       = "${var.name}"
+                      delimiter  = "${var.delimiter}"
+                      attributes = ["${compact(concat(var.attributes, list("origin")))}"]
+                      tags       = "${var.tags}"
+                    }
+
+                    resource "aws_cloudfront_origin_access_identity" "default" {
+                      comment = "${module.distribution_label.id}"
+                    }
+
+                    module "logs" {
+                      source                   = "github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.2.2"
+                      namespace                = "${var.namespace}"
+                      stage                    = "${var.stage}"
+                      name                     = "${var.name}"
+                      delimiter                = "${var.delimiter}"
+                      attributes               = ["${compact(concat(var.attributes, list("origin", "logs")))}"]
+                      tags                     = "${var.tags}"
+                      prefix                   = "${var.log_prefix}"
+                      standard_transition_days = "${var.log_standard_transition_days}"
+                      glacier_transition_days  = "${var.log_glacier_transition_days}"
+                      expiration_days          = "${var.log_expiration_days}"
+                    }
+
+                    module "distribution_label" {
+                      source     = "github.com/cloudposse/terraform-null-label.git"
+                      namespace  = "${var.namespace}"
+                      stage      = "${var.stage}"
+                      name       = "${var.name}"
+                      attributes = "${var.attributes}"
+                      delimiter  = "${var.delimiter}"
+                      tags       = "${var.tags}"
+                    }
+
+                    resource "aws_cloudfront_distribution" "default" {
+                      enabled             = "${var.enabled}"
+                      is_ipv6_enabled     = "${var.is_ipv6_enabled}"
+                      comment             = "${var.comment}"
+                      default_root_object = "${var.default_root_object}"
+                      price_class         = "${var.price_class}"
+
+                      logging_config = {
+                        include_cookies = "${var.log_include_cookies}"
+                        bucket          = "${module.logs.bucket_domain_name}"
+                        prefix          = "${var.log_prefix}"
+                      }
+
+                      aliases = ["${var.aliases}"]
+
+                      custom_error_response = ["${var.custom_error_response}"]
+
+                      origin {
+                        domain_name = "${var.origin_domain_name}"
+                        origin_id   = "${module.distribution_label.id}"
+                        origin_path = "${var.origin_path}"
+
+                        custom_origin_config {
+                          http_port                = "${var.origin_http_port}"
+                          https_port               = "${var.origin_https_port}"
+                          origin_protocol_policy   = "${var.origin_protocol_policy}"
+                          origin_ssl_protocols     = "${var.origin_ssl_protocols}"
+                          origin_keepalive_timeout = "${var.origin_keepalive_timeout}"
+                          origin_read_timeout      = "${var.origin_read_timeout}"
+                        }
+                      }
+
+                      viewer_certificate {
+                        acm_certificate_arn            = "${var.acm_certificate_arn}"
+                        ssl_support_method             = "sni-only"
+                        minimum_protocol_version       = "${var.viewer_minimum_protocol_version}"
+                        cloudfront_default_certificate = "${var.acm_certificate_arn == "" ? true : false}"
+                      }
+
+                      default_cache_behavior {
+                        allowed_methods  = "${var.allowed_methods}"
+                        cached_methods   = "${var.cached_methods}"
+                        target_origin_id = "${module.distribution_label.id}"
+                        compress         = "${var.compress}"
+
+                        forwarded_values {
+                          headers = ["${var.forward_headers}"]
+
+                          query_string = "${var.forward_query_string}"
+
+                          cookies {
+                            forward           = "${var.forward_cookies}"
+                            whitelisted_names = ["${var.forward_cookies_whitelisted_names}"]
+                          }
+                        }
+
+                        viewer_protocol_policy = "${var.viewer_protocol_policy}"
+                        default_ttl            = "${var.default_ttl}"
+                        min_ttl                = "${var.min_ttl}"
+                        max_ttl                = "${var.max_ttl}"
+                      }
+
+                      cache_behavior = "${var.cache_behavior}"
+
+                      web_acl_id = "${var.web_acl_id}"
+
+                      restrictions {
+                        geo_restriction {
+                          restriction_type = "${var.geo_restriction_type}"
+                          locations        = "${var.geo_restriction_locations}"
+                        }
+                      }
+
+                      tags = "${module.distribution_label.tags}"
+                    }
+
+                    module "dns" {
+                      source           = "git::https://github.com/cloudposse/terraform-cloudflare-zone.git//some/dir?ref=tags/0.2.5"
+                      enabled          = "${var.dns_aliases_enabled}"
+                      aliases          = "${var.aliases}"
+                      parent_zone_id   = "${var.parent_zone_id}"
+                      parent_zone_name = "${var.parent_zone_name}"
+                      target_dns_name  = "${aws_cloudfront_distribution.default.domain_name}"
+                      target_zone_id   = "${aws_cloudfront_distribution.default.hosted_zone_id}"
+                    }
+
+                    module "duplicate_label" {
+                      source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.7"
+                      namespace  = "${var.namespace}"
+                      stage      = "${var.stage}"
+                      name       = "${var.name}"
+                      delimiter  = "${var.delimiter}"
+                      attributes = ["${compact(concat(var.attributes, list("origin")))}"]
+                      tags       = "${var.tags}"
+                    }
+
+                    module "github_ssh_without_protocol" {
+                      source     = "git@github.com:cloudposse/terraform-aws-jenkins.git?ref=tags/0.10.6//some/dir"
+                      namespace  = "${var.namespace}"
+                      stage      = "${var.stage}"
+                      name       = "${var.name}"
+                      delimiter  = "${var.delimiter}"
+                      attributes = ["${compact(concat(var.attributes, list("origin")))}"]
+                      tags       = "${var.tags}"
+                    }
+                  content_encoding: utf-8
+                  deleted: false
+                  directory: /opentofu
+                  name: main.tf
+                  operation: update
+                  support_file: false
+                  type: file
+            pr-title: Bump github_ssh_without_protocol::terraform-aws-jenkins from 0.4.0 to 0.10.6 in /opentofu
+            pr-body: "Bumps [github_ssh_without_protocol::terraform-aws-jenkins](https://github.com/cloudposse/terraform-aws-jenkins) from 0.4.0 to 0.10.6.\n<details>\n<summary>Release notes</summary>\n<p><em>Sourced from <a href=\"https://github.com/cloudposse/terraform-aws-jenkins/releases\">github_ssh_without_protocol::terraform-aws-jenkins's releases</a>.</em></p>\n<blockquote>\n<h2>v0.10.6</h2>\n<h2>\U0001F916 Automatic Updates</h2>\n<!-- raw HTML omitted -->\n<p>This PR contains the following updates:</p>\n<table>\n<thead>\n<tr>\n<th>Package</th>\n<th>Type</th>\n<th>Update</th>\n<th>Change</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td><a href=\"https://registry.terraform.io/modules/cloudposse/cicd/aws\">cloudposse/cicd/aws</a> (<a href=\"https://togithub.com/cloudposse/terraform-aws-cicd\">source</a>)</td>\n<td>module</td>\n<td>patch</td>\n<td><code>0.19.4</code> -&gt; <code>0.19.5</code></td>\n</tr>\n</tbody>\n</table>\n<hr />\n<!-- raw HTML omitted -->\n<h2>v0.10.5</h2>\n<h2>\U0001F916 Automatic Updates</h2>\n<!-- raw HTML omitted -->\n<p>This PR contains the following updates:</p>\n<table>\n<thead>\n<tr>\n<th>Package</th>\n<th>Type</th>\n<th>Update</th>\n<th>Change</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td><a href=\"https://registry.terraform.io/modules/cloudposse/backup/aws\">cloudposse/backup/aws</a> (<a href=\"https://togithub.com/cloudposse/terraform-aws-backup\">source</a>)</td>\n<td>module</td>\n<td>minor</td>\n<td><code>0.13.1</code> -&gt; <code>0.14.0</code></td>\n</tr>\n</tbody>\n</table>\n<hr />\n<!-- raw HTML omitted -->\n<h2>v0.10.4</h2>\n<h2>\U0001F916 Automatic Updates</h2>\n<!-- raw HTML omitted -->\n<p>This PR contains the following updates:</p>\n<table>\n<thead>\n<tr>\n<th>Package</th>\n<th>Type</th>\n<th>Update</th>\n<th>Change</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td><a href=\"https://registry.terraform.io/modules/cloudposse/cicd/aws\">cloudposse/cicd/aws</a> (<a href=\"https://togithub.com/cloudposse/terraform-aws-cicd\">source</a>)</td>\n<td>module</td>\n<td>patch</td>\n<td><code>0.19.1</code> -&gt; <code>0.19.4</code></td>\n</tr>\n</tbody>\n</table>\n<hr />\n<!-- raw HTML omitted -->\n<h2>v0.10.3</h2>\n<h2>\U0001F916 Automatic Updates</h2>\n<!-- raw HTML omitted -->\n</blockquote>\n<p>... (truncated)</p>\n</details>\n<details>\n<summary>Commits</summary>\n<ul>\n<li><a href=\"https://github.com/cloudposse-archives/terraform-aws-jenkins/commit/07899c811e348f0c426e6858c96c49cb545b39cc\"><code>07899c8</code></a> chore(deps): update terraform cloudposse/cicd/aws to v0.19.5 (<a href=\"https://redirect.github.com/cloudposse/terraform-aws-jenkins/issues/92\">#92</a>)</li>\n<li><a href=\"https://github.com/cloudposse-archives/terraform-aws-jenkins/commit/78ba2bc5a0d84d27d295055e3fbbaf2163ce88bb\"><code>78ba2bc</code></a> chore(deps): update terraform cloudposse/backup/aws to v0.14.0 (<a href=\"https://redirect.github.com/cloudposse/terraform-aws-jenkins/issues/90\">#90</a>)</li>\n<li><a href=\"https://github.com/cloudposse-archives/terraform-aws-jenkins/commit/3966f67ae68ed1e97e1f3cc4c611a1c3b9cd19da\"><code>3966f67</code></a> chore(deps): update terraform cloudposse/cicd/aws to v0.19.4 (<a href=\"https://redirect.github.com/cloudposse/terraform-aws-jenkins/issues/89\">#89</a>)</li>\n<li><a href=\"https://github.com/cloudposse-archives/terraform-aws-jenkins/commit/1dbfe5b194288266096abb699fc823d6553fba96\"><code>1dbfe5b</code></a> chore(deps): update terraform cloudposse/cicd/aws to v0.19.1 (<a href=\"https://redirect.github.com/cloudposse/terraform-aws-jenkins/issues/65\">#65</a>)</li>\n<li><a href=\"https://github.com/cloudposse-archives/terraform-aws-jenkins/commit/774a1b81b4eda41e13a15a1138256e3885f7e790\"><code>774a1b8</code></a> chore(deps): update terraform cloudposse/elastic-beanstalk-environment/aws to...</li>\n<li><a href=\"https://github.com/cloudposse-archives/terraform-aws-jenkins/commit/53f84372307d3712eb3b2334f5e079d2a7696876\"><code>53f8437</code></a> chore(deps): update terraform cloudposse/efs/aws to v0.32.7 (<a href=\"https://redirect.github.com/cloudposse/terraform-aws-jenkins/issues/86\">#86</a>)</li>\n<li><a href=\"https://github.com/cloudposse-archives/terraform-aws-jenkins/commit/4ae2c938c8aae325a69a53b0bbb4c65ec2ea579a\"><code>4ae2c93</code></a> Provide SSL security policy (<a href=\"https://redirect.github.com/cloudposse/terraform-aws-jenkins/issues/45\">#45</a>)</li>\n<li><a href=\"https://github.com/cloudposse-archives/terraform-aws-jenkins/commit/fc65422a5d3f60588cae1aae1a91bd2676c1103a\"><code>fc65422</code></a> chore(deps): update terraform cloudposse/backup/aws to v0.13.1 (<a href=\"https://redirect.github.com/cloudposse/terraform-aws-jenkins/issues/77\">#77</a>)</li>\n<li><a href=\"https://github.com/cloudposse-archives/terraform-aws-jenkins/commit/27bdb559d7b6985de7a4bd5a80eca61d17122dd0\"><code>27bdb55</code></a> chore(deps): update terraform cloudposse/ecr/aws to v0.34.0 (<a href=\"https://redirect.github.com/cloudposse/terraform-aws-jenkins/issues/79\">#79</a>)</li>\n<li><a href=\"https://github.com/cloudposse-archives/terraform-aws-jenkins/commit/a25c91b035a00718d123c8e4239ab44e25826de7\"><code>a25c91b</code></a> chore(deps): update terraform cloudposse/label/null to v0.25.0 (<a href=\"https://redirect.github.com/cloudposse/terraform-aws-jenkins/issues/80\">#80</a>)</li>\n<li>Additional commits viewable in <a href=\"https://github.com/cloudposse/terraform-aws-jenkins/compare/tags/0.4.0...tags/0.10.6\">compare view</a></li>\n</ul>\n</details>\n<br />\n"
+            commit-message: |-
+                Bump github_ssh_without_protocol::terraform-aws-jenkins in /opentofu
+
+                Bumps [github_ssh_without_protocol::terraform-aws-jenkins](https://github.com/cloudposse/terraform-aws-jenkins) from 0.4.0 to 0.10.6.
+                - [Release notes](https://github.com/cloudposse/terraform-aws-jenkins/releases)
+                - [Commits](https://github.com/cloudposse/terraform-aws-jenkins/compare/tags/0.4.0...tags/0.10.6)
+    - type: create_pull_request
+      expect:
+        data:
+            base-commit-sha: e97f61f9fd7b34f24e246c13b64621e71f7a390e
+            dependencies:
+                - name: logs::github::cloudposse/terraform-aws-s3-log-storage::tags/0.2.2
+                  previous-requirements:
+                    - file: main.tf
+                      groups: []
+                      requirement: null
+                      source:
+                        branch: null
+                        ref: tags/0.2.2
+                        type: git
+                        url: https://github.com/cloudposse/terraform-aws-s3-log-storage.git
+                  previous-version: 0.2.2
+                  requirements:
+                    - file: main.tf
+                      groups: []
+                      requirement: null
+                      source:
+                        branch: null
+                        ref: tags/0.28.0
+                        type: git
+                        url: https://github.com/cloudposse/terraform-aws-s3-log-storage.git
+                  version: 0.28.0
+                  directory: /opentofu
+            updated-dependency-files:
+                - content: |
+                    module "origin_label" {
+                      source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.7"
+                      namespace  = "${var.namespace}"
+                      stage      = "${var.stage}"
+                      name       = "${var.name}"
+                      delimiter  = "${var.delimiter}"
+                      attributes = ["${compact(concat(var.attributes, list("origin")))}"]
+                      tags       = "${var.tags}"
+                    }
+
+                    resource "aws_cloudfront_origin_access_identity" "default" {
+                      comment = "${module.distribution_label.id}"
+                    }
+
+                    module "logs" {
+                      source                   = "github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.28.0"
+                      namespace                = "${var.namespace}"
+                      stage                    = "${var.stage}"
+                      name                     = "${var.name}"
+                      delimiter                = "${var.delimiter}"
+                      attributes               = ["${compact(concat(var.attributes, list("origin", "logs")))}"]
+                      tags                     = "${var.tags}"
+                      prefix                   = "${var.log_prefix}"
+                      standard_transition_days = "${var.log_standard_transition_days}"
+                      glacier_transition_days  = "${var.log_glacier_transition_days}"
+                      expiration_days          = "${var.log_expiration_days}"
+                    }
+
+                    module "distribution_label" {
+                      source     = "github.com/cloudposse/terraform-null-label.git"
+                      namespace  = "${var.namespace}"
+                      stage      = "${var.stage}"
+                      name       = "${var.name}"
+                      attributes = "${var.attributes}"
+                      delimiter  = "${var.delimiter}"
+                      tags       = "${var.tags}"
+                    }
+
+                    resource "aws_cloudfront_distribution" "default" {
+                      enabled             = "${var.enabled}"
+                      is_ipv6_enabled     = "${var.is_ipv6_enabled}"
+                      comment             = "${var.comment}"
+                      default_root_object = "${var.default_root_object}"
+                      price_class         = "${var.price_class}"
+
+                      logging_config = {
+                        include_cookies = "${var.log_include_cookies}"
+                        bucket          = "${module.logs.bucket_domain_name}"
+                        prefix          = "${var.log_prefix}"
+                      }
+
+                      aliases = ["${var.aliases}"]
+
+                      custom_error_response = ["${var.custom_error_response}"]
+
+                      origin {
+                        domain_name = "${var.origin_domain_name}"
+                        origin_id   = "${module.distribution_label.id}"
+                        origin_path = "${var.origin_path}"
+
+                        custom_origin_config {
+                          http_port                = "${var.origin_http_port}"
+                          https_port               = "${var.origin_https_port}"
+                          origin_protocol_policy   = "${var.origin_protocol_policy}"
+                          origin_ssl_protocols     = "${var.origin_ssl_protocols}"
+                          origin_keepalive_timeout = "${var.origin_keepalive_timeout}"
+                          origin_read_timeout      = "${var.origin_read_timeout}"
+                        }
+                      }
+
+                      viewer_certificate {
+                        acm_certificate_arn            = "${var.acm_certificate_arn}"
+                        ssl_support_method             = "sni-only"
+                        minimum_protocol_version       = "${var.viewer_minimum_protocol_version}"
+                        cloudfront_default_certificate = "${var.acm_certificate_arn == "" ? true : false}"
+                      }
+
+                      default_cache_behavior {
+                        allowed_methods  = "${var.allowed_methods}"
+                        cached_methods   = "${var.cached_methods}"
+                        target_origin_id = "${module.distribution_label.id}"
+                        compress         = "${var.compress}"
+
+                        forwarded_values {
+                          headers = ["${var.forward_headers}"]
+
+                          query_string = "${var.forward_query_string}"
+
+                          cookies {
+                            forward           = "${var.forward_cookies}"
+                            whitelisted_names = ["${var.forward_cookies_whitelisted_names}"]
+                          }
+                        }
+
+                        viewer_protocol_policy = "${var.viewer_protocol_policy}"
+                        default_ttl            = "${var.default_ttl}"
+                        min_ttl                = "${var.min_ttl}"
+                        max_ttl                = "${var.max_ttl}"
+                      }
+
+                      cache_behavior = "${var.cache_behavior}"
+
+                      web_acl_id = "${var.web_acl_id}"
+
+                      restrictions {
+                        geo_restriction {
+                          restriction_type = "${var.geo_restriction_type}"
+                          locations        = "${var.geo_restriction_locations}"
+                        }
+                      }
+
+                      tags = "${module.distribution_label.tags}"
+                    }
+
+                    module "dns" {
+                      source           = "git::https://github.com/cloudposse/terraform-cloudflare-zone.git//some/dir?ref=tags/0.2.5"
+                      enabled          = "${var.dns_aliases_enabled}"
+                      aliases          = "${var.aliases}"
+                      parent_zone_id   = "${var.parent_zone_id}"
+                      parent_zone_name = "${var.parent_zone_name}"
+                      target_dns_name  = "${aws_cloudfront_distribution.default.domain_name}"
+                      target_zone_id   = "${aws_cloudfront_distribution.default.hosted_zone_id}"
+                    }
+
+                    module "duplicate_label" {
+                      source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.7"
+                      namespace  = "${var.namespace}"
+                      stage      = "${var.stage}"
+                      name       = "${var.name}"
+                      delimiter  = "${var.delimiter}"
+                      attributes = ["${compact(concat(var.attributes, list("origin")))}"]
+                      tags       = "${var.tags}"
+                    }
+
+                    module "github_ssh_without_protocol" {
+                      source     = "git@github.com:cloudposse/terraform-aws-jenkins.git?ref=tags/0.4.0//some/dir"
+                      namespace  = "${var.namespace}"
+                      stage      = "${var.stage}"
+                      name       = "${var.name}"
+                      delimiter  = "${var.delimiter}"
+                      attributes = ["${compact(concat(var.attributes, list("origin")))}"]
+                      tags       = "${var.tags}"
+                    }
+                  content_encoding: utf-8
+                  deleted: false
+                  directory: /opentofu
+                  name: main.tf
+                  operation: update
+                  support_file: false
+                  type: file
+            pr-title: Bump logs::terraform-aws-s3-log-storage from 0.2.2 to 0.28.0 in /opentofu
+            pr-body: "Bumps [logs::terraform-aws-s3-log-storage](https://github.com/cloudposse/terraform-aws-s3-log-storage) from 0.2.2 to 0.28.0.\n<details>\n<summary>Release notes</summary>\n<p><em>Sourced from <a href=\"https://github.com/cloudposse/terraform-aws-s3-log-storage/releases\">logs::terraform-aws-s3-log-storage's releases</a>.</em></p>\n<blockquote>\n<h2>v0.28.0 (Action Needed) Support AWS v4 provider</h2>\n<h1>WARNING, DATA LOSS LIKELY if you do not follow upgrade instructions:</h1>\n<ul>\n<li>Upgrade instructions: <a href=\"https://github.com/cloudposse/terraform-aws-s3-log-storage/wiki/Upgrading-to-v0.28.0-and-AWS-provider-v4-(POTENTIAL-DATA-LOSS)\">v0.27.0 to v0.28.0</a></li>\n<li>Upgrade instructions: <a href=\"https://github.com/cloudposse/terraform-aws-s3-log-storage/wiki/Upgrading-to-v0.27.0-(POTENTIAL-DATA-LOSS)\">versions prior to v0.27.0 to v0.27.0\n</a></li>\n</ul>\n<h2>\U0001F680 Enhancements</h2>\n<!-- raw HTML omitted -->\n<h2>what</h2>\n<ul>\n<li>Migrate to AWS v4 Terraform provider</li>\n<li>Add features\n<ul>\n<li>Allow full S3 storage lifecycle configuration</li>\n<li>Allow multiple bucket policy documents</li>\n<li>Allow specifying the bucket name directly, rather than requiring it to be generated by <code>null-label</code></li>\n<li>Allow specifying S3 object ownership</li>\n<li>Allow enabling S3 bucket keys for encryption</li>\n</ul>\n</li>\n<li>Deprecate variable by variable specification of a single storage lifecycle rule</li>\n<li>Add extra safety measure <code>force_destroy_enabled</code></li>\n</ul>\n<h2>why</h2>\n<ul>\n<li>AWS v4 broke this module</li>\n<li>Feature parity</li>\n<li>Replaced with more power and more flexible input</li>\n<li>Reduce the chance that automated upgrades will cause data loss</li>\n</ul>\n<h2>references</h2>\n<ul>\n<li>Upgrade instructions: <a href=\"https://github.com/cloudposse/terraform-aws-s3-log-storage/wiki/Upgrading-to-v0.28.0-and-AWS-provider-v4-(POTENTIAL-DATA-LOSS)\">v0.27.0 to v0.28.0</a></li>\n<li>Upgrade instructions: <a href=\"https://github.com/cloudposse/terraform-aws-s3-log-storage/wiki/Upgrading-to-v0.27.0-(POTENTIAL-DATA-LOSS)\">versions prior to v0.27.0 to v0.27.0\n</a></li>\n</ul>\n<!-- raw HTML omitted -->\n<h2>v0.27.0 (WARNING: Potential Data Loss) Prepare for AWS provider v4</h2>\n<h1>Update: This version no longer recommended</h1>\n<p>With the release of version 1.0.0 of this module, use of this version is no longer recommended. When you are able to use Terraform v1.3.0 or later and Terraform AWS provider v4.9.0 or later, upgrade directly to v1.0.0 or later of this module.</p>\n<h1>Warning: Potential total data loss</h1>\n<p>This release is a refactoring in preparation for supporting Terraform AWS Provider v4. One feature was removed, but otherwise there are no changes to inputs or behavior. However, the Terraform &quot;addresses&quot; of resources have changed, so you are need to run several <code>terraform state mv</code> commands.</p>\n<p><strong>Warning:</strong> failure to run the required <code>terraform state mv</code> commands will cause Terraform to delete your existing S3 bucket and create a new one, <strong>deleting all the data stored in the bucket in the process.</strong></p>\n<p>Details on how to safely upgrade are in this repository's Wiki <a href=\"https://github.com/cloudposse/terraform-aws-s3-log-storage/wiki/Upgrading-to-v0.27.0-(POTENTIAL-DATA-LOSS)\">here</a></p>\n<h2>Support for &quot;MFA delete&quot; removed</h2>\n<!-- raw HTML omitted -->\n</blockquote>\n<p>... (truncated)</p>\n</details>\n<details>\n<summary>Commits</summary>\n<ul>\n<li><a href=\"https://github.com/cloudposse/terraform-aws-s3-log-storage/commit/112c75d1f1ad2b8b2a1f9722e3172eae03149ca0\"><code>112c75d</code></a> Support AWS v4 provider (<a href=\"https://redirect.github.com/cloudposse/terraform-aws-s3-log-storage/issues/71\">#71</a>)</li>\n<li><a href=\"https://github.com/cloudposse/terraform-aws-s3-log-storage/commit/2c17ca6f11ae11139743e09a0ad5cdb8bb7b2f04\"><code>2c17ca6</code></a> Cleanups and safety checks for upgrade (<a href=\"https://redirect.github.com/cloudposse/terraform-aws-s3-log-storage/issues/70\">#70</a>)</li>\n<li><a href=\"https://github.com/cloudposse/terraform-aws-s3-log-storage/commit/048ae6a1069a98dc9a2c8e882c946f7c231f5599\"><code>048ae6a</code></a> Refactor to use s3-bucket module, update in general (<a href=\"https://redirect.github.com/cloudposse/terraform-aws-s3-log-storage/issues/66\">#66</a>)</li>\n<li><a href=\"https://github.com/cloudposse/terraform-aws-s3-log-storage/commit/f1b6ec3059a857bced06cc212d78ffc9bf948900\"><code>f1b6ec3</code></a> Add S3 bucket ownership controls (<a href=\"https://redirect.github.com/cloudposse/terraform-aws-s3-log-storage/issues/61\">#61</a>)</li>\n<li><a href=\"https://github.com/cloudposse/terraform-aws-s3-log-storage/commit/2c2fac814eaa0617dafab34d6b0aba29600632e5\"><code>2c2fac8</code></a> Add support for bucket notifications (<a href=\"https://redirect.github.com/cloudposse/terraform-aws-s3-log-storage/issues/60\">#60</a>)</li>\n<li><a href=\"https://github.com/cloudposse/terraform-aws-s3-log-storage/commit/ad6a2fbb2447ff02d36288802e6809f946c380fe\"><code>ad6a2fb</code></a> Update context.tf from origin source (<a href=\"https://redirect.github.com/cloudposse/terraform-aws-s3-log-storage/issues/59\">#59</a>)</li>\n<li><a href=\"https://github.com/cloudposse/terraform-aws-s3-log-storage/commit/c1a2a8faba43c9b3a824184faa4be0d6dfea09e4\"><code>c1a2a8f</code></a> Add variable access_log_bucket_prefix to customize S3 access log configuratio...</li>\n<li><a href=\"https://github.com/cloudposse/terraform-aws-s3-log-storage/commit/ad40cf204650fef1645d9d90eee4312b08088994\"><code>ad40cf2</code></a> add allow_ssl_requests_only flag (<a href=\"https://redirect.github.com/cloudposse/terraform-aws-s3-log-storage/issues/56\">#56</a>)</li>\n<li><a href=\"https://github.com/cloudposse/terraform-aws-s3-log-storage/commit/f6a32f00ab35ae1dddde1988fb227cf710da62c7\"><code>f6a32f0</code></a> add allow_ssl_requests_only flag (<a href=\"https://redirect.github.com/cloudposse/terraform-aws-s3-log-storage/issues/55\">#55</a>)</li>\n<li><a href=\"https://github.com/cloudposse/terraform-aws-s3-log-storage/commit/7a05bb81ac0cf8126d4fcde86d66798d556bb5ef\"><code>7a05bb8</code></a> added versioning mfa delete enabled option (<a href=\"https://redirect.github.com/cloudposse/terraform-aws-s3-log-storage/issues/54\">#54</a>)</li>\n<li>Additional commits viewable in <a href=\"https://github.com/cloudposse/terraform-aws-s3-log-storage/compare/tags/0.2.2...tags/0.28.0\">compare view</a></li>\n</ul>\n</details>\n<br />\n"
+            commit-message: |-
+                Bump logs::terraform-aws-s3-log-storage in /opentofu
+
+                Bumps [logs::terraform-aws-s3-log-storage](https://github.com/cloudposse/terraform-aws-s3-log-storage) from 0.2.2 to 0.28.0.
+                - [Release notes](https://github.com/cloudposse/terraform-aws-s3-log-storage/releases)
+                - [Commits](https://github.com/cloudposse/terraform-aws-s3-log-storage/compare/tags/0.2.2...tags/0.28.0)
+    - type: create_pull_request
+      expect:
+        data:
+            base-commit-sha: e97f61f9fd7b34f24e246c13b64621e71f7a390e
+            dependencies:
+                - name: origin_label::github::cloudposse/terraform-null-label::tags/0.3.7
+                  previous-requirements:
+                    - file: main.tf
+                      groups: []
+                      requirement: null
+                      source:
+                        branch: null
+                        ref: tags/0.3.7
+                        type: git
+                        url: https://github.com/cloudposse/terraform-null-label.git
+                  previous-version: 0.3.7
+                  requirements:
+                    - file: main.tf
+                      groups: []
+                      requirement: null
+                      source:
+                        branch: null
+                        ref: tags/0.25.0
+                        type: git
+                        url: https://github.com/cloudposse/terraform-null-label.git
+                  version: 0.25.0
+                  directory: /opentofu
+            updated-dependency-files:
+                - content: |
+                    module "origin_label" {
+                      source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.25.0"
+                      namespace  = "${var.namespace}"
+                      stage      = "${var.stage}"
+                      name       = "${var.name}"
+                      delimiter  = "${var.delimiter}"
+                      attributes = ["${compact(concat(var.attributes, list("origin")))}"]
+                      tags       = "${var.tags}"
+                    }
+
+                    resource "aws_cloudfront_origin_access_identity" "default" {
+                      comment = "${module.distribution_label.id}"
+                    }
+
+                    module "logs" {
+                      source                   = "github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.2.2"
+                      namespace                = "${var.namespace}"
+                      stage                    = "${var.stage}"
+                      name                     = "${var.name}"
+                      delimiter                = "${var.delimiter}"
+                      attributes               = ["${compact(concat(var.attributes, list("origin", "logs")))}"]
+                      tags                     = "${var.tags}"
+                      prefix                   = "${var.log_prefix}"
+                      standard_transition_days = "${var.log_standard_transition_days}"
+                      glacier_transition_days  = "${var.log_glacier_transition_days}"
+                      expiration_days          = "${var.log_expiration_days}"
+                    }
+
+                    module "distribution_label" {
+                      source     = "github.com/cloudposse/terraform-null-label.git"
+                      namespace  = "${var.namespace}"
+                      stage      = "${var.stage}"
+                      name       = "${var.name}"
+                      attributes = "${var.attributes}"
+                      delimiter  = "${var.delimiter}"
+                      tags       = "${var.tags}"
+                    }
+
+                    resource "aws_cloudfront_distribution" "default" {
+                      enabled             = "${var.enabled}"
+                      is_ipv6_enabled     = "${var.is_ipv6_enabled}"
+                      comment             = "${var.comment}"
+                      default_root_object = "${var.default_root_object}"
+                      price_class         = "${var.price_class}"
+
+                      logging_config = {
+                        include_cookies = "${var.log_include_cookies}"
+                        bucket          = "${module.logs.bucket_domain_name}"
+                        prefix          = "${var.log_prefix}"
+                      }
+
+                      aliases = ["${var.aliases}"]
+
+                      custom_error_response = ["${var.custom_error_response}"]
+
+                      origin {
+                        domain_name = "${var.origin_domain_name}"
+                        origin_id   = "${module.distribution_label.id}"
+                        origin_path = "${var.origin_path}"
+
+                        custom_origin_config {
+                          http_port                = "${var.origin_http_port}"
+                          https_port               = "${var.origin_https_port}"
+                          origin_protocol_policy   = "${var.origin_protocol_policy}"
+                          origin_ssl_protocols     = "${var.origin_ssl_protocols}"
+                          origin_keepalive_timeout = "${var.origin_keepalive_timeout}"
+                          origin_read_timeout      = "${var.origin_read_timeout}"
+                        }
+                      }
+
+                      viewer_certificate {
+                        acm_certificate_arn            = "${var.acm_certificate_arn}"
+                        ssl_support_method             = "sni-only"
+                        minimum_protocol_version       = "${var.viewer_minimum_protocol_version}"
+                        cloudfront_default_certificate = "${var.acm_certificate_arn == "" ? true : false}"
+                      }
+
+                      default_cache_behavior {
+                        allowed_methods  = "${var.allowed_methods}"
+                        cached_methods   = "${var.cached_methods}"
+                        target_origin_id = "${module.distribution_label.id}"
+                        compress         = "${var.compress}"
+
+                        forwarded_values {
+                          headers = ["${var.forward_headers}"]
+
+                          query_string = "${var.forward_query_string}"
+
+                          cookies {
+                            forward           = "${var.forward_cookies}"
+                            whitelisted_names = ["${var.forward_cookies_whitelisted_names}"]
+                          }
+                        }
+
+                        viewer_protocol_policy = "${var.viewer_protocol_policy}"
+                        default_ttl            = "${var.default_ttl}"
+                        min_ttl                = "${var.min_ttl}"
+                        max_ttl                = "${var.max_ttl}"
+                      }
+
+                      cache_behavior = "${var.cache_behavior}"
+
+                      web_acl_id = "${var.web_acl_id}"
+
+                      restrictions {
+                        geo_restriction {
+                          restriction_type = "${var.geo_restriction_type}"
+                          locations        = "${var.geo_restriction_locations}"
+                        }
+                      }
+
+                      tags = "${module.distribution_label.tags}"
+                    }
+
+                    module "dns" {
+                      source           = "git::https://github.com/cloudposse/terraform-cloudflare-zone.git//some/dir?ref=tags/0.2.5"
+                      enabled          = "${var.dns_aliases_enabled}"
+                      aliases          = "${var.aliases}"
+                      parent_zone_id   = "${var.parent_zone_id}"
+                      parent_zone_name = "${var.parent_zone_name}"
+                      target_dns_name  = "${aws_cloudfront_distribution.default.domain_name}"
+                      target_zone_id   = "${aws_cloudfront_distribution.default.hosted_zone_id}"
+                    }
+
+                    module "duplicate_label" {
+                      source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.7"
+                      namespace  = "${var.namespace}"
+                      stage      = "${var.stage}"
+                      name       = "${var.name}"
+                      delimiter  = "${var.delimiter}"
+                      attributes = ["${compact(concat(var.attributes, list("origin")))}"]
+                      tags       = "${var.tags}"
+                    }
+
+                    module "github_ssh_without_protocol" {
+                      source     = "git@github.com:cloudposse/terraform-aws-jenkins.git?ref=tags/0.4.0//some/dir"
+                      namespace  = "${var.namespace}"
+                      stage      = "${var.stage}"
+                      name       = "${var.name}"
+                      delimiter  = "${var.delimiter}"
+                      attributes = ["${compact(concat(var.attributes, list("origin")))}"]
+                      tags       = "${var.tags}"
+                    }
+                  content_encoding: utf-8
+                  deleted: false
+                  directory: /opentofu
+                  name: main.tf
+                  operation: update
+                  support_file: false
+                  type: file
+            pr-title: Bump origin_label::terraform-null-label from 0.3.7 to 0.25.0 in /opentofu
+            pr-body: |
+                Bumps [origin_label::terraform-null-label](https://github.com/cloudposse/terraform-null-label) from 0.3.7 to 0.25.0.
+                <details>
+                <summary>Release notes</summary>
+                <p><em>Sourced from <a href="https://github.com/cloudposse/terraform-null-label/releases">origin_label::terraform-null-label's releases</a>.</em></p>
+                <blockquote>
+                <h2>v0.25.0</h2>
+                <!-- raw HTML omitted -->
+                <h2>what</h2>
+                <ul>
+                <li>Add additional label and <code>id</code> component: <code>tenant</code></li>
+                <li>New input <code>labels_as_tags</code> controls which labels are exported as tags</li>
+                <li>New input <code>descriptor_formats</code> generates new output <code>descriptors</code></li>
+                <li>Update README, remove link to obsolete <code>terraform-terraform-label</code></li>
+                </ul>
+                <h2>why</h2>
+                <ul>
+                <li>Support users that host resources on behalf of and/or dedicated to single customers</li>
+                <li>Supersedes and closes <a href="https://redirect.github.com/cloudposse/terraform-null-label/issues/131">#131</a>, giving people control over which tags the module generates</li>
+                <li>Simple mechanism for creating multiple identifiers from the same inputs, reducing the need to create multiple instances of <code>null-label</code></li>
+                <li>Document <code>tenant</code>, <code>labels_as_tags</code>, <code>descriptor_formats</code>, add additional clarification, stop promoting obsolete module</li>
+                </ul>
+                <!-- raw HTML omitted -->
+                <!-- raw HTML omitted -->
+                <h2>what</h2>
+                <ul>
+                <li>Update README snippets to reflect use of Terraform Registry.</li>
+                </ul>
+                <h2>why</h2>
+                <ul>
+                <li>Including snippets that reflect use of the Terraform Registry make it easier for users to quickly instantiate a null_label module.</li>
+                <li>README is out of date and does not include snippets that reflect use of the Terraform Registry.</li>
+                </ul>
+                <h2>references</h2>
+                <ul>
+                <li>N/A</li>
+                </ul>
+                <!-- raw HTML omitted -->
+                <!-- raw HTML omitted -->
+                <h2>what</h2>
+                <ul>
+                <li>Resolve Bridgecrew compliance complaint about example Autoscaling Group (BC_AWS_GENERAL_31)</li>
+                <li>Fix typo in README</li>
+                <li>Include Terraform lock file in <code>.gitignore</code></li>
+                </ul>
+                <h2>why</h2>
+                <ul>
+                <li>Get clean Bridgecrew badge</li>
+                <li>Correct confusing error</li>
+                <li>Ensure lock files are not checked into GitHub</li>
+                </ul>
+                <h2>note</h2>
+                <p>The PR can and should be merged into <code>master</code> to update README and Bridgecrew without triggering a new release/version. These changes have no effect on the actual module in use and a release will create unnecessary ripple effects. However, merging to <code>master</code> will update the README and badges, so is worthwhile, and the changes will move forward into the next release.</p>
+                <!-- raw HTML omitted -->
+                </blockquote>
+                <p>... (truncated)</p>
+                </details>
+                <details>
+                <summary>Commits</summary>
+                <ul>
+                <li><a href="https://github.com/cloudposse/terraform-null-label/commit/488ab91e34a24a86957e397d9f7262ec5925586a"><code>488ab91</code></a> Properly output descriptors of chained modules (<a href="https://redirect.github.com/cloudposse/terraform-null-label/issues/133">#133</a>)</li>
+                <li><a href="https://github.com/cloudposse/terraform-null-label/commit/503f50c2fbf6974eee8091220ee3c246ba035931"><code>503f50c</code></a> Add &quot;tenant&quot;, &quot;labels_as_tags&quot;, and &quot;descriptors&quot; (<a href="https://redirect.github.com/cloudposse/terraform-null-label/issues/132">#132</a>)</li>
+                <li><a href="https://github.com/cloudposse/terraform-null-label/commit/2428b46ab57e4a93de5b942eb6a279ac89ec9b85"><code>2428b46</code></a> Fix: Update README Snippets (<a href="https://redirect.github.com/cloudposse/terraform-null-label/issues/130">#130</a>)</li>
+                <li><a href="https://github.com/cloudposse/terraform-null-label/commit/cf38625a5dde227db04c9cfedc1327d610229fec"><code>cf38625</code></a> Bridgecrew compliance (<a href="https://redirect.github.com/cloudposse/terraform-null-label/issues/125">#125</a>)</li>
+                <li><a href="https://github.com/cloudposse/terraform-null-label/commit/dc699992922b452ccc521c3dfe9c9c5c1f8376af"><code>dc69999</code></a> Copy validation to exports/context.tf (<a href="https://redirect.github.com/cloudposse/terraform-null-label/issues/123">#123</a>)</li>
+                <li><a href="https://github.com/cloudposse/terraform-null-label/commit/3a7014c622571cbbbe0daf270d1d8c9d1f2cbb3f"><code>3a7014c</code></a> Include updates to exports/context.tf (<a href="https://redirect.github.com/cloudposse/terraform-null-label/issues/122">#122</a>)</li>
+                <li><a href="https://github.com/cloudposse/terraform-null-label/commit/2de8bb4edf38c5ccc17969774cc853e2dfc36df7"><code>2de8bb4</code></a> Restore backward compatibility with v0.22.1 and earlier (<a href="https://redirect.github.com/cloudposse/terraform-null-label/issues/121">#121</a>)</li>
+                <li><a href="https://github.com/cloudposse/terraform-null-label/commit/6a7c42ef2105764b96d97e7d9ab9578dd1d83dd5"><code>6a7c42e</code></a> feat: add support for choosing letter case of context tags (<a href="https://redirect.github.com/cloudposse/terraform-null-label/issues/107">#107</a>)</li>
+                <li><a href="https://github.com/cloudposse/terraform-null-label/commit/f145d2a07da722f988ba6845737c3f2c1d55e476"><code>f145d2a</code></a> Add var.attributes to end of context.attributes, not vice versa (<a href="https://redirect.github.com/cloudposse/terraform-null-label/issues/114">#114</a>)</li>
+                <li><a href="https://github.com/cloudposse/terraform-null-label/commit/3861091c159d77115703b43cb88a47f6ee6a6191"><code>3861091</code></a> Restore &quot;this&quot; name (<a href="https://redirect.github.com/cloudposse/terraform-null-label/issues/111">#111</a>)</li>
+                <li>Additional commits viewable in <a href="https://github.com/cloudposse/terraform-null-label/compare/tags/0.3.7...tags/0.25.0">compare view</a></li>
+                </ul>
+                </details>
+                <br />
+            commit-message: |-
+                Bump origin_label::terraform-null-label in /opentofu
+
+                Bumps [origin_label::terraform-null-label](https://github.com/cloudposse/terraform-null-label) from 0.3.7 to 0.25.0.
+                - [Release notes](https://github.com/cloudposse/terraform-null-label/releases)
+                - [Commits](https://github.com/cloudposse/terraform-null-label/compare/tags/0.3.7...tags/0.25.0)
+    - type: mark_as_processed
+      expect:
+        data:
+            base-commit-sha: e97f61f9fd7b34f24e246c13b64621e71f7a390e


### PR DESCRIPTION
## Summary
- Adds `tests/smoke-opentofu.yaml` and an `opentofu/` fixture (mirrors the existing `terraform/` fixture; opentofu reads `.tf` natively).
- Without a `smoke-opentofu*.yaml`, the dependabot-core Smoke workflow's `discover` step produces an empty matrix when only `opentofu/**` files change, which fails the workflow. See https://github.com/dependabot/dependabot-core/actions/runs/25124115887.

## Notes for reviewer
- The `output:` block was recorded locally with `dependabot test --local`, so `source.commit` and the embedded `base-commit-sha` values are placeholders. Please run the **Regenerate Test** workflow (`test: opentofu`) after merge to pin them to the merged commit SHA.

## Test plan
- [ ] Trigger `Regenerate Test` (workflow_dispatch, `test: opentofu`) on `main` after merge and confirm the generated PR's diff is limited to `source.commit` / `base-commit-sha` updates.
- [ ] Push a no-op commit to a dependabot-core branch touching `opentofu/**` and verify the Smoke workflow now expands the matrix and runs the `e2e` job.