### PR TITLE
only run tests changed in CI for PRs

### DIFF
--- a/.github/workflows/list-suites.yml
+++ b/.github/workflows/list-suites.yml
@@ -2,10 +2,10 @@ name: List Suites
 on:  # yamllint disable-line rule:truthy
   workflow_call:
     inputs:
-      base_ref:
+      base_sha:
         description: >
-          If set, only emit suites affected by changes between this base ref
-          and HEAD. Unset (default) emits every suite in tests/.
+          If set, only emit suites affected by changes between this base
+          commit SHA and HEAD. Unset (default) emits every suite in tests/.
         required: false
         type: string
         default: ""
@@ -19,13 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          # Need history so we can diff against the base ref.
+          # Need history so we can diff against the base SHA.
           fetch-depth: 0
 
       - name: Compute suite list
         id: suites
         env:
-          BASE_REF: ${{ inputs.base_ref }}
+          BASE_SHA: ${{ inputs.base_sha }}
         run: |
           set -euo pipefail
 
@@ -41,13 +41,14 @@ jobs:
             echo "suite=$list" >> "$GITHUB_OUTPUT"
           }
 
-          if [ -z "$BASE_REF" ]; then
+          if [ -z "$BASE_SHA" ]; then
             emit "$(all_suites)"
             exit 0
           fi
 
-          git fetch --no-tags --depth=1 origin "$BASE_REF"
-          changed=$(git diff --name-only "origin/$BASE_REF...HEAD")
+          # The base SHA is immutable, so the diff is stable even if the
+          # base branch advances during the run.
+          changed=$(git diff --name-only "$BASE_SHA...HEAD")
           echo "Changed files:"
           echo "$changed"
 
@@ -58,87 +59,21 @@ jobs:
             exit 0
           fi
 
-          # Filter a newline-separated list of test yaml paths (on stdin)
-          # down to those whose source.repo is this repository. Tests that
-          # pull manifests from external repos (e.g.
-          # smoke-npm-yarn-berry-workspaces uses dsp-testing/...) are not
-          # affected by local file changes.
-          local_only() {
-            while IFS= read -r f; do
-              [ -z "$f" ] && continue
-              if grep -qE '^[[:space:]]+repo: dependabot/smoke-tests$' "$f"; then
-                echo "$f"
-              fi
-            done
-          }
-
-          # Build the affected suite set:
-          #   1. Direct edits to tests/smoke-<name>.yaml → <name>
-          #      (no source.repo filter — editing the YAML means you want
-          #      to test it regardless of where it pulls manifests from).
-          #   2. Edits under .github/workflows/ → every local test using the
-          #      github_actions package-manager (e.g. smoke-actions), which
-          #      treats workflow files as its manifest.
-          #   3. Edits under a top-level manifest dir → every local test that
-          #      references that dir via `directory: /<topdir>` (exact or as
-          #      a path prefix). Local tests that target the repo root
-          #      (`directory: /` or `directory: /.`) are also included
-          #      whenever any manifest changes, since they may be affected.
-          #   4. Edits to known root-level manifest files (e.g. .gitmodules
-          #      for the submodules ecosystem) flag a manifest change so
-          #      root-targeting tests are picked up.
+          # Build the affected suite set. Each test pins its source to a
+          # specific commit SHA, so manifest edits on this branch do not
+          # change what any test sees until someone regenerates the YAML
+          # and bumps the commit. That means the only PR change that can
+          # affect a test's outcome is an edit to its own YAML.
           suites=""
-          manifest_changed=0
           while IFS= read -r path; do
-            [ -z "$path" ] && continue
             case "$path" in
               tests/smoke-*.yaml)
                 name="${path#tests/smoke-}"
                 name="${name%.yaml}"
                 suites+="$name"$'\n'
                 ;;
-              .github/workflows/*)
-                # Workflow files are themselves a manifest type exercised
-                # by github_actions suites (which scan the whole repo).
-                manifest_changed=1
-                actions_matches=$(grep -lE '^[[:space:]]+package-manager: github_actions$' tests/smoke-*.yaml | local_only || true)
-                if [ -n "$actions_matches" ]; then
-                  suites+=$(echo "$actions_matches" | sed 's|tests/smoke-||;s|\.yaml$||')$'\n'
-                fi
-                ;;
-              */*)
-                topdir="${path%%/*}"
-                # Skip non-manifest top-level paths.
-                case "$topdir" in
-                  tests|script|.github|.devcontainer|.idea) continue ;;
-                esac
-                manifest_changed=1
-                # Match `directory: /<topdir>` exactly or as a path prefix
-                # (e.g. /bundler or /bundler/multi-dir/foo, but not /bundler2).
-                matches=$(grep -lE "directory: /${topdir}(/|$)" tests/smoke-*.yaml | local_only || true)
-                if [ -n "$matches" ]; then
-                  suites+=$(echo "$matches" | sed 's|tests/smoke-||;s|\.yaml$||')$'\n'
-                fi
-                ;;
-              *)
-                # Root-level files. Only known manifest files trigger a run;
-                # anything else (README.md, CODEOWNERS, .gitattributes, …)
-                # is ignored.
-                case "$path" in
-                  .gitmodules) manifest_changed=1 ;;
-                esac
-                ;;
             esac
           done <<<"$changed"
