### PR TITLE
Add a smoke test that covers graphing a project with no dependencies

### DIFF
--- a/npm/no-dependencies/package-lock.json
+++ b/npm/no-dependencies/package-lock.json
@@ -1,0 +1,15 @@
+{
+  "name": "deprecated-app",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "deprecated-app",
+      "version": "1.0.0",
+      "deprecated": true,
+      "license": "ISC",
+      "devDependencies": {}
+    }
+  }
+}

--- a/npm/no-dependencies/package.json
+++ b/npm/no-dependencies/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "deprecated-app",
+  "version": "1.0.0",
+  "main": "index.js",
+  "description": "⚠️ ARCHIVED - no longer maintained.",
+  "deprecated": true,
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/tests/smoke-go-graph-replace-local.yaml
+++ b/tests/smoke-go-graph-replace-local.yaml
@@ -30,8 +30,16 @@ output:
             detector:
                 name: dependabot
                 url: https://github.com/dependabot/dependabot-core
-                version: 0.377.0
-            manifests: {}
+                version: 0.383.0
+            manifests:
+                /go/graphs/replace-local/go.mod:
+                    file:
+                        source_location: go/graphs/replace-local/go.mod
+                    metadata:
+                        blob_oid: 7c0ab47b4a3e51809be2c24dfcbbf745650224cf
+                        ecosystem: golang
+                    name: /go/graphs/replace-local/go.mod
+                    resolved: {}
             metadata:
                 scanned_manifest_path: golang::/go/graphs/replace-local
                 status: ok

--- a/tests/smoke-go-graph-replace-remote.yaml
+++ b/tests/smoke-go-graph-replace-remote.yaml
@@ -30,8 +30,16 @@ output:
             detector:
                 name: dependabot
                 url: https://github.com/dependabot/dependabot-core
-                version: 0.377.0
-            manifests: {}
+                version: 0.383.0
+            manifests:
+                /go/graphs/replace-remote/go.mod:
+                    file:
+                        source_location: go/graphs/replace-remote/go.mod
+                    metadata:
+                        blob_oid: eaf52b9411bec0de34a80dda837426338a1ac095
+                        ecosystem: golang
+                    name: /go/graphs/replace-remote/go.mod
+                    resolved: {}
             metadata:
                 scanned_manifest_path: golang::/go/graphs/replace-remote
                 status: ok

--- a/tests/smoke-npm-graph-empty.yaml
+++ b/tests/smoke-npm-graph-empty.yaml
@@ -1,0 +1,53 @@
+input:
+    job:
+        command: graph
+        package-manager: npm_and_yarn
+        allowed-updates:
+            - update-type: all
+        source:
+            provider: github
+            repo: dependabot/smoke-tests
+            directories:
+                - /npm/no-dependencies
+            commit: 3e73d6e82c53ccd0c0eb4cdd046cecf01acd240d
+            hostname: github.com
+            api-endpoint: https://api.github.com
+        reject-external-code: true
+    credentials:
+        - host: github.com
+          password: $LOCAL_GITHUB_ACCESS_TOKEN
+          type: git_source
+          username: x-access-token
+        - index-url: https://pypi.org/simple/
+          replaces-base: true
+          type: python_index
+output:
+    - type: create_dependency_submission
+      expect:
+        data:
+            version: 1
+            sha: 3e73d6e82c53ccd0c0eb4cdd046cecf01acd240d
+            ref: refs/heads/main
+            job:
+                correlator: dependabot-npm_and_yarn-npm-no-dependencies
+                id: cli
+            detector:
+                name: dependabot
+                url: https://github.com/dependabot/dependabot-core
+                version: 0.383.0
+            manifests:
+                /npm/no-dependencies/package-lock.json:
+                    file:
+                        source_location: npm/no-dependencies/package-lock.json
+                    metadata:
+                        blob_oid: bf20dc474a3b2fe505baa9e00b02c446f602a3e9
+                        ecosystem: npm
+                    name: /npm/no-dependencies/package-lock.json
+                    resolved: {}
+            metadata:
+                scanned_manifest_path: npm::/npm/no-dependencies
+                status: ok
+    - type: mark_as_processed
+      expect:
+        data:
+            base-commit-sha: 3e73d6e82c53ccd0c0eb4cdd046cecf01acd240d


### PR DESCRIPTION
This covers a corner case we are currently handling in a suboptimal way - a manifest that exists but has no dependencies is indistinguishable from a deleted manifest currently but there's a subtle but important difference now that we need to compare snapshots for PRs.