### PR TITLE
Update Gradle wrapper smoke expectation for binary jar output

### DIFF
--- a/tests/smoke-gradle-wrapper.yaml
+++ b/tests/smoke-gradle-wrapper.yaml
@@ -402,7 +402,7 @@ output:
                   operation: update
                   support_file: false
                   type: file
-                - content: 2412aacb07ada2ac41e9d44859da439f817825faf49a06869cf1ddc5a1e978c5
+                - content: 55d0c392ca300e53b2ddee20f47234e59435a47319cea9a39fdb4b3e968b5f43
                   content_encoding: sha256
                   deleted: false
                   directory: /gradle-wrapper


### PR DESCRIPTION
## Summary
- update `tests/smoke-gradle-wrapper.yaml` with the new `gradle-wrapper.jar` SHA-256 expectation

## Why
A recent `dependabot/dependabot-core` fix corrects Gradle wrapper updates to materialize `gradle-wrapper.jar` as real binary bytes in the updater temp workspace instead of writing base64 text under the `.jar` path.

That changes the resulting wrapper JAR content fingerprint in the smoke test output. This fixture update records the new correct SHA-256 so the Gradle wrapper smoke test matches the fixed behavior.

## Related
- dependabot/dependabot-core#15001