### PR TITLE
Extend Python graph smoke tests

### DIFF
--- a/poetry-ephemeral-graph/pyproject.toml
+++ b/poetry-ephemeral-graph/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.poetry]
+name = "smoke-poetry-ephemeral-graph"
+version = "0.1.0"
+description = "Smoke test for ephemeral lockfile generation (no committed poetry.lock)"
+authors = ["Test <test@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.9"
+requests = "2.31.0"
+flask = "3.0.0"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/smoke-pip-compile-graph.yaml
+++ b/tests/smoke-pip-compile-graph.yaml
@@ -1,0 +1,81 @@
+input:
+    job:
+        command: graph
+        package-manager: pip
+        allowed-updates:
+            - update-type: all
+        ignore-conditions:
+            - dependency-name: django
+              source: tests/smoke-pip-compile-graph.yaml
+              version-requirement: '>3.2.14'
+            - dependency-name: numpy
+              source: tests/smoke-pip-compile-graph.yaml
+              version-requirement: '>1.23.0'
+        source:
+            provider: github
+            repo: dependabot/smoke-tests
+            directories:
+                - /pip-compile
+            commit: 8230ed21d3b924bb0bf183883b040e7195ce6902
+            hostname: github.com
+            api-endpoint: https://api.github.com
+    credentials:
+        - host: github.com
+          password: $LOCAL_GITHUB_ACCESS_TOKEN
+          type: git_source
+          username: x-access-token
+output:
+    - type: create_dependency_submission
+      expect:
+        data:
+            version: 1
+            sha: 8230ed21d3b924bb0bf183883b040e7195ce6902
+            ref: refs/heads/main
+            job:
+                correlator: dependabot-pip-pip-compile
+                id: cli
+            detector:
+                name: dependabot
+                url: https://github.com/dependabot/dependabot-core
+                version: 0.380.0
+            manifests:
+                /pip-compile/requirements.txt:
+                    file:
+                        source_location: pip-compile/requirements.txt
+                    metadata:
+                        blob_oid: e7b848cd84e575287b9e2265242f110bbe1a1906
+                        ecosystem: pypi
+                    name: /pip-compile/requirements.txt
+                    resolved:
+                        pkg:pypi/asgiref@3.5.2:
+                            dependencies: []
+                            package_url: pkg:pypi/asgiref@3.5.2
+                            relationship: indirect
+                            scope: runtime
+                        pkg:pypi/django@3.2.14:
+                            dependencies: []
+                            package_url: pkg:pypi/django@3.2.14
+                            relationship: direct
+                            scope: runtime
+                        pkg:pypi/numpy@1.23.0:
+                            dependencies: []
+                            package_url: pkg:pypi/numpy@1.23.0
+                            relationship: direct
+                            scope: runtime
+                        pkg:pypi/pytz@2022.1:
+                            dependencies: []
+                            package_url: pkg:pypi/pytz@2022.1
+                            relationship: indirect
+                            scope: runtime
+                        pkg:pypi/sqlparse@0.4.2:
+                            dependencies: []
+                            package_url: pkg:pypi/sqlparse@0.4.2
+                            relationship: indirect
+                            scope: runtime
+            metadata:
+                scanned_manifest_path: pypi::/pip-compile
+                status: ok
+    - type: mark_as_processed
+      expect:
+        data:
+            base-commit-sha: 8230ed21d3b924bb0bf183883b040e7195ce6902

--- a/tests/smoke-pip-graph.yaml
+++ b/tests/smoke-pip-graph.yaml
@@ -1,0 +1,84 @@
+input:
+    job:
+        command: graph
+        package-manager: pip
+        allowed-updates:
+            - update-type: all
+        ignore-conditions:
+            - dependency-name: django
+              source: tests/smoke-pip-graph.yaml
+              version-requirement: '>3.2.14'
+            - dependency-name: requests
+              source: tests/smoke-pip-graph.yaml
+              version-requirement: '>2.28.0'
+            - dependency-name: numpy
+              source: tests/smoke-pip-graph.yaml
+              version-requirement: '>1.23.0'
+        source:
+            provider: github
+            repo: dependabot/smoke-tests
+            directories:
+                - /pip
+            commit: 8230ed21d3b924bb0bf183883b040e7195ce6902
+            hostname: github.com
+            api-endpoint: https://api.github.com
+    credentials:
+        - host: github.com
+          password: $LOCAL_GITHUB_ACCESS_TOKEN
+          type: git_source
+          username: x-access-token
+output:
+    - type: create_dependency_submission
+      expect:
+        data:
+            version: 1
+            sha: 8230ed21d3b924bb0bf183883b040e7195ce6902
+            ref: refs/heads/main
+            job:
+                correlator: dependabot-pip-pip
+                id: cli
+            detector:
+                name: dependabot
+                url: https://github.com/dependabot/dependabot-core
+                version: 0.380.0
+            manifests:
+                /pip/requirements.txt:
+                    file:
+                        source_location: pip/requirements.txt
+                    metadata:
+                        blob_oid: 749bad17894b9934fcab3fb593618b64c3910799
+                        ecosystem: pypi
+                    name: /pip/requirements.txt
+                    resolved:
+                        pkg:pypi/django:
+                            dependencies: []
+                            package_url: pkg:pypi/django
+                            relationship: direct
+                            scope: runtime
+                        pkg:pypi/numpy@1.23.0:
+                            dependencies: []
+                            package_url: pkg:pypi/numpy@1.23.0
+                            relationship: direct
+                            scope: runtime
+                        pkg:pypi/pytest:
+                            dependencies: []
+                            package_url: pkg:pypi/pytest
+                            relationship: direct
+                            scope: runtime
+                        pkg:pypi/pyyaml:
+                            dependencies: []
+                            package_url: pkg:pypi/pyyaml
+                            relationship: direct
+                            scope: runtime
+                        pkg:pypi/requests@2.28.0:
+                            dependencies: []
+                            package_url: pkg:pypi/requests@2.28.0
+                            relationship: direct
+                            scope: runtime
+            metadata:
+                scanned_manifest_path: pypi::/pip
+                status: ok
+    - type: mark_as_processed
+      expect:
+        data:
+            base-commit-sha: 8230ed21d3b924bb0bf183883b040e7195ce6902

--- a/tests/smoke-poetry-ephemeral-graph.yaml
+++ b/tests/smoke-poetry-ephemeral-graph.yaml
@@ -1,0 +1,145 @@
+input:
+    job:
+        command: graph
+        package-manager: pip
+        allowed-updates:
+            - update-type: all
+        ignore-conditions:
+            - dependency-name: requests
+              source: tests/smoke-poetry-ephemeral-graph.yaml
+              version-requirement: '>2.31.0'
+            - dependency-name: flask
+              source: tests/smoke-poetry-ephemeral-graph.yaml
+              version-requirement: '>3.0.0'
+        source:
+            provider: github
+            repo: dependabot/smoke-tests
+            directories:
+                - /poetry-ephemeral-graph
+            commit: 8230ed21d3b924bb0bf183883b040e7195ce6902
+            hostname: github.com
+            api-endpoint: https://api.github.com
+    credentials:
+        - host: github.com
+          password: $LOCAL_GITHUB_ACCESS_TOKEN
+          type: git_source
+          username: x-access-token
+output:
+    - type: create_dependency_submission
+      expect:
+        data:
+            version: 1
+            sha: 8230ed21d3b924bb0bf183883b040e7195ce6902
+            ref: refs/heads/main
+            job:
+                correlator: dependabot-pip-poetry-ephemeral-graph
+                id: cli
+            detector:
+                name: dependabot
+                url: https://github.com/dependabot/dependabot-core
+                version: 0.380.0
+            manifests:
+                /poetry-ephemeral-graph/pyproject.toml:
+                    file:
+                        source_location: poetry-ephemeral-graph/pyproject.toml
+                    metadata:
+                        blob_oid: 08657e0cd1918359821b881efb2d78d35c06ece9
+                        ecosystem: pypi
+                    name: /poetry-ephemeral-graph/pyproject.toml
+                    resolved:
+                        pkg:pypi/blinker@1.9.0:
+                            dependencies: []
+                            package_url: pkg:pypi/blinker@1.9.0
+                            relationship: indirect
+                            scope: runtime
+                        pkg:pypi/certifi@2026.5.20:
+                            dependencies: []
+                            package_url: pkg:pypi/certifi@2026.5.20
+                            relationship: indirect
+                            scope: runtime
+                        pkg:pypi/charset-normalizer@3.4.7:
+                            dependencies: []
+                            package_url: pkg:pypi/charset-normalizer@3.4.7
+                            relationship: indirect
+                            scope: runtime
+                        pkg:pypi/click@8.1.8:
+                            dependencies:
+                                - pkg:pypi/colorama@0.4.6
+                            package_url: pkg:pypi/click@8.1.8
+                            relationship: indirect
+                            scope: runtime
+                        pkg:pypi/colorama@0.4.6:
+                            dependencies: []
+                            package_url: pkg:pypi/colorama@0.4.6
+                            relationship: indirect
+                            scope: development
+                        pkg:pypi/flask@3.0.0:
+                            dependencies:
+                                - pkg:pypi/blinker@1.9.0
+                                - pkg:pypi/click@8.1.8
+                                - pkg:pypi/importlib-metadata@8.7.1
+                                - pkg:pypi/itsdangerous@2.2.0
+                                - pkg:pypi/jinja2@3.1.6
+                                - pkg:pypi/werkzeug@3.1.8
+                            package_url: pkg:pypi/flask@3.0.0
+                            relationship: direct
+                            scope: runtime
+                        pkg:pypi/idna@3.18:
+                            dependencies: []
+                            package_url: pkg:pypi/idna@3.18
+                            relationship: indirect
+                            scope: runtime
+                        pkg:pypi/importlib-metadata@8.7.1:
+                            dependencies:
+                                - pkg:pypi/zipp@3.23.1
+                            package_url: pkg:pypi/importlib-metadata@8.7.1
+                            relationship: indirect
+                            scope: development
+                        pkg:pypi/itsdangerous@2.2.0:
+                            dependencies: []
+                            package_url: pkg:pypi/itsdangerous@2.2.0
+                            relationship: indirect
+                            scope: runtime
+                        pkg:pypi/jinja2@3.1.6:
+                            dependencies:
+                                - pkg:pypi/markupsafe@3.0.3
+                            package_url: pkg:pypi/jinja2@3.1.6
+                            relationship: indirect
+                            scope: runtime
+                        pkg:pypi/markupsafe@3.0.3:
+                            dependencies: []
+                            package_url: pkg:pypi/markupsafe@3.0.3
+                            relationship: indirect
+                            scope: runtime
+                        pkg:pypi/requests@2.31.0:
+                            dependencies:
+                                - pkg:pypi/certifi@2026.5.20
+                                - pkg:pypi/charset-normalizer@3.4.7
+                                - pkg:pypi/idna@3.18
+                                - pkg:pypi/urllib3@2.6.3
+                            package_url: pkg:pypi/requests@2.31.0
+                            relationship: direct
+                            scope: runtime
+                        pkg:pypi/urllib3@2.6.3:
+                            dependencies: []
+                            package_url: pkg:pypi/urllib3@2.6.3
+                            relationship: indirect
+                            scope: runtime
+                        pkg:pypi/werkzeug@3.1.8:
+                            dependencies:
+                                - pkg:pypi/markupsafe@3.0.3
+                            package_url: pkg:pypi/werkzeug@3.1.8
+                            relationship: indirect
+                            scope: runtime
+                        pkg:pypi/zipp@3.23.1:
+                            dependencies: []
+                            package_url: pkg:pypi/zipp@3.23.1
+                            relationship: indirect
+                            scope: development
+            metadata:
+                scanned_manifest_path: pypi::/poetry-ephemeral-graph
+                status: ok
+    - type: mark_as_processed
+      expect:
+        data:
+            base-commit-sha: 8230ed21d3b924bb0bf183883b040e7195ce6902


### PR DESCRIPTION
This PR adds a batch of graphing scenarios for Python package managers to cover a few package managers we weren't covering so far, as well as capture the intended outcome of a poetry project without a lockfile