### PR TITLE
update smoke tests to include new `directory` property

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # PHP archive files
 *.phar binary
+
+# yarn-berry assets
+*.zip binary

--- a/tests/smoke-nuget-central-package-management.yaml
+++ b/tests/smoke-nuget-central-package-management.yaml
@@ -1,5 +1,6 @@
 input:
     job:
+        command: update
         package-manager: nuget
         allowed-updates:
             - update-type: all
@@ -60,6 +61,7 @@ output:
                         source_url: https://github.com/JamesNK/Newtonsoft.Json
                         type: nuget_repo
                   version: 13.0.3
+                  directory: /nuget/central-package-management
             updated-dependency-files:
                 - content: |-
                     <Project>

--- a/tests/smoke-nuget-compatible-version.yaml
+++ b/tests/smoke-nuget-compatible-version.yaml
@@ -1,5 +1,6 @@
 input:
     job:
+        command: update
         package-manager: nuget
         allowed-updates:
             - update-type: all
@@ -126,6 +127,7 @@ output:
                         source_url: https://github.com/dotnet/aspnetcore
                         type: nuget_repo
                   version: 6.0.25
+                  directory: /nuget/compatible-version
             updated-dependency-files:
                 - content: |-
                     <Project Sdk="Microsoft.NET.Sdk">

--- a/tests/smoke-nuget-dirs-proj.yaml
+++ b/tests/smoke-nuget-dirs-proj.yaml
@@ -1,5 +1,6 @@
 input:
     job:
+        command: update
         package-manager: nuget
         allowed-updates:
             - update-type: all
@@ -68,6 +69,7 @@ output:
                         source_url: https://github.com/NuGet/NuGet.Client
                         type: nuget_repo
                   version: 6.8.0
+                  directory: /nuget/dirs-proj
                 - name: NuGet.Versioning
                   previous-requirements:
                     - file: /nuget/dirs-proj/project2/project.csproj
@@ -85,6 +87,7 @@ output:
                         source_url: https://github.com/NuGet/NuGet.Client
                         type: nuget_repo
                   version: 6.8.0
+                  directory: /nuget/dirs-proj
             updated-dependency-files:
                 - content: |-
                     <Project Sdk="Microsoft.NET.Sdk">

--- a/tests/smoke-nuget-group-multidir.yaml
+++ b/tests/smoke-nuget-group-multidir.yaml
@@ -96,6 +96,7 @@ output:
                         source_url: https://github.com/NuGet/NuGet.Client
                         type: nuget_repo
                   version: 6.2.4
+                  directory: /nuget/multi-dir/foo
                 - name: NuGet.Versioning
                   previous-requirements:
                     - file: /nuget/multi-dir/bar/project.csproj
@@ -113,6 +114,7 @@ output:
                         source_url: https://github.com/NuGet/NuGet.Client
                         type: nuget_repo
                   version: 6.2.4
+                  directory: /nuget/multi-dir/bar
             updated-dependency-files:
                 - content: |
                     <Project Sdk="Microsoft.NET.Sdk">

--- a/tests/smoke-nuget-lockfile.yaml
+++ b/tests/smoke-nuget-lockfile.yaml
@@ -1,5 +1,6 @@
 input:
     job:
+        command: update
         package-manager: nuget
         allowed-updates:
             - update-type: all
@@ -708,6 +709,7 @@ output:
                         source_url: https://github.com/JamesNK/Newtonsoft.Json.Bson
                         type: nuget_repo
                   version: 1.0.2