-
-          if [ "$manifest_changed" = "1" ]; then
-            # Local tests with `directory: /` or `directory: /.` operate on
-            # the repo root, so any manifest change may affect them.
-            root_matches=$(grep -lE 'directory: /\.?$' tests/smoke-*.yaml | local_only || true)
-            if [ -n "$root_matches" ]; then
-              suites+=$(echo "$root_matches" | sed 's|tests/smoke-||;s|\.yaml$||')$'\n'
-            fi
-          fi
 
           emit "$suites"
     outputs:

--- a/.github/workflows/list-suites.yml
+++ b/.github/workflows/list-suites.yml
@@ -60,11 +60,15 @@ jobs:
 
           # Build the affected suite set:
           #   1. Direct edits to tests/smoke-<name>.yaml → <name>.
-          #   2. Edits under a top-level manifest dir → every test that
+          #   2. Edits under .github/workflows/ → every test using the
+          #      github_actions package-manager (e.g. smoke-actions), which
+          #      treats workflow files as its manifest.
+          #   3. Edits under a top-level manifest dir → every test that
           #      references that dir via `directory: /<topdir>` (exact or as
           #      a path prefix). Tests that target the repo root
-          #      (`directory: /`) are also included whenever any manifest
-          #      dir changes, since they may be affected.
+          #      (`directory: /` or `directory: /.`) are also included
+          #      whenever any manifest dir changes, since they may be
+          #      affected.
           suites=""
           manifest_changed=0
           while IFS= read -r path; do
@@ -74,6 +78,15 @@ jobs:
                 name="${path#tests/smoke-}"
                 name="${name%.yaml}"
                 suites+="$name"$'\n'
+                ;;
+              .github/workflows/*)
+                # Workflow files are themselves a manifest type exercised
+                # by github_actions suites (which scan the whole repo).
+                manifest_changed=1
+                actions_matches=$(grep -lE '^\s+package-manager: github_actions$' tests/smoke-*.yaml || true)
+                if [ -n "$actions_matches" ]; then
+                  suites+=$(echo "$actions_matches" | sed 's|tests/smoke-||;s|\.yaml$||')$'\n'
+                fi
                 ;;
               */*)
                 topdir="${path%%/*}"
@@ -93,8 +106,9 @@ jobs:
           done <<<"$changed"
 
           if [ "$manifest_changed" = "1" ]; then
-            # Tests with `directory: /` operate on the repo root.
-            root_matches=$(grep -lE 'directory: /$' tests/smoke-*.yaml || true)
+            # Tests with `directory: /` or `directory: /.` operate on the
+            # repo root, so any manifest-dir change may affect them.
+            root_matches=$(grep -lE 'directory: /\.?$' tests/smoke-*.yaml || true)
             if [ -n "$root_matches" ]; then
               suites+=$(echo "$root_matches" | sed 's|tests/smoke-||;s|\.yaml$||')$'\n'
             fi

--- a/.github/workflows/list-suites.yml
+++ b/.github/workflows/list-suites.yml
@@ -47,8 +47,10 @@ jobs:
           fi
 
           # The base SHA is immutable, so the diff is stable even if the
-          # base branch advances during the run.
-          changed=$(git diff --name-only "$BASE_SHA...HEAD")
+          # base branch advances during the run. --diff-filter=ACMRT
+          # excludes deletions (D) so removed test YAMLs aren't queued for
+          # the matrix.
+          changed=$(git diff --name-only --diff-filter=ACMRT "$BASE_SHA...HEAD")
           echo "Changed files:"
           echo "$changed"
 

--- a/.github/workflows/list-suites.yml
+++ b/.github/workflows/list-suites.yml
@@ -58,17 +58,35 @@ jobs:
             exit 0
           fi
 
