### PR TITLE
Add a smoke test for the nub ecosystem

### DIFF
--- a/nub/nub.lock
+++ b/nub/nub.lock
@@ -1,0 +1,590 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      eslint-plugin-yml:
+        specifier: 1.5.0
+        version: 1.5.0(eslint@10.9.1)
+
+packages:
+
+  '@eslint-community/eslint-utils@4.10.1':
+    resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.23.5':
+    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/config-helpers@0.7.0':
+    resolution: {integrity: sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/core@1.2.1':
+    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/object-schema@3.0.5':
+    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/plugin-kit@0.7.2':
+    resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
+
+  '@types/esrecurse@4.3.1':
+    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-plugin-yml@1.5.0:
+    resolution: {integrity: sha512-iygN054g+ZrnYmtOXMnT+sx9iDNXt89/m0+506cQHeG0+5jJN8hY5iOPQLd3yfd50AfK/mSasajBWruf1SoHpQ==}
+    engines: {node: ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '>=6.0.0'
+
+  eslint-scope@9.1.2:
+    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@10.9.1:
+    resolution: {integrity: sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.4:
+    resolution: {integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
+    engines: {node: 18 || 20 || >=22}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  yaml-eslint-parser@1.3.2:
+    resolution: {integrity: sha512-odxVsHAkZYYglR30aPYRY4nUGJnoJ2y1ww2HDvZALo0BDETv9kWbi16J52eHs+PWRNmF4ub6nZqfVOeesOvntg==}
+    engines: {node: ^14.17.0 || >=16.0.0}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+snapshots:
+
+  '@eslint-community/eslint-utils@4.10.1(eslint@10.9.1)':
+    dependencies:
+      eslint: 10.9.1
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.23.5':
+    dependencies:
+      '@eslint/object-schema': 3.0.5
+      debug: 4.4.3
+      minimatch: 10.2.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.7.0':
+    dependencies:
+      '@eslint/core': 1.2.1
+
+  '@eslint/core@1.2.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/object-schema@3.0.5': {}
+
+  '@eslint/plugin-kit@0.7.2':
+    dependencies:
+      '@eslint/core': 1.2.1
+      levn: 0.4.1
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
+
+  '@types/esrecurse@4.3.1': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  acorn-jsx@5.3.2(acorn@8.18.0):
+    dependencies:
+      acorn: 8.18.0
+
+  acorn@8.18.0: {}
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  balanced-match@4.0.4: {}
+
+  brace-expansion@5.0.9:
+    dependencies:
+      balanced-match: 4.0.4
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-is@0.1.4: {}
+
+  escape-string-regexp@4.0.0: {}
+
+  eslint-plugin-yml@1.5.0(eslint@10.9.1):
+    dependencies:
+      debug: 4.4.3
+      eslint: 10.9.1
+      lodash: 4.18.1
+      natural-compare: 1.4.0
+      yaml-eslint-parser: 1.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-scope@9.1.2:
+    dependencies:
+      '@types/esrecurse': 4.3.1
+      '@types/estree': 1.0.9
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@10.9.1:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.9.1)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5
+      '@eslint/config-helpers': 0.7.0
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.2
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      minimatch: 10.2.6
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.18.0
+      acorn-jsx: 5.3.2(acorn@8.18.0)
+      eslint-visitor-keys: 5.0.1
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
+  esutils@2.0.3: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.4
+      keyv: 4.5.4
+
+  flatted@3.4.4: {}
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  ignore@5.3.2: {}
+
+  imurmurhash@0.1.4: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  isexe@2.0.0: {}
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash@4.18.1: {}
+
+  minimatch@10.2.6:
+    dependencies:
+      brace-expansion: 5.0.9
+
+  ms@2.1.3: {}
+
+  natural-compare@1.4.0: {}
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
+  prelude-ls@1.2.1: {}
+
+  punycode@2.3.1: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  word-wrap@1.2.5: {}
+
+  yaml-eslint-parser@1.3.2:
+    dependencies:
+      eslint-visitor-keys: 3.4.3
+      yaml: 2.9.0
+
+  yaml@2.9.0: {}
+
+  yocto-queue@0.1.0: {}

--- a/nub/package.json
+++ b/nub/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "nub-smoke",
+  "version": "1.0.0",
+  "private": true,
+  "devDependencies": {
+    "eslint-plugin-yml": "1.5.0"
+  },
+  "packageManager": "nub@0.8.0"
+}

--- a/tests/smoke-nub.yaml
+++ b/tests/smoke-nub.yaml
@@ -1,8 +1,14 @@
 input:
     job:
+        command: update
         package-manager: nub
         allowed-updates:
             - dependency-name: eslint-plugin-yml
+        experiments:
+            record-ecosystem-versions: true
+        ignore-conditions:
+            - dependency-name: eslint-plugin-yml
+              version-requirement: '>1.7.0'
         source:
             provider: github
             repo: colinhacks/smoke-tests

--- a/tests/smoke-nub.yaml
+++ b/tests/smoke-nub.yaml
@@ -1,0 +1,16 @@
+input:
+    job:
+        package-manager: nub
+        allowed-updates:
+            - dependency-name: eslint-plugin-yml
+        source:
+            provider: github
+            repo: colinhacks/smoke-tests
+            directory: /nub/
+            commit: c153f279babc52427f216aacb96acf4592bd473a
+    credentials:
+        - host: github.com
+          password: $LOCAL_GITHUB_ACCESS_TOKEN
+          type: git_source
+          username: x-access-token
+output: []

--- a/tests/smoke-nub.yaml
+++ b/tests/smoke-nub.yaml
@@ -19,4 +19,938 @@ input:
           password: $LOCAL_GITHUB_ACCESS_TOKEN
           type: git_source
           username: x-access-token
-output: []
+output:
+    - type: record_ecosystem_versions
+      expect:
+        data:
+            ecosystem_versions:
+                package_managers:
+                    nub: 0.8.0
+    - type: update_dependency_list
+      expect:
+        data:
+            dependencies:
+                - name: eslint-plugin-yml
+                  requirements:
+                    - file: package.json
+                      groups:
+                        - devDependencies
+                      requirement: 1.5.0
+                      source: null
+                  version: 1.5.0
+                - name: '@eslint-community/eslint-utils'
+                  requirements: []
+                  version: 4.10.1
+                - name: '@eslint-community/regexpp'
+                  requirements: []
+                  version: 4.12.2
+                - name: '@eslint/config-array'
+                  requirements: []
+                  version: 0.23.5
+                - name: '@eslint/config-helpers'
+                  requirements: []
+                  version: 0.7.0
+                - name: '@eslint/core'
+                  requirements: []
+                  version: 1.2.1
+                - name: '@eslint/object-schema'
+                  requirements: []
+                  version: 3.0.5
+                - name: '@eslint/plugin-kit'
+                  requirements: []
+                  version: 0.7.2
+                - name: '@humanfs/core'
+                  requirements: []
+                  version: 0.19.2
+                - name: '@humanfs/node'
+                  requirements: []
+                  version: 0.16.8
+                - name: '@humanfs/types'
+                  requirements: []
+                  version: 0.15.0
+                - name: '@humanwhocodes/module-importer'
+                  requirements: []
+                  version: 1.0.1
+                - name: '@humanwhocodes/retry'
+                  requirements: []
+                  version: 0.4.3
+                - name: '@types/esrecurse'
+                  requirements: []
+                  version: 4.3.1
+                - name: '@types/estree'
+                  requirements: []
+                  version: 1.0.9
+                - name: '@types/json-schema'
+                  requirements: []
+                  version: 7.0.15
+                - name: acorn-jsx
+                  requirements: []
+                  version: 5.3.2
+                - name: acorn
+                  requirements: []
+                  version: 8.18.0
+                - name: ajv
+                  requirements: []
+                  version: 6.15.0
+                - name: balanced-match
+                  requirements: []
+                  version: 4.0.4
+                - name: brace-expansion
+                  requirements: []
+                  version: 5.0.9
+                - name: cross-spawn
+                  requirements: []
+                  version: 7.0.6
+                - name: debug
+                  requirements: []
+                  version: 4.4.3
+                - name: deep-is
+                  requirements: []
+                  version: 0.1.4
+                - name: escape-string-regexp
+                  requirements: []
+                  version: 4.0.0
+                - name: eslint-scope
+                  requirements: []
+                  version: 9.1.2
+                - name: eslint-visitor-keys
+                  requirements: []
+                  version: 3.4.3
+                - name: eslint
+                  requirements: []
+                  version: 10.9.1
+                - name: espree
+                  requirements: []
+                  version: 11.2.0
+                - name: esquery
+                  requirements: []
+                  version: 1.7.0
+                - name: esrecurse
+                  requirements: []
+                  version: 4.3.0
+                - name: estraverse
+                  requirements: []
+                  version: 5.3.0
+                - name: esutils
+                  requirements: []
+                  version: 2.0.3
+                - name: fast-deep-equal
+                  requirements: []
+                  version: 3.1.3
+                - name: fast-json-stable-stringify
+                  requirements: []
+                  version: 2.1.0
+                - name: fast-levenshtein
+                  requirements: []
+                  version: 2.0.6
+                - name: file-entry-cache
+                  requirements: []
+                  version: 8.0.0
+                - name: find-up
+                  requirements: []
+                  version: 5.0.0
+                - name: flat-cache
+                  requirements: []
+                  version: 4.0.1
+                - name: flatted
+                  requirements: []
+                  version: 3.4.4
+                - name: glob-parent
+                  requirements: []
+                  version: 6.0.2
+                - name: ignore
+                  requirements: []
+                  version: 5.3.2
+                - name: imurmurhash
+                  requirements: []
+                  version: 0.1.4
+                - name: is-extglob
+                  requirements: []
+                  version: 2.1.1
+                - name: is-glob
+                  requirements: []
+                  version: 4.0.3
+                - name: isexe
+                  requirements: []
+                  version: 2.0.0
+                - name: json-buffer
+                  requirements: []
+                  version: 3.0.1
+                - name: json-schema-traverse
+                  requirements: []
+                  version: 0.4.1
+                - name: json-stable-stringify-without-jsonify
+                  requirements: []
+                  version: 1.0.1
+                - name: keyv
+                  requirements: []
+                  version: 4.5.4
+                - name: levn
+                  requirements: []
+                  version: 0.4.1
+                - name: locate-path
+                  requirements: []
+                  version: 6.0.0
+                - name: lodash
+                  requirements: []
+                  version: 4.18.1
+                - name: minimatch
+                  requirements: []
+                  version: 10.2.6
+                - name: ms
+                  requirements: []
+                  version: 2.1.3
+                - name: natural-compare
+                  requirements: []
+                  version: 1.4.0
+                - name: optionator
+                  requirements: []
+                  version: 0.9.4
+                - name: p-limit
+                  requirements: []
+                  version: 3.1.0
+                - name: p-locate
+                  requirements: []
+                  version: 5.0.0
+                - name: path-exists
+                  requirements: []
+                  version: 4.0.0
+                - name: path-key
+                  requirements: []
+                  version: 3.1.1
+                - name: prelude-ls
+                  requirements: []
+                  version: 1.2.1
+                - name: punycode
+                  requirements: []
+                  version: 2.3.1
+                - name: shebang-command
+                  requirements: []
+                  version: 2.0.0
+                - name: shebang-regex
+                  requirements: []
+                  version: 3.0.0
+                - name: type-check
+                  requirements: []
+                  version: 0.4.0
+                - name: uri-js
+                  requirements: []
+                  version: 4.4.1
+                - name: which
+                  requirements: []
+                  version: 2.0.2
+                - name: word-wrap
+                  requirements: []
+                  version: 1.2.5
+                - name: yaml-eslint-parser
+                  requirements: []
+                  version: 1.3.2
+                - name: yaml
+                  requirements: []
+                  version: 2.9.0
+                - name: yocto-queue
+                  requirements: []
+                  version: 0.1.0
+            dependency_files:
+                - /nub/package.json
+                - /nub/nub.lock
+    - type: create_pull_request
+      expect:
+        data:
+            base-commit-sha: c153f279babc52427f216aacb96acf4592bd473a
+            dependencies:
+                - name: eslint-plugin-yml
+                  previous-requirements:
+                    - file: package.json
+                      groups:
+                        - devDependencies
+                      requirement: 1.5.0
+                      source: null
+                  previous-version: 1.5.0
+                  requirements:
+                    - file: package.json
+                      groups:
+                        - devDependencies
+                      requirement: 1.7.0
+                      source: null
+                  version: 1.7.0
+                  directory: /nub
+            updated-dependency-files:
+                - content: |
+                    {
+                      "name": "nub-smoke",
+                      "version": "1.0.0",
+                      "private": true,
+                      "devDependencies": {
+                        "eslint-plugin-yml": "1.7.0"
+                      },
+                      "packageManager": "nub@0.8.0"
+                    }
+                  content_encoding: utf-8
+                  deleted: false
+                  directory: /nub
+                  name: package.json
+                  operation: update
+                  support_file: false
+                  type: file
+                - content: |
+                    lockfileVersion: '9.0'
+
+                    settings:
+                      autoInstallPeers: true
+                      excludeLinksFromLockfile: false
+
+                    importers:
+
+                      .:
+                        devDependencies:
+                          eslint-plugin-yml:
+                            specifier: 1.7.0
+                            version: 1.7.0(eslint@10.9.1)
+
+                    packages:
+
+                      '@eslint-community/eslint-utils@4.10.1':
+                        resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
+                        engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+                        peerDependencies:
+                          eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+                      '@eslint-community/regexpp@4.12.2':
+                        resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+                        engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+                      '@eslint/config-array@0.23.5':
+                        resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
+                        engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+                      '@eslint/config-helpers@0.7.0':
+                        resolution: {integrity: sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==}
+                        engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+                      '@eslint/core@1.2.1':
+                        resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+                        engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+                      '@eslint/object-schema@3.0.5':
+                        resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
+                        engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+                      '@eslint/plugin-kit@0.7.2':
+                        resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
+                        engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+                      '@humanfs/core@0.19.2':
+                        resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+                        engines: {node: '>=18.18.0'}
+
+                      '@humanfs/node@0.16.8':
+                        resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+                        engines: {node: '>=18.18.0'}
+
+                      '@humanfs/types@0.15.0':
+                        resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+                        engines: {node: '>=18.18.0'}
+
+                      '@humanwhocodes/module-importer@1.0.1':
+                        resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+                        engines: {node: '>=12.22'}
+
+                      '@humanwhocodes/retry@0.4.3':
+                        resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+                        engines: {node: '>=18.18'}
+
+                      '@types/esrecurse@4.3.1':
+                        resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+
+                      '@types/estree@1.0.9':
+                        resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+                      '@types/json-schema@7.0.15':
+                        resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+                      acorn-jsx@5.3.2:
+                        resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+                        peerDependencies:
+                          acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+                      acorn@8.18.0:
+                        resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
+                        engines: {node: '>=0.4.0'}
+                        hasBin: true
+
+                      ajv@6.15.0:
+                        resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+                      balanced-match@4.0.4:
+                        resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+                        engines: {node: 18 || 20 || >=22}
+
+                      brace-expansion@5.0.9:
+                        resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+                        engines: {node: 20 || >=22}
+
+                      cross-spawn@7.0.6:
+                        resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+                        engines: {node: '>= 8'}
+
+                      debug@4.4.3:
+                        resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+                        engines: {node: '>=6.0'}
+                        peerDependencies:
+                          supports-color: '*'
+                        peerDependenciesMeta:
+                          supports-color:
+                            optional: true
+
+                      deep-is@0.1.4:
+                        resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+                      escape-string-regexp@4.0.0:
+                        resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+                        engines: {node: '>=10'}
+
+                      eslint-plugin-yml@1.7.0:
+                        resolution: {integrity: sha512-qq61FQJk+qIgWl0R06bec7UQQEIBrUH22jS+MroTbFUKu+3/iVlGRpZd8mjpOAm/+H/WEDFwy4x/+kKgVGbsWw==}
+                        engines: {node: ^14.17.0 || >=16.0.0}
+                        peerDependencies:
+                          eslint: '>=6.0.0'
+
+                      eslint-scope@9.1.2:
+                        resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
+                        engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+                      eslint-visitor-keys@3.4.3:
+                        resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+                        engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+                      eslint-visitor-keys@5.0.1:
+                        resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+                        engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+                      eslint@10.9.1:
+                        resolution: {integrity: sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==}
+                        engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+                        hasBin: true
+                        peerDependencies:
+                          jiti: '*'
+                        peerDependenciesMeta:
+                          jiti:
+                            optional: true
+
+                      espree@11.2.0:
+                        resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+                        engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+                      esquery@1.7.0:
+                        resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+                        engines: {node: '>=0.10'}
+
+                      esrecurse@4.3.0:
+                        resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+                        engines: {node: '>=4.0'}
+
+                      estraverse@5.3.0:
+                        resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+                        engines: {node: '>=4.0'}
+
+                      esutils@2.0.3:
+                        resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+                        engines: {node: '>=0.10.0'}
+
+                      fast-deep-equal@3.1.3:
+                        resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+                      fast-json-stable-stringify@2.1.0:
+                        resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+                      fast-levenshtein@2.0.6:
+                        resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+                      file-entry-cache@8.0.0:
+                        resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+                        engines: {node: '>=16.0.0'}
+
+                      find-up@5.0.0:
+                        resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+                        engines: {node: '>=10'}
+
+                      flat-cache@4.0.1:
+                        resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+                        engines: {node: '>=16'}
+
+                      flatted@3.4.4:
+                        resolution: {integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==}
+
+                      glob-parent@6.0.2:
+                        resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+                        engines: {node: '>=10.13.0'}
+
+                      ignore@5.3.2:
+                        resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+                        engines: {node: '>= 4'}
+
+                      imurmurhash@0.1.4:
+                        resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+                        engines: {node: '>=0.8.19'}
+
+                      is-extglob@2.1.1:
+                        resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+                        engines: {node: '>=0.10.0'}
+
+                      is-glob@4.0.3:
+                        resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+                        engines: {node: '>=0.10.0'}
+
+                      isexe@2.0.0:
+                        resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+                      json-buffer@3.0.1:
+                        resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+                      json-schema-traverse@0.4.1:
+                        resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+                      json-stable-stringify-without-jsonify@1.0.1:
+                        resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+                      keyv@4.5.4:
+                        resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+                      levn@0.4.1:
+                        resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+                        engines: {node: '>= 0.8.0'}
+
+                      locate-path@6.0.0:
+                        resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+                        engines: {node: '>=10'}
+
+                      lodash@4.18.1:
+                        resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
+                      minimatch@10.2.6:
+                        resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
+                        engines: {node: 18 || 20 || >=22}
+
+                      ms@2.1.3:
+                        resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+                      natural-compare@1.4.0:
+                        resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+                      optionator@0.9.4:
+                        resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+                        engines: {node: '>= 0.8.0'}
+
+                      p-limit@3.1.0:
+                        resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+                        engines: {node: '>=10'}
+
+                      p-locate@5.0.0:
+                        resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+                        engines: {node: '>=10'}
+
+                      path-exists@4.0.0:
+                        resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+                        engines: {node: '>=8'}
+
+                      path-key@3.1.1:
+                        resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+                        engines: {node: '>=8'}
+
+                      prelude-ls@1.2.1:
+                        resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+                        engines: {node: '>= 0.8.0'}
+
+                      punycode@2.3.1:
+                        resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+                        engines: {node: '>=6'}
+
+                      shebang-command@2.0.0:
+                        resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+                        engines: {node: '>=8'}
+
+                      shebang-regex@3.0.0:
+                        resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+                        engines: {node: '>=8'}
+
+                      type-check@0.4.0:
+                        resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+                        engines: {node: '>= 0.8.0'}
+
+                      uri-js@4.4.1:
+                        resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+                      which@2.0.2:
+                        resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+                        engines: {node: '>= 8'}
+                        hasBin: true
+
+                      word-wrap@1.2.5:
+                        resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+                        engines: {node: '>=0.10.0'}
+
+                      yaml-eslint-parser@1.3.2:
+                        resolution: {integrity: sha512-odxVsHAkZYYglR30aPYRY4nUGJnoJ2y1ww2HDvZALo0BDETv9kWbi16J52eHs+PWRNmF4ub6nZqfVOeesOvntg==}
+                        engines: {node: ^14.17.0 || >=16.0.0}
+
+                      yaml@2.9.0:
+                        resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+                        engines: {node: '>= 14.6'}
+                        hasBin: true
+
+                      yocto-queue@0.1.0:
+                        resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+                        engines: {node: '>=10'}
+
+                    snapshots:
+
+                      '@eslint-community/eslint-utils@4.10.1(eslint@10.9.1)':
+                        dependencies:
+                          eslint: 10.9.1
+                          eslint-visitor-keys: 3.4.3
+
+                      '@eslint-community/regexpp@4.12.2': {}
+
+                      '@eslint/config-array@0.23.5':
+                        dependencies:
+                          '@eslint/object-schema': 3.0.5
+                          debug: 4.4.3
+                          minimatch: 10.2.6
+                        transitivePeerDependencies:
+                          - supports-color
+
+                      '@eslint/config-helpers@0.7.0':
+                        dependencies:
+                          '@eslint/core': 1.2.1
+
+                      '@eslint/core@1.2.1':
+                        dependencies:
+                          '@types/json-schema': 7.0.15
+
+                      '@eslint/object-schema@3.0.5': {}
+
+                      '@eslint/plugin-kit@0.7.2':
+                        dependencies:
+                          '@eslint/core': 1.2.1
+                          levn: 0.4.1
+
+                      '@humanfs/core@0.19.2':
+                        dependencies:
+                          '@humanfs/types': 0.15.0
+
+                      '@humanfs/node@0.16.8':
+                        dependencies:
+                          '@humanfs/core': 0.19.2
+                          '@humanfs/types': 0.15.0
+                          '@humanwhocodes/retry': 0.4.3
+
+                      '@humanfs/types@0.15.0': {}
+
+                      '@humanwhocodes/module-importer@1.0.1': {}
+
+                      '@humanwhocodes/retry@0.4.3': {}
+
+                      '@types/esrecurse@4.3.1': {}
+
+                      '@types/estree@1.0.9': {}
+
+                      '@types/json-schema@7.0.15': {}
+
+                      acorn-jsx@5.3.2(acorn@8.18.0):
+                        dependencies:
+                          acorn: 8.18.0
+
+                      acorn@8.18.0: {}
+
+                      ajv@6.15.0:
+                        dependencies:
+                          fast-deep-equal: 3.1.3
+                          fast-json-stable-stringify: 2.1.0
+                          json-schema-traverse: 0.4.1
+                          uri-js: 4.4.1
+
+                      balanced-match@4.0.4: {}
+
+                      brace-expansion@5.0.9:
+                        dependencies:
+                          balanced-match: 4.0.4
+
+                      cross-spawn@7.0.6:
+                        dependencies:
+                          path-key: 3.1.1
+                          shebang-command: 2.0.0
+                          which: 2.0.2
+
+                      debug@4.4.3:
+                        dependencies:
+                          ms: 2.1.3
+
+                      deep-is@0.1.4: {}
+
+                      escape-string-regexp@4.0.0: {}
+
+                      eslint-plugin-yml@1.7.0(eslint@10.9.1):
+                        dependencies:
+                          debug: 4.4.3
+                          eslint: 10.9.1
+                          lodash: 4.18.1
+                          natural-compare: 1.4.0
+                          yaml-eslint-parser: 1.3.2
+                        transitivePeerDependencies:
+                          - supports-color
+
+                      eslint-scope@9.1.2:
+                        dependencies:
+                          '@types/esrecurse': 4.3.1
+                          '@types/estree': 1.0.9
+                          esrecurse: 4.3.0
+                          estraverse: 5.3.0
+
+                      eslint-visitor-keys@3.4.3: {}
+
+                      eslint-visitor-keys@5.0.1: {}
+
+                      eslint@10.9.1:
+                        dependencies:
+                          '@eslint-community/eslint-utils': 4.10.1(eslint@10.9.1)
+                          '@eslint-community/regexpp': 4.12.2
+                          '@eslint/config-array': 0.23.5
+                          '@eslint/config-helpers': 0.7.0
+                          '@eslint/core': 1.2.1
+                          '@eslint/plugin-kit': 0.7.2
+                          '@humanfs/node': 0.16.8
+                          '@humanwhocodes/module-importer': 1.0.1
+                          '@humanwhocodes/retry': 0.4.3
+                          '@types/estree': 1.0.9
+                          ajv: 6.15.0
+                          cross-spawn: 7.0.6
+                          debug: 4.4.3
+                          escape-string-regexp: 4.0.0
+                          eslint-scope: 9.1.2
+                          eslint-visitor-keys: 5.0.1
+                          espree: 11.2.0
+                          esquery: 1.7.0
+                          esutils: 2.0.3
+                          fast-deep-equal: 3.1.3
+                          file-entry-cache: 8.0.0
+                          find-up: 5.0.0
+                          glob-parent: 6.0.2
+                          ignore: 5.3.2
+                          imurmurhash: 0.1.4
+                          is-glob: 4.0.3
+                          json-stable-stringify-without-jsonify: 1.0.1
+                          minimatch: 10.2.6
+                          natural-compare: 1.4.0
+                          optionator: 0.9.4
+                        transitivePeerDependencies:
+                          - supports-color
+
+                      espree@11.2.0:
+                        dependencies:
+                          acorn: 8.18.0
+                          acorn-jsx: 5.3.2(acorn@8.18.0)
+                          eslint-visitor-keys: 5.0.1
+
+                      esquery@1.7.0:
+                        dependencies:
+                          estraverse: 5.3.0
+
+                      esrecurse@4.3.0:
+                        dependencies:
+                          estraverse: 5.3.0
+
+                      estraverse@5.3.0: {}
+
+                      esutils@2.0.3: {}
+
+                      fast-deep-equal@3.1.3: {}
+
+                      fast-json-stable-stringify@2.1.0: {}
+
+                      fast-levenshtein@2.0.6: {}
+
+                      file-entry-cache@8.0.0:
+                        dependencies:
+                          flat-cache: 4.0.1
+
+                      find-up@5.0.0:
+                        dependencies:
+                          locate-path: 6.0.0
+                          path-exists: 4.0.0
+
+                      flat-cache@4.0.1:
+                        dependencies:
+                          flatted: 3.4.4
+                          keyv: 4.5.4
+
+                      flatted@3.4.4: {}
+
+                      glob-parent@6.0.2:
+                        dependencies:
+                          is-glob: 4.0.3
+
+                      ignore@5.3.2: {}
+
+                      imurmurhash@0.1.4: {}
+
+                      is-extglob@2.1.1: {}
+
+                      is-glob@4.0.3:
+                        dependencies:
+                          is-extglob: 2.1.1
+
+                      isexe@2.0.0: {}
+
+                      json-buffer@3.0.1: {}
+
+                      json-schema-traverse@0.4.1: {}
+
+                      json-stable-stringify-without-jsonify@1.0.1: {}
+
+                      keyv@4.5.4:
+                        dependencies:
+                          json-buffer: 3.0.1
+
+                      levn@0.4.1:
+                        dependencies:
+                          prelude-ls: 1.2.1
+                          type-check: 0.4.0
+
+                      locate-path@6.0.0:
+                        dependencies:
+                          p-locate: 5.0.0
+
+                      lodash@4.18.1: {}
+
+                      minimatch@10.2.6:
+                        dependencies:
+                          brace-expansion: 5.0.9
+
+                      ms@2.1.3: {}
+
+                      natural-compare@1.4.0: {}
+
+                      optionator@0.9.4:
+                        dependencies:
+                          deep-is: 0.1.4
+                          fast-levenshtein: 2.0.6
+                          levn: 0.4.1
+                          prelude-ls: 1.2.1
+                          type-check: 0.4.0
+                          word-wrap: 1.2.5
+
+                      p-limit@3.1.0:
+                        dependencies:
+                          yocto-queue: 0.1.0
+
+                      p-locate@5.0.0:
+                        dependencies:
+                          p-limit: 3.1.0
+
+                      path-exists@4.0.0: {}
+
+                      path-key@3.1.1: {}
+
+                      prelude-ls@1.2.1: {}
+
+                      punycode@2.3.1: {}
+
+                      shebang-command@2.0.0:
+                        dependencies:
+                          shebang-regex: 3.0.0
+
+                      shebang-regex@3.0.0: {}
+
+                      type-check@0.4.0:
+                        dependencies:
+                          prelude-ls: 1.2.1
+
+                      uri-js@4.4.1:
+                        dependencies:
+                          punycode: 2.3.1
+
+                      which@2.0.2:
+                        dependencies:
+                          isexe: 2.0.0
+
+                      word-wrap@1.2.5: {}
+
+                      yaml-eslint-parser@1.3.2:
+                        dependencies:
+                          eslint-visitor-keys: 3.4.3
+                          yaml: 2.9.0
+
+                      yaml@2.9.0: {}
+
+                      yocto-queue@0.1.0: {}
+                  content_encoding: utf-8
+                  deleted: false
+                  directory: /nub
+                  name: nub.lock
+                  operation: update
+                  support_file: false
+                  type: file
+            pr-title: Bump eslint-plugin-yml from 1.5.0 to 1.7.0 in /nub
+            pr-body: |
+                Bumps [eslint-plugin-yml](https://github.com/ota-meshi/eslint-plugin-yml) from 1.5.0 to 1.7.0.
+                <details>
+                <summary>Release notes</summary>
+                <p><em>Sourced from <a href="https://github.com/ota-meshi/eslint-plugin-yml/releases">eslint-plugin-yml's releases</a>.</em></p>
+                <blockquote>
+                <h2>v1.7.0</h2>
+                <h3>Minor Changes</h3>
+                <ul>
+                <li><a href="https://redirect.github.com/ota-meshi/eslint-plugin-yml/pull/238">#238</a> <a href="https://github.com/ota-meshi/eslint-plugin-yml/commit/6033d9c6130f08ff5667ffa712a63b74244a4b48"><code>6033d9c</code></a> Thanks <a href="https://github.com/ota-meshi"><code>@​ota-meshi</code></a>! - feat: export meta object</li>
+                </ul>
+                <h2>v1.6.0</h2>
+                <h3>Minor Changes</h3>
+                <ul>
+                <li><a href="https://redirect.github.com/ota-meshi/eslint-plugin-yml/pull/236">#236</a> <a href="https://github.com/ota-meshi/eslint-plugin-yml/commit/7e34b7748a4e3663ab56dc504214ba613b3f8347"><code>7e34b77</code></a> Thanks <a href="https://github.com/sxyazi"><code>@​sxyazi</code></a>! - feat: add <code>yml/no-trailing-zeros</code> rule</li>
+                </ul>
+                </blockquote>
+                </details>
+                <details>
+                <summary>Changelog</summary>
+                <p><em>Sourced from <a href="https://github.com/ota-meshi/eslint-plugin-yml/blob/master/CHANGELOG.md">eslint-plugin-yml's changelog</a>.</em></p>
+                <blockquote>
+                <h2>1.7.0</h2>
+                <h3>Minor Changes</h3>
+                <ul>
+                <li><a href="https://redirect.github.com/ota-meshi/eslint-plugin-yml/pull/238">#238</a> <a href="https://github.com/ota-meshi/eslint-plugin-yml/commit/6033d9c6130f08ff5667ffa712a63b74244a4b48"><code>6033d9c</code></a> Thanks <a href="https://github.com/ota-meshi"><code>@​ota-meshi</code></a>! - feat: export meta object</li>
+                </ul>
+                <h2>1.6.0</h2>
+                <h3>Minor Changes</h3>
+                <ul>
+                <li><a href="https://redirect.github.com/ota-meshi/eslint-plugin-yml/pull/236">#236</a> <a href="https://github.com/ota-meshi/eslint-plugin-yml/commit/7e34b7748a4e3663ab56dc504214ba613b3f8347"><code>7e34b77</code></a> Thanks <a href="https://github.com/sxyazi"><code>@​sxyazi</code></a>! - feat: add <code>yml/no-trailing-zeros</code> rule</li>
+                </ul>
+                </blockquote>
+                </details>
+                <details>
+                <summary>Commits</summary>
+                <ul>
+                <li><a href="https://github.com/ota-meshi/eslint-plugin-yml/commit/7cc11ebc45402ed7275dcbbef69a93d9e841951a"><code>7cc11eb</code></a> chore: release eslint-plugin-yml (<a href="https://redirect.github.com/ota-meshi/eslint-plugin-yml/issues/239">#239</a>)</li>
+                <li><a href="https://github.com/ota-meshi/eslint-plugin-yml/commit/545b362f9905c7cabbea2400d8ac3deca2c92257"><code>545b362</code></a> test: fix</li>
+                <li><a href="https://github.com/ota-meshi/eslint-plugin-yml/commit/6033d9c6130f08ff5667ffa712a63b74244a4b48"><code>6033d9c</code></a> feat: export meta object (<a href="https://redirect.github.com/ota-meshi/eslint-plugin-yml/issues/238">#238</a>)</li>
+                <li><a href="https://github.com/ota-meshi/eslint-plugin-yml/commit/7c2e179d1f62a73e083d5e0acbce74878d15f0ed"><code>7c2e179</code></a> chore: release eslint-plugin-yml (<a href="https://redirect.github.com/ota-meshi/eslint-plugin-yml/issues/237">#237</a>)</li>
+                <li><a href="https://github.com/ota-meshi/eslint-plugin-yml/commit/829d9cf4f38bdca0d5bd6264d7c07a8e0b71dec4"><code>829d9cf</code></a> test: add more testcases for no-trailing-zeros</li>
+                <li><a href="https://github.com/ota-meshi/eslint-plugin-yml/commit/7e34b7748a4e3663ab56dc504214ba613b3f8347"><code>7e34b77</code></a> feat: add <code>no-trailing-zeros</code> rule (<a href="https://redirect.github.com/ota-meshi/eslint-plugin-yml/issues/236">#236</a>)</li>
+                <li><a href="https://github.com/ota-meshi/eslint-plugin-yml/commit/dc9edb1956cd6a3021ba603e6929654aa52356c4"><code>dc9edb1</code></a> chore(deps): update dependency monaco-editor to ^0.38.0</li>
+                <li><a href="https://github.com/ota-meshi/eslint-plugin-yml/commit/694d94487c1f931692f70ac05df640c5d724c70e"><code>694d944</code></a> chore(deps): update coverallsapp/github-action action to v2.1.2</li>
+                <li><a href="https://github.com/ota-meshi/eslint-plugin-yml/commit/8d46f065e8b8a8c1f2a5d3479a2d7d9939b1ac7d"><code>8d46f06</code></a> chore(deps): update coverallsapp/github-action action to v2.1.1</li>
+                <li><a href="https://github.com/ota-meshi/eslint-plugin-yml/commit/29e6634da253e32834fc066357b379ccf93bde22"><code>29e6634</code></a> chore(deps): update dependency stylelint-config-standard to v33 (<a href="https://redirect.github.com/ota-meshi/eslint-plugin-yml/issues/232">#232</a>)</li>
+                <li>Additional commits viewable in <a href="https://github.com/ota-meshi/eslint-plugin-yml/compare/v1.5.0...v1.7.0">compare view</a></li>
+                </ul>
+                </details>
+                <br />
+            commit-message: |-
+                Bump eslint-plugin-yml from 1.5.0 to 1.7.0 in /nub
+
+                Bumps [eslint-plugin-yml](https://github.com/ota-meshi/eslint-plugin-yml) from 1.5.0 to 1.7.0.
+                - [Release notes](https://github.com/ota-meshi/eslint-plugin-yml/releases)
+                - [Changelog](https://github.com/ota-meshi/eslint-plugin-yml/blob/master/CHANGELOG.md)
+                - [Commits](https://github.com/ota-meshi/eslint-plugin-yml/compare/v1.5.0...v1.7.0)
+    - type: mark_as_processed
+      expect:
+        data:
+            base-commit-sha: c153f279babc52427f216aacb96acf4592bd473a


### PR DESCRIPTION
Adds a smoke test for the nub ecosystem proposed in dependabot/dependabot-core#15524.

The recorded output came from the Regenerate Test workflow run against that pull request, which builds the nub updater image and puts the fixture through a real update job. It covers `record_ecosystem_versions`, `update_dependency_list`, a `create_pull_request` bumping `eslint-plugin-yml` from 1.5.0 to 1.7.0 across both `package.json` and `nub.lock`, and `mark_as_processed`.

The fixture follows the pnpm and yarn-berry tests, including an ignore-condition that pins the update target so the recording does not drift as new releases ship.

Two things worth flagging, both expected:

`smoke (nub)` fails here with `unknown package manager: nub`. The CLI resolves an updater image from a fixed map in `internal/infra/run.go`, which has no nub entry, and no `dependabot-updater-nub` image is published yet. The check can only pass once the core pull request merges and an image ships, so this test is not mergeable ahead of it.

`source.repo` and `source.commit` point at the fork the fixture was recorded from, because the fixture does not exist in this repo yet. They need regenerating against this repo once these files land.
