### PR TITLE
Add blob_oid to graph smoke test fixtures

### DIFF
--- a/tests/smoke-go-graph.yaml
+++ b/tests/smoke-go-graph.yaml
@@ -38,6 +38,7 @@ output:
                     file:
                         source_location: go/go.mod
                     metadata:
+                        blob_oid: c2ef476c816dcb088aa9bd2505c6d371d1358995
                         ecosystem: golang
                     name: /go/go.mod
                     resolved:

--- a/tests/smoke-pipenv-graph.yaml
+++ b/tests/smoke-pipenv-graph.yaml
@@ -43,6 +43,7 @@ output:
                     file:
                         source_location: pipenv-graph/Pipfile.lock
                     metadata:
+                        blob_oid: a1cdc339b81bddc65f341c97bc9aeed4e43c8fb9
                         ecosystem: pypi
                     name: /pipenv-graph/Pipfile.lock
                     resolved:

--- a/tests/smoke-poetry-graph.yaml
+++ b/tests/smoke-poetry-graph.yaml
@@ -43,6 +43,7 @@ output:
                     file:
                         source_location: poetry-graph/poetry.lock
                     metadata:
+                        blob_oid: 8b11b6c1f4a8040567f25581d9a9462cddb7c069
                         ecosystem: pypi
                     name: /poetry-graph/poetry.lock
                     resolved:

--- a/tests/smoke-uv-graph.yaml
+++ b/tests/smoke-uv-graph.yaml
@@ -38,6 +38,7 @@ output:
                     file:
                         source_location: uv/uv.lock
                     metadata:
+                        blob_oid: 1645be636d271856c2539e432c0c1aa47800e248
                         ecosystem: pypi
                     name: /uv/uv.lock
                     resolved:


### PR DESCRIPTION
See https://github.com/dependabot/dependabot-core/pull/14857.

dependabot-core now includes blob_oid metadata in dependency submission manifests. Update the expected output for all 4 graph smoke tests with the correct Git blob SHA-1 values.