### PR TITLE
Update dotnet_sdk prerelease smoke test

### DIFF
--- a/tests/smoke-dotnet-sdk-prerelease.yaml
+++ b/tests/smoke-dotnet-sdk-prerelease.yaml
@@ -47,15 +47,15 @@ output:
                   requirements:
                     - file: global.json
                       groups: []
-                      requirement: 9.0.100.pre.rc.2.24474.11
+                      requirement: 9.0.100-rc.2.24474.11
                       source: null
-                  version: 9.0.100.pre.rc.2.24474.11
+                  version: 9.0.100-rc.2.24474.11
                   directory: /dotnet-sdk/allow-prerelease
             updated-dependency-files:
                 - content: |
                     {
                       "sdk": {
-                        "version": "9.0.100.pre.rc.2.24474.11",
+                        "version": "9.0.100-rc.2.24474.11",
                         "allowPrerelease": true
                       }
                     }
@@ -66,9 +66,9 @@ output:
                   operation: update
                   support_file: false
                   type: file
-            pr-title: Bump dotnet-sdk from 8.0.300 to 9.0.100.pre.rc.2.24474.11 in /dotnet-sdk/allow-prerelease
+            pr-title: Bump dotnet-sdk from 8.0.300 to 9.0.100-rc.2.24474.11 in /dotnet-sdk/allow-prerelease
             pr-body: |
-                Bumps [dotnet-sdk](https://github.com/dotnet/sdk) from 8.0.300 to 9.0.100.pre.rc.2.24474.11.
+                Bumps [dotnet-sdk](https://github.com/dotnet/sdk) from 8.0.300 to 9.0.100-rc.2.24474.11.
                 <details>
                 <summary>Release notes</summary>
                 <p><em>Sourced from <a href="https://github.com/dotnet/sdk/releases">dotnet-sdk's releases</a>.</em></p>
@@ -117,7 +117,7 @@ output:
             commit-message: |-
                 Bump dotnet-sdk in /dotnet-sdk/allow-prerelease
 
-                Bumps [dotnet-sdk](https://github.com/dotnet/sdk) from 8.0.300 to 9.0.100.pre.rc.2.24474.11.
+                Bumps [dotnet-sdk](https://github.com/dotnet/sdk) from 8.0.300 to 9.0.100-rc.2.24474.11.
                 - [Release notes](https://github.com/dotnet/sdk/releases)
                 - [Commits](https://github.com/dotnet/sdk/compare/v8.0.300...v9.0.100-rc.2.24474.11)
     - type: mark_as_processed


### PR DESCRIPTION
Updates the `dotnet_sdk` prerelease fixture for dependabot/dependabot-core#15746.

The updater now preserves the SDK's `-rc` version format.

The smoke check uses the released updater and is expected to fail until the core change is merged. The fixture passes locally against the linked core PR with 44/44 cached calls.
