### PR TITLE
Regenerate vcpkg smoke test for baseline-governed ports

### DIFF
--- a/tests/smoke-vcpkg-builtin-baseline.yaml
+++ b/tests/smoke-vcpkg-builtin-baseline.yaml
@@ -1,5 +1,6 @@
 input:
     job:
+        command: update
         package-manager: vcpkg
         allowed-updates:
             - update-type: all
@@ -42,6 +43,13 @@ output:
                       requirement: '>=8.14.0'
                       source: null
                   version: 8.14.0
+                - name: ms-gsl
+                  requirements:
+                    - file: vcpkg.json
+                      groups: []
+                      requirement: null
+                      source: null
+                  version: 4.0.0#1
             dependency_files:
                 - /vcpkg/builtin-baseline/vcpkg.json
     - type: create_pull_request


### PR DESCRIPTION
Regenerated for [dependabot-core#15676](https://github.com/dependabot/dependabot-core/pull/15676), which adds security update support to the vcpkg ecosystem.

### What changed

Two additions, no deletions:

* **`ms-gsl` now appears in `update_dependency_list`.** vcpkg resolves a bare string dependency's version from `versions/baseline.json` at the commit the manifest pins, and core now does the same. Previously only `curl` was reported, because it carries an explicit `version>=` constraint. This is the point of the core change rather than a side effect: for a security alert to fire on `pkg:vcpkg/ms-gsl`, the dependency submission has to contain `ms-gsl` with a resolved version.
* **`command: update`** in the job input. The fixture predates that CLI field; 63 of the other 100 tests already record it.

`ms-gsl` is correctly reported as up to date, so no pull request is opened for it. A port with no `version>=` constraint takes its version from the baseline, and bumping the baseline is how you move it, so core deliberately leaves those alone during routine runs.

### How it was generated

`dependabot test` against an updater image built from the core branch, using the downloaded proxy cache, the same way the Smoke workflow runs. CLI v1.91.0, matching `go install ...@latest` in CI.

### Note on release notes

An earlier regeneration also dropped the entire release notes block from the vcpkg pull request body. That turned out to be a genuine regression in the core branch rather than fixture drift, which I confirmed by building the updater image from `main` and diffing the two runs.

The cause: a registry baseline's previous version is the ref `master`, and core's new `Vcpkg::Version.correct?` accepted arbitrary strings for vcpkg's `version-string` scheme, so `master` looked like a version. `ReleaseFinder` then compared every release tag against it and discarded them all. Fixed in the core PR by requiring a vcpkg version to contain a digit, which no git ref does. This fixture keeps its release notes.

### Caching

The regeneration ran at 100% cache coverage (46/46). The core change adds a small number of proxy calls for the vcpkg registry, so it is worth running Cache-One after merge.
