### PR TITLE
Add some go projects to capture nuanced graphing scenarios

### DIFF
--- a/go/graphs/README.md
+++ b/go/graphs/README.md
@@ -1,0 +1,3 @@
+# Graph-specific Scenarios
+
+This folder contains some scenarios that need modified parser behaviour when we are generating a graph job for a golang project instead of performing updates.

--- a/go/graphs/private-packages-without-credentials/go.mod
+++ b/go/graphs/private-packages-without-credentials/go.mod
@@ -1,0 +1,5 @@
+module github.com/dependabot/smoke-tests/go/graphs/private-packages-without-credentials
+
+go 1.22
+
+require github.com/dependabot/sekret-project v0.1.0

--- a/go/graphs/private-packages-without-credentials/main.go
+++ b/go/graphs/private-packages-without-credentials/main.go
@@ -1,0 +1,5 @@
+package main
+
+import _ "github.com/dependabot/sekret-project"
+
+func main() {}

--- a/go/graphs/replace-local/go.mod
+++ b/go/graphs/replace-local/go.mod
@@ -1,0 +1,7 @@
+module github.com/dependabot/smoke-tests/go/graphs/replace-local
+
+go 1.22
+
+require golang.org/x/text v0.3.7
+
+replace golang.org/x/text => ../nonexistent

--- a/go/graphs/replace-local/main.go
+++ b/go/graphs/replace-local/main.go
@@ -1,0 +1,5 @@
+package main
+
+import _ "golang.org/x/text"
+
+func main() {}

--- a/go/graphs/replace-remote/go.mod
+++ b/go/graphs/replace-remote/go.mod
@@ -1,0 +1,7 @@
+module github.com/dependabot/smoke-tests/go/graphs/replace-remote
+
+go 1.22
+
+require golang.org/x/crypto v0.23.0
+
+replace golang.org/x/crypto => github.com/pion/dtls/v2 v2.2.11

--- a/go/graphs/replace-remote/main.go
+++ b/go/graphs/replace-remote/main.go
@@ -1,0 +1,5 @@
+package main
+
+import _ "golang.org/x/crypto"
+
+func main() {}

--- a/go/graphs/replace-subproject/go.mod
+++ b/go/graphs/replace-subproject/go.mod
@@ -1,0 +1,14 @@
+module github.com/dependabot/smoke-tests/go/graphs/replace-subproject
+
+go 1.22
+
+require github.com/dependabot/smoke-tests/go/graphs/replace-subproject/subpkg v0.0.0
+
+require rsc.io/quote v1.5.0
+
+require (
+    golang.org/x/text v0.4.0 // indirect
+    rsc.io/sampler v1.3.0 // indirect
+)
+
+replace github.com/dependabot/smoke-tests/go/graphs/replace-subproject/subpkg => ./subpkg

--- a/go/graphs/replace-subproject/main.go
+++ b/go/graphs/replace-subproject/main.go
@@ -1,0 +1,8 @@
+package main
+
+import (
+    _ "github.com/dependabot/smoke-tests/go/graphs/replace-subproject/subpkg"
+    _ "rsc.io/quote"
+)
+
+func main() {}

--- a/go/graphs/replace-subproject/subpkg/go.mod
+++ b/go/graphs/replace-subproject/subpkg/go.mod
@@ -1,0 +1,11 @@
+module github.com/dependabot/smoke-tests/go/graphs/replace-subproject/subpkg
+
+go 1.22
+
+require github.com/fatih/color v1.15.0
+
+require (
+    github.com/mattn/go-colorable v0.1.13 // indirect
+    github.com/mattn/go-isatty v0.0.20 // indirect
+    golang.org/x/sys v0.6.0 // indirect
+)

--- a/go/graphs/replace-subproject/subpkg/subpkg.go
+++ b/go/graphs/replace-subproject/subpkg/subpkg.go
@@ -1,0 +1,5 @@
+package subpkg
+
+import _ "github.com/fatih/color"
+
+func Init() {}


### PR DESCRIPTION
This PR adds a set of reference go.mod projects to capture some behaviour we need to refine for graphing scenarios specifically:

- Smoke test outcomes where we cannot reach a private dependency
- Smoke test outcomes around `replace` directives where:
  - The `replace` relates to a dev alias ( target is not checked in )
  - The `replace` relates to a submodule ( the target is checked in, see k8s/k8s )
  - The `replace` relates to a remote module ( the target is a fully qualified package reference )

The smoke tests are not yet implemented, this is just adding them to the example code so we can start experimenting/generating smoke tests.