+          # Filter a newline-separated list of test yaml paths (on stdin)
+          # down to those whose source.repo is this repository. Tests that
+          # pull manifests from external repos (e.g.
+          # smoke-npm-yarn-berry-workspaces uses dsp-testing/...) are not
+          # affected by local file changes.
+          local_only() {
+            while IFS= read -r f; do
+              [ -z "$f" ] && continue
+              if grep -qE '^[[:space:]]+repo: dependabot/smoke-tests$' "$f"; then
+                echo "$f"
+              fi
+            done
+          }
+
           # Build the affected suite set:
-          #   1. Direct edits to tests/smoke-<name>.yaml → <name>.
-          #   2. Edits under .github/workflows/ → every test using the
+          #   1. Direct edits to tests/smoke-<name>.yaml → <name>
+          #      (no source.repo filter — editing the YAML means you want
+          #      to test it regardless of where it pulls manifests from).
+          #   2. Edits under .github/workflows/ → every local test using the
           #      github_actions package-manager (e.g. smoke-actions), which
           #      treats workflow files as its manifest.
-          #   3. Edits under a top-level manifest dir → every test that
+          #   3. Edits under a top-level manifest dir → every local test that
           #      references that dir via `directory: /<topdir>` (exact or as
-          #      a path prefix). Tests that target the repo root
+          #      a path prefix). Local tests that target the repo root
           #      (`directory: /` or `directory: /.`) are also included
-          #      whenever any manifest dir changes, since they may be
-          #      affected.
+          #      whenever any manifest changes, since they may be affected.
+          #   4. Edits to known root-level manifest files (e.g. .gitmodules
+          #      for the submodules ecosystem) flag a manifest change so
+          #      root-targeting tests are picked up.
           suites=""
           manifest_changed=0
           while IFS= read -r path; do
@@ -83,7 +101,7 @@ jobs:
                 # Workflow files are themselves a manifest type exercised
                 # by github_actions suites (which scan the whole repo).
                 manifest_changed=1
-                actions_matches=$(grep -lE '^\s+package-manager: github_actions$' tests/smoke-*.yaml || true)
+                actions_matches=$(grep -lE '^[[:space:]]+package-manager: github_actions$' tests/smoke-*.yaml | local_only || true)
                 if [ -n "$actions_matches" ]; then
                   suites+=$(echo "$actions_matches" | sed 's|tests/smoke-||;s|\.yaml$||')$'\n'
                 fi
@@ -97,18 +115,26 @@ jobs:
                 manifest_changed=1
                 # Match `directory: /<topdir>` exactly or as a path prefix
                 # (e.g. /bundler or /bundler/multi-dir/foo, but not /bundler2).
-                matches=$(grep -lE "directory: /${topdir}(/|$)" tests/smoke-*.yaml || true)
+                matches=$(grep -lE "directory: /${topdir}(/|$)" tests/smoke-*.yaml | local_only || true)
                 if [ -n "$matches" ]; then
                   suites+=$(echo "$matches" | sed 's|tests/smoke-||;s|\.yaml$||')$'\n'
                 fi
+                ;;
+              *)
+                # Root-level files. Only known manifest files trigger a run;
+                # anything else (README.md, CODEOWNERS, .gitattributes, …)
+                # is ignored.
+                case "$path" in
+                  .gitmodules) manifest_changed=1 ;;
+                esac
                 ;;
             esac
           done <<<"$changed"
 
           if [ "$manifest_changed" = "1" ]; then
-            # Tests with `directory: /` or `directory: /.` operate on the
-            # repo root, so any manifest-dir change may affect them.
-            root_matches=$(grep -lE 'directory: /\.?$' tests/smoke-*.yaml || true)
+            # Local tests with `directory: /` or `directory: /.` operate on
+            # the repo root, so any manifest change may affect them.
+            root_matches=$(grep -lE 'directory: /\.?$' tests/smoke-*.yaml | local_only || true)
             if [ -n "$root_matches" ]; then
               suites+=$(echo "$root_matches" | sed 's|tests/smoke-||;s|\.yaml$||')$'\n'
             fi

--- a/.github/workflows/list-suites.yml
+++ b/.github/workflows/list-suites.yml
@@ -1,6 +1,14 @@
 name: List Suites
 on:  # yamllint disable-line rule:truthy
   workflow_call:
+    inputs:
+      base_ref:
+        description: >
+          If set, only emit suites affected by changes between this base ref
+          and HEAD. Unset (default) emits every suite in tests/.
+        required: false
+        type: string
+        default: ""
     outputs:
       suites:
         description: List of suites to run from the tests/ directory
