### PR TITLE
fix correctness issues and reduce redundant comments

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,9 +10,9 @@ Before running or regenerating any smoke tests, you must:
 
 1. **Install the Dependabot CLI** by running `go install github.com/dependabot/cli/cmd/dependabot@latest`. This installs the latest released version onto your `$PATH`. Requires Go to be installed.
 
-2. **Set up TLS certificates** by running `script/setup-tls.sh`. In sandboxed environments (GitHub Codespaces, GitHub Actions) a TLS-intercepting proxy re-signs all outbound HTTPS traffic with a mkcert CA. This script disables the runc shim's certificate bind mounts so the Dependabot CLI's containers keep their original cert stores. The helper scripts (`script/run-one.sh`, `script/regen.sh`) automatically detect the mkcert CA and pass `--proxy-cert` to the CLI.
+2. **Set up TLS certificates** by running `script/setup-tls.sh`. This is only needed in the Copilot coding agent's sandboxed environment, where a TLS-intercepting proxy re-signs all outbound HTTPS traffic with a mkcert CA. The script disables the runc shim's certificate bind mounts so the Dependabot CLI's containers keep their original cert stores, and is a no-op outside that environment (e.g. Codespaces, GitHub Actions, local machines). The helper scripts (`script/run-one.sh`, `script/regen.sh`) automatically detect the mkcert CA and pass `--proxy-cert` to the CLI.
 
-Both steps are required every time a new environment is created (e.g. a fresh Codespace or a new CI job).
+Both steps are required every time a new sandboxed environment is created.
 
 ## Running and Regenerating Tests
 
@@ -57,4 +57,4 @@ The `package-manager` field in test YAML uses internal Dependabot names, which d
 
 ## Troubleshooting TLS
 
-If you see errors like `Cannot handshake client`, `CAfile: none`, or `server certificate verification failed` when running smoke tests, make sure you have run both setup steps above. The `--proxy-cert` flag passes the mkcert CA to the Dependabot proxy so it can verify the infrastructure's MITM certificates on outbound connections.
+If you see errors like `Cannot handshake client`, `CAfile: none`, or `server certificate verification failed` when running smoke tests in the Copilot coding agent's sandboxed environment, make sure you have run `script/setup-tls.sh`. The `--proxy-cert` flag (passed automatically by the helper scripts) gives the mkcert CA to the Dependabot proxy so it can verify the infrastructure's MITM certificates on outbound connections.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ The `script/regen.sh` script regenerates one or more smoke test files locally. I
 # Basic usage — regenerate with the released CLI
 script/regen.sh tests/smoke-bundler.yaml
 
+# Regenerate everything (e.g. after a breaking change in dependabot-core)
+script/regen.sh tests/smoke-*.yaml
+
 # Use a pre-built updater image
 script/regen.sh --updater-image my-image:latest tests/smoke-bundler.yaml
 

--- a/script/regen.sh
+++ b/script/regen.sh
@@ -7,9 +7,6 @@ if [ ! -x "$DEPENDABOT" ]; then
   exit 1
 fi
 
-# In sandboxed environments with TLS interception (e.g. Codespaces),
-# pass the mkcert CA to the proxy so it can verify MITM certs.
-# Requires script/setup-tls.sh to have been run first.
 PROXY_CERT_ARGS=()
 MKCERT_CA="/home/runner/work/_temp/runtime-logs/mkcert/rootCA.pem"
 if [ -f "$MKCERT_CA" ]; then

--- a/script/run-one.sh
+++ b/script/run-one.sh
@@ -7,9 +7,6 @@ if [ ! -x "$DEPENDABOT" ]; then
   exit 1
 fi
 
-# In sandboxed environments with TLS interception (e.g. Codespaces),
-# pass the mkcert CA to the proxy so it can verify MITM certs.
-# Requires script/setup-tls.sh to have been run first.
 PROXY_CERT_ARGS=()
 MKCERT_CA="/home/runner/work/_temp/runtime-logs/mkcert/rootCA.pem"
 if [ -f "$MKCERT_CA" ]; then

--- a/script/setup-tls.sh
+++ b/script/setup-tls.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-# Sets up TLS certificates for running Dependabot CLI in sandboxed environments
-# (GitHub Codespaces / GitHub Actions with TLS interception).
+# Sets up TLS certificates for running Dependabot CLI in the Copilot coding
+# agent's sandboxed environment, which uses TLS interception. Not needed in
+# Codespaces or GitHub Actions.
 #
-# In these environments, a runc shim intercepts container creation and replaces
+# In this environment, a runc shim intercepts container creation and replaces
 # /etc/ssl/certs/ with only a mkcert CA cert. This breaks the Dependabot CLI's
 # proxy<->updater trust chain because the proxy's dynamic MITM CA (dbot-ca.crt)
 # gets overwritten.


### PR DESCRIPTION
The TLS setup is only needed in Copilot's sandbox environments. Corrected comments related to that and other miscellaneous cleanups.