### PR TITLE
Capture current graph behaviour with golang replace statements

### DIFF
--- a/tests/smoke-go-graph-private-no-creds.yaml
+++ b/tests/smoke-go-graph-private-no-creds.yaml
@@ -1,0 +1,61 @@
+input:
+    job:
+        command: graph
+        package-manager: go_modules
+        allowed-updates:
+            - update-type: all
+        source:
+            provider: github
+            repo: dependabot/smoke-tests
+            directories:
+                - /go/graphs/private-packages-without-credentials
+            commit: 6c7557f98092fee58a96b9f4cb1a0ec7e2472cb1
+            hostname: github.com
+            api-endpoint: https://api.github.com
+    credentials:
+        - host: github.com
+          password: $LOCAL_GITHUB_ACCESS_TOKEN
+          type: git_source
+          username: x-access-token
+output:
+    - type: record_update_job_warning
+      expect:
+        data:
+            warn-type: dependency_graph_incomplete
+            warn-title: dependency graph incomplete
+            warn-description: 'The dependency graph may be incomplete. The following git URLs could not be retrieved: github.com/dependabot/sekret-project'
+    - type: create_dependency_submission
+      expect:
+        data:
+            version: 1
+            sha: 6c7557f98092fee58a96b9f4cb1a0ec7e2472cb1
+            ref: refs/heads/main
+            job:
+                correlator: dependabot-go_modules-b643eab7160a61359bf52d40168d2deea7204e06d8e27384d7f27f461fc70bc1
+                id: cli
+            detector:
+                name: dependabot
+                url: https://github.com/dependabot/dependabot-core
+                version: 0.377.0
+            manifests:
+                /go/graphs/private-packages-without-credentials/go.mod:
+                    file:
+                        source_location: go/graphs/private-packages-without-credentials/go.mod
+                    metadata:
+                        blob_oid: e9cbb2d39390e5a370d1fe3a94437f16e539878f
+                        ecosystem: golang
+                    name: /go/graphs/private-packages-without-credentials/go.mod
+                    resolved:
+                        pkg:golang/github.com/dependabot/sekret-project@v0.1.0:
+                            dependencies: []
+                            package_url: pkg:golang/github.com/dependabot/sekret-project@v0.1.0
+                            relationship: direct
+                            scope: runtime
+            metadata:
+                reason: error fetching sub-dependencies
+                scanned_manifest_path: golang::/go/graphs/private-packages-without-credentials
+                status: degraded
+    - type: mark_as_processed
+      expect:
+        data:
+            base-commit-sha: 6c7557f98092fee58a96b9f4cb1a0ec7e2472cb1

--- a/tests/smoke-go-graph-replace-local.yaml
+++ b/tests/smoke-go-graph-replace-local.yaml
@@ -1,0 +1,41 @@
+input:
+    job:
+        command: graph
+        package-manager: go_modules
+        allowed-updates:
+            - update-type: all
+        source:
+            provider: github
+            repo: dependabot/smoke-tests
+            directories:
+                - /go/graphs/replace-local
+            commit: 6c7557f98092fee58a96b9f4cb1a0ec7e2472cb1
+            hostname: github.com
+            api-endpoint: https://api.github.com
+    credentials:
+        - host: github.com
+          password: $LOCAL_GITHUB_ACCESS_TOKEN
+          type: git_source
+          username: x-access-token
+output:
+    - type: create_dependency_submission
+      expect:
+        data:
+            version: 1
+            sha: 6c7557f98092fee58a96b9f4cb1a0ec7e2472cb1
+            ref: refs/heads/main
+            job:
+                correlator: dependabot-go_modules-go-graphs-replace-local
+                id: cli
+            detector:
+                name: dependabot
+                url: https://github.com/dependabot/dependabot-core
+                version: 0.377.0
+            manifests: {}
+            metadata:
+                scanned_manifest_path: golang::/go/graphs/replace-local
+                status: ok
+    - type: mark_as_processed
+      expect:
+        data:
+            base-commit-sha: 6c7557f98092fee58a96b9f4cb1a0ec7e2472cb1