@@ -10,9 +18,88 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Get workflow names
+        with:
+          # Need history so we can diff against the base ref.
+          fetch-depth: 0
+
+      - name: Compute suite list
         id: suites
+        env:
+          BASE_REF: ${{ inputs.base_ref }}
         run: |
-          echo "suite=$(ls tests | sed 's/^tests\///' | sed 's/smoke-//' | sed 's/.yaml$//' | jq -R | jq -sc)" >> $GITHUB_OUTPUT
+          set -euo pipefail
+
+          all_suites() {
+            ls tests | sed 's/^tests\///;s/smoke-//;s/\.yaml$//'
+          }
+
+          emit() {
+            # $1 is a newline-separated suite list (possibly empty).
+            local list
+            list=$(printf '%s\n' "$1" | sed '/^$/d' | sort -u | jq -R | jq -sc)
+            echo "Suites: $list"
+            echo "suite=$list" >> "$GITHUB_OUTPUT"
+          }
+
+          if [ -z "$BASE_REF" ]; then
+            emit "$(all_suites)"
+            exit 0
+          fi
+
+          git fetch --no-tags --depth=1 origin "$BASE_REF"
+          changed=$(git diff --name-only "origin/$BASE_REF...HEAD")
+          echo "Changed files:"
+          echo "$changed"
+
+          # Any change to shared infra forces a full run.
+          if echo "$changed" | grep -qE '^(script/|\.github/workflows/(smoke|list-suites)\.yml$)'; then
+            echo "Shared infra changed — running full suite."
+            emit "$(all_suites)"
+            exit 0
+          fi
+
+          # Build the affected suite set:
+          #   1. Direct edits to tests/smoke-<name>.yaml → <name>.
+          #   2. Edits under a top-level manifest dir → every test that
+          #      references that dir via `directory: /<topdir>` (exact or as
+          #      a path prefix). Tests that target the repo root
+          #      (`directory: /`) are also included whenever any manifest
+          #      dir changes, since they may be affected.
+          suites=""
+          manifest_changed=0
+          while IFS= read -r path; do
+            [ -z "$path" ] && continue
+            case "$path" in
+              tests/smoke-*.yaml)
+                name="${path#tests/smoke-}"
+                name="${name%.yaml}"
+                suites+="$name"$'\n'
+                ;;
+              */*)
+                topdir="${path%%/*}"
+                # Skip non-manifest top-level paths.
+                case "$topdir" in
+                  tests|script|.github|.devcontainer|.idea) continue ;;
+                esac
+                manifest_changed=1
+                # Match `directory: /<topdir>` exactly or as a path prefix
+                # (e.g. /bundler or /bundler/multi-dir/foo, but not /bundler2).
+                matches=$(grep -lE "directory: /${topdir}(/|$)" tests/smoke-*.yaml || true)
+                if [ -n "$matches" ]; then
+                  suites+=$(echo "$matches" | sed 's|tests/smoke-||;s|\.yaml$||')$'\n'
+                fi
+                ;;
+            esac
+          done <<<"$changed"
+
+          if [ "$manifest_changed" = "1" ]; then
+            # Tests with `directory: /` operate on the repo root.
+            root_matches=$(grep -lE 'directory: /$' tests/smoke-*.yaml || true)
+            if [ -n "$root_matches" ]; then
+              suites+=$(echo "$root_matches" | sed 's|tests/smoke-||;s|\.yaml$||')$'\n'
+            fi
+          fi
+
+          emit "$suites"
     outputs:
       suites: ${{ steps.suites.outputs.suite }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -14,10 +14,15 @@ env:
 jobs:
   suites:
     uses: ./.github/workflows/list-suites.yml
+    with:
+      # On PRs, restrict the matrix to suites affected by the diff.
+      # On schedule / workflow_dispatch, leave empty to run all suites.
+      base_ref: ${{ github.event_name == 'pull_request' && github.base_ref || '' }}
 
   smoke:
     runs-on: ubuntu-latest
     needs: [suites]
+    if: needs.suites.outputs.suites != '[]'
     strategy:
       fail-fast: false
       max-parallel: 10

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -17,7 +17,7 @@ jobs:
     with:
       # On PRs, restrict the matrix to suites affected by the diff.
       # On schedule / workflow_dispatch, leave empty to run all suites.
-      base_ref: ${{ github.event_name == 'pull_request' && github.base_ref || '' }}
+      base_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
 
   smoke:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Every PR is running all smoke tests which quickly exhausts the API allowance. This (should) make it so it will only run the tests changed when raising a PR. 

Note that only tests that have been modified need to be run. All tests should be pinned to a Git SHA and so modifying manifests alone should not break anything.