### PR TITLE
Add merge commit sha for adding sbt smoke test

### DIFF
--- a/tests/smoke-sbt.yaml
+++ b/tests/smoke-sbt.yaml
@@ -16,7 +16,7 @@ input:
             provider: github
             repo: dependabot/smoke-tests
             directory: /sbt
-            commit: REPLACE_WITH_MERGE_COMMIT_SHA
+            commit: 99337236e1b2c38341b8bd359069b6c0aaf94b0d
     credentials:
         - host: github.com
           password: $LOCAL_GITHUB_ACCESS_TOKEN


### PR DESCRIPTION
This PR replaces the `REPLACE_WITH_MERGE_COMMIT_SHA` placeholder with the merge commit SHA for adding the `sbt` smoke test.