--- a/tests/smoke-go-graph-replace-remote.yaml
+++ b/tests/smoke-go-graph-replace-remote.yaml
@@ -1,0 +1,41 @@
+input:
+    job:
+        command: graph
+        package-manager: go_modules
+        allowed-updates:
+            - update-type: all
+        source:
+            provider: github
+            repo: dependabot/smoke-tests
+            directories:
+                - /go/graphs/replace-remote
+            commit: 6c7557f98092fee58a96b9f4cb1a0ec7e2472cb1
+            hostname: github.com
+            api-endpoint: https://api.github.com
+    credentials:
+        - host: github.com
+          password: $LOCAL_GITHUB_ACCESS_TOKEN
+          type: git_source
+          username: x-access-token
+output:
+    - type: create_dependency_submission
+      expect:
+        data:
+            version: 1
+            sha: 6c7557f98092fee58a96b9f4cb1a0ec7e2472cb1
+            ref: refs/heads/main
+            job:
+                correlator: dependabot-go_modules-go-graphs-replace-remote
+                id: cli
+            detector:
+                name: dependabot
+                url: https://github.com/dependabot/dependabot-core
+                version: 0.377.0
+            manifests: {}
+            metadata:
+                scanned_manifest_path: golang::/go/graphs/replace-remote
+                status: ok
+    - type: mark_as_processed
+      expect:
+        data:
+            base-commit-sha: 6c7557f98092fee58a96b9f4cb1a0ec7e2472cb1

--- a/tests/smoke-go-graph-replace-subproject.yaml
+++ b/tests/smoke-go-graph-replace-subproject.yaml
@@ -1,0 +1,66 @@
+input:
+    job:
+        command: graph
+        package-manager: go_modules
+        allowed-updates:
+            - update-type: all
+        source:
+            provider: github
+            repo: dependabot/smoke-tests
+            directories:
+                - /go/graphs/replace-subproject
+            commit: 6c7557f98092fee58a96b9f4cb1a0ec7e2472cb1
+            hostname: github.com
+            api-endpoint: https://api.github.com
+    credentials:
+        - host: github.com
+          password: $LOCAL_GITHUB_ACCESS_TOKEN
+          type: git_source
+          username: x-access-token
+output:
+    - type: create_dependency_submission
+      expect:
+        data:
+            version: 1
+            sha: 6c7557f98092fee58a96b9f4cb1a0ec7e2472cb1
+            ref: refs/heads/main
+            job:
+                correlator: dependabot-go_modules-go-graphs-replace-subproject
+                id: cli
+            detector:
+                name: dependabot
+                url: https://github.com/dependabot/dependabot-core
+                version: 0.377.0
+            manifests:
+                /go/graphs/replace-subproject/go.mod:
+                    file:
+                        source_location: go/graphs/replace-subproject/go.mod
+                    metadata:
+                        blob_oid: 9a414f014ac3bd884bc4f545ceda32454b99545c
+                        ecosystem: golang
+                    name: /go/graphs/replace-subproject/go.mod
+                    resolved:
+                        pkg:golang/golang.org/x/text@v0.4.0:
+                            dependencies: []
+                            package_url: pkg:golang/golang.org/x/text@v0.4.0
+                            relationship: indirect
+                            scope: runtime
+                        pkg:golang/rsc.io/quote@v1.5.0:
+                            dependencies:
+                                - pkg:golang/rsc.io/sampler@v1.3.0
+                            package_url: pkg:golang/rsc.io/quote@v1.5.0
+                            relationship: direct
+                            scope: runtime
+                        pkg:golang/rsc.io/sampler@v1.3.0:
+                            dependencies:
+                                - pkg:golang/golang.org/x/text@v0.4.0
+                            package_url: pkg:golang/rsc.io/sampler@v1.3.0
+                            relationship: indirect
+                            scope: runtime
+            metadata:
+                scanned_manifest_path: golang::/go/graphs/replace-subproject
+                status: ok
+    - type: mark_as_processed
+      expect:
+        data:
+            base-commit-sha: 6c7557f98092fee58a96b9f4cb1a0ec7e2472cb1


### PR DESCRIPTION
This PR adds a set of four smoke tests that act as regression coverage for uncommon but important Go scenarios:

- When you have a private package we cannot access
- When there is a replace statement that:
  - Replaces a package with a local folder that isn't checked in
  - Replaces a package with an alternative remote package
  - Replaces a package with a relative path ( i.e. a subproject )

These tests capture _current_ behaviour as a baseline before we make a more general pass on how we handle this kind of 'alias' directive consistently across ecosystems so it is likely we will make behaviour changes in the next month that will require regenerating these tests.