### PR TITLE
Disable cooldown in Docker multidir smoke test

### DIFF
--- a/tests/smoke-docker-version-multidir.yaml
+++ b/tests/smoke-docker-version-multidir.yaml
@@ -2,6 +2,9 @@ input:
     job:
         command: update
         package-manager: docker
+        cooldown:
+            exclude:
+                - "*"
         allowed-updates:
             - update-type: all
         dependency-groups:

--- a/tests/smoke-docker-version-multidir.yaml
+++ b/tests/smoke-docker-version-multidir.yaml
@@ -3,7 +3,8 @@ input:
         command: update
         package-manager: docker
         cooldown:
-            default-days: 0
+            exclude:
+                - "*"
         allowed-updates:
             - update-type: all
         dependency-groups:

--- a/tests/smoke-docker-version-multidir.yaml
+++ b/tests/smoke-docker-version-multidir.yaml
@@ -3,8 +3,7 @@ input:
         command: update
         package-manager: docker
         cooldown:
-            exclude:
-                - "*"
+            default-days: 0
         allowed-updates:
             - update-type: all
         dependency-groups:


### PR DESCRIPTION
The Docker multidir scenario expects the 6.0 and 7.0 images to update to 8.0. Jobs now apply a three-day cooldown by default, and the mutable MCR 8.0 tags were recently republished, so the updater skips them and resolves 7.0 instead.

This scenario tests grouped updates across directories, not cooldown behavior. Exclude all dependencies from cooldown so mutable tag timestamps do not change its expected result.

The failure is reproducible in dependabot-core PRs #15780 and #15781; their logs show `Skipping tag 8.0 due to cooldown period` immediately before selecting 7.0. A zero-day setting does not work here because the CLI model omits zero-valued cooldown fields during JSON serialization.