+                  directory: /nuget/lock-file
             updated-dependency-files:
                 - content: |-
                     {

--- a/tests/smoke-nuget-peer-dependencies.yaml
+++ b/tests/smoke-nuget-peer-dependencies.yaml
@@ -1,5 +1,6 @@
 input:
     job:
+        command: update
         package-manager: nuget
         allowed-updates:
             - update-type: all
@@ -154,6 +155,7 @@ output:
                         source_url: https://github.com/dotnet/runtime
                         type: nuget_repo
                   version: 8.0.0
+                  directory: /nuget/peer-dependencies
                 - name: Microsoft.Extensions.Logging
                   previous-requirements:
                     - file: /nuget/peer-dependencies/project.csproj
@@ -171,6 +173,7 @@ output:
                         source_url: https://github.com/dotnet/runtime
                         type: nuget_repo
                   version: 8.0.0
+                  directory: /nuget/peer-dependencies
             updated-dependency-files:
                 - content: |-
                     <Project Sdk="Microsoft.NET.Sdk">
@@ -227,6 +230,7 @@ output:
                         source_url: https://github.com/dotnet/runtime
                         type: nuget_repo
                   version: 8.0.0
+                  directory: /nuget/peer-dependencies
             updated-dependency-files:
                 - content: |-
                     <Project Sdk="Microsoft.NET.Sdk">

--- a/tests/smoke-nuget-potential-downgrade.yaml
+++ b/tests/smoke-nuget-potential-downgrade.yaml
@@ -1,5 +1,6 @@
 input:
     job:
+        command: update
         package-manager: nuget
         allowed-updates:
             - update-type: all
@@ -1320,6 +1321,7 @@ output:
                         source_url: https://github.com/microsoft/vssdktestfx
                         type: nuget_repo
                   version: 17.6.16
+                  directory: /nuget/potential-downgrade
                 - name: Microsoft.VisualStudio.Sdk.TestFramework.Xunit
                   previous-requirements:
                     - file: /nuget/potential-downgrade/project.csproj
@@ -1337,6 +1339,7 @@ output:
                         source_url: https://github.com/microsoft/vssdktestfx
                         type: nuget_repo
                   version: 17.6.16
+                  directory: /nuget/potential-downgrade
                 - name: Moq
                   previous-requirements:
                     - file: /nuget/potential-downgrade/project.csproj
@@ -1354,6 +1357,7 @@ output:
                         source_url: https://github.com/moq/moq4
                         type: nuget_repo
                   version: 4.18.4
+                  directory: /nuget/potential-downgrade
             updated-dependency-files:
                 - content: |
                     <Project>

--- a/tests/smoke-nuget-props-and-targets.yaml
+++ b/tests/smoke-nuget-props-and-targets.yaml
@@ -1,5 +1,6 @@
 input:
     job:
+        command: update
         package-manager: nuget
         allowed-updates:
             - update-type: all
@@ -72,6 +73,7 @@ output:
                         source_url: https://github.com/dotnet/roslyn-analyzers
                         type: nuget_repo
                   version: 3.3.4
+                  directory: /nuget/props-and-targets
             updated-dependency-files:
                 - content: |-
                     <!--
@@ -123,6 +125,7 @@ output:
                         source_url: https://github.com/NuGet/NuGet.Client
                         type: nuget_repo
                   version: 6.8.0
+                  directory: /nuget/props-and-targets
             updated-dependency-files:
                 - content: |-
                     <!--

--- a/tests/smoke-nuget-resolvability.yaml
+++ b/tests/smoke-nuget-resolvability.yaml
@@ -1,5 +1,6 @@
 input:
     job:
+        command: update
         package-manager: nuget
         allowed-updates:
             - update-type: all
@@ -265,6 +266,7 @@ output:
                         source_url: https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks
                         type: nuget_repo
                   version: 7.0.0
+                  directory: /nuget/resolvability
             updated-dependency-files:
                 - content: |-
                     <Project>
@@ -311,6 +313,7 @@ output:
                         source_url: https://github.com/dotnet/aspnetcore
                         type: nuget_repo
                   version: 7.0.9
+                  directory: /nuget/resolvability
             updated-dependency-files:
                 - content: |-
                     <Project>

--- a/tests/smoke-nuget-sdk-implicit-deps.yaml
+++ b/tests/smoke-nuget-sdk-implicit-deps.yaml
@@ -1,5 +1,6 @@
 input:
     job:
+        command: update
         package-manager: nuget
         allowed-updates:
             - update-type: all
@@ -197,6 +198,7 @@ output:
                         source_url: null
                         type: nuget_repo
                   version: 5.0.2
+                  directory: /nuget/sdk-implicit-deps
             updated-dependency-files:
                 - content: |-
                     <Project Sdk="Microsoft.NET.Sdk">

--- a/tests/smoke-nuget-sdk-replacement-packages.yaml
+++ b/tests/smoke-nuget-sdk-replacement-packages.yaml
@@ -1,5 +1,6 @@
 input:
     job:
+        command: update
         package-manager: nuget
         allowed-updates:
             - update-type: all
@@ -78,6 +79,7 @@ output:
                         source_url: https://github.com/dotnet/runtime
                         type: nuget_repo
                   version: 8.0.5
+                  directory: /nuget/sdk-replacement-packages
             updated-dependency-files:
                 - content: |
                     <Project Sdk="Microsoft.NET.Sdk">

--- a/tests/smoke-nuget-transitive-and-top-level-deps.yaml
+++ b/tests/smoke-nuget-transitive-and-top-level-deps.yaml
@@ -1,5 +1,6 @@
 input:
     job:
+        command: update
         package-manager: nuget
         allowed-updates:
             - update-type: all
@@ -87,6 +88,7 @@ output:
                         source_url: https://github.com/JamesNK/Newtonsoft.Json
                         type: nuget_repo
                   version: 13.0.1
+                  directory: /nuget/top-level-only
             updated-dependency-files:
                 - content: |-
                     <Project Sdk="Microsoft.NET.Sdk">

--- a/tests/smoke-nuget-transitive-pinning.yaml
+++ b/tests/smoke-nuget-transitive-pinning.yaml
@@ -1,5 +1,6 @@
 input:
     job:
+        command: update
         package-manager: nuget
         allowed-updates:
             - update-type: all
@@ -198,6 +199,7 @@ output:
                         source_url: null
                         type: nuget_repo
                   version: 5.0.2
+                  directory: /nuget/transitive-pinning
             updated-dependency-files:
                 - content: |-
                     <Project>

--- a/tests/smoke-nuget-version-multidir.yaml
+++ b/tests/smoke-nuget-version-multidir.yaml
@@ -273,6 +273,7 @@ output:
                         source_url: https://github.com/dotnet/runtime
                         type: nuget_repo
                   version: 8.0.0
+                  directory: /nuget/multi-dir/foo
                 - name: NuGet.Versioning
                   previous-requirements:
                     - file: /nuget/multi-dir/foo/project.csproj
@@ -290,6 +291,7 @@ output:
                         source_url: https://github.com/NuGet/NuGet.Client
                         type: nuget_repo
                   version: 6.8.0
+                  directory: /nuget/multi-dir/foo
                 - name: Microsoft.Extensions.Http
                   previous-requirements:
                     - file: /nuget/multi-dir/bar/project.csproj
@@ -307,6 +309,7 @@ output:
                         source_url: https://github.com/dotnet/runtime
                         type: nuget_repo
                   version: 8.0.0
+                  directory: /nuget/multi-dir/bar
                 - name: NuGet.Versioning
                   previous-requirements:
                     - file: /nuget/multi-dir/bar/project.csproj
@@ -324,6 +327,7 @@ output:
                         source_url: https://github.com/NuGet/NuGet.Client
                         type: nuget_repo
                   version: 6.8.0
+                  directory: /nuget/multi-dir/bar
             updated-dependency-files:
                 - content: |
                     <Project Sdk="Microsoft.NET.Sdk">

--- a/tests/smoke-nuget-version-property.yaml
+++ b/tests/smoke-nuget-version-property.yaml
@@ -1,5 +1,6 @@
 input:
     job:
+        command: update
         package-manager: nuget
         allowed-updates:
             - update-type: all
@@ -60,6 +61,7 @@ output:
                         source_url: https://github.com/JamesNK/Newtonsoft.Json
                         type: nuget_repo
                   version: 13.0.3
+                  directory: /nuget/version-property
             updated-dependency-files:
                 - content: |-
                     <Project>

--- a/tests/smoke-nuget.yaml
+++ b/tests/smoke-nuget.yaml
@@ -1,5 +1,6 @@
 input:
     job:
+        command: update
         package-manager: nuget
         allowed-updates:
             - update-type: all
@@ -59,6 +60,7 @@ output:
                         source_url: https://github.com/NuGet/NuGet.Client
                         type: nuget_repo
                   version: 6.2.2
+                  directory: /nuget
             updated-dependency-files:
                 - content: |
                     <Project Sdk="Microsoft.NET.Sdk">


### PR DESCRIPTION
Note, this PR exists to support https://github.com/dependabot/dependabot-core/pull/15914 and is expected to fail until that is